### PR TITLE
fix: Docusaurus broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ forge fmt
 
 ## Local Testnet
 
-To deploy the relay contract to a local environment for testing use our convenience script [here](./sdk/scripts/init-bridge.ts):
+To deploy the relay contract to a local environment for testing use our convenience script [here](https://github.com/bob-collective/bob/blob/master/sdk/scripts/init-bridge.ts):
 
 ```shell
 # start local ethereum testnet node


### PR DESCRIPTION
Docusaurus tries to link `init-bridge.ts` if it's a relative path hence the absolute GitHub URL used in readme. 