### PR TITLE
(WIP)fix: update python script.

### DIFF
--- a/docs/scripts/forge_doc_reformat.py
+++ b/docs/scripts/forge_doc_reformat.py
@@ -7,6 +7,18 @@ Therefore, run this script after running the `forge doc --out docs/docs/contract
 import os
 import re
 
+# Function to replace GitHub source URLs with the 'master' branch
+def replace_git_sources(md_content):
+    def replace_source(match):
+        original_url = match.group(0)
+        # Capture the commit hash or tag using a group in the regular expression
+        commit_hash = match.group(1)
+        replaced_url = original_url.replace(f'/blob/{commit_hash}/', '/blob/master/')
+        return replaced_url
+
+    # Updated regular expression to capture the commit hash or tag
+    return re.sub(r'https://github.com/.+?/blob/([a-f0-9]+?)/.+?$', replace_source, md_content, flags=re.MULTILINE)
+
 # Function to parse the Inherits line in the Markdown content
 def parse_inherits(md_content):
     inherits_match = re.search(r'\*\*Inherits:\*\*\s*([\s\S]*?)\n', md_content)
@@ -38,6 +50,8 @@ def process_md_file(file_path):
     if inherits:
         modified_inherits = replace_paths_with_empty_brackets(inherits)
         md_content = md_content.replace(inherits, modified_inherits)
+
+    md_content = replace_git_sources(md_content)
 
     # Write the modified content back to the original file
     with open(file_path, 'w') as file:


### PR DESCRIPTION
**Problem**
The `forge doc` generates hyperlinks for git sources based on the commit ID. Instead, it points the git sources to the master branch. This way docs will only be regenerated in the PR, if the PR changes the source contract code. Right now the docs are getting regenerated even if there is no change in the contract because the commit id is changing. 

Example
Old Git Source md taken from forge doc:
```markdown
[Git Source](https://github.com/bob-collective/bob/blob/a2d50b71441518de135cd83845410eb07966908d/src/swap/Wrapped.sol)
```

Expected Git Source md taken from forge doc: 
```markdown
[Git Source](https://github.com/bob-collective/bob/blob/master/src/swap/Wrapped.sol)
```

**Solution** 
Update Python script to handle it. 