### PR TITLE
fix: Update btc core version, add docs to relay contract

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
     bitcoind:
-        image: "ruimarinho/bitcoin-core:24"
+        image: "lightninglabs/bitcoin-core:25"
         command:
             - -regtest
             - -server
@@ -15,7 +15,7 @@ services:
             - "18443:18443"
 
     bitcoin-cli:
-        image: "ruimarinho/bitcoin-core:24"
+        image: "lightninglabs/bitcoin-core:25"
         command:
             - /bin/sh
             - -c

--- a/docs/docs/contracts/src/src/relay/LightRelay.sol/contract.LightRelay.md
+++ b/docs/docs/contracts/src/src/relay/LightRelay.sol/contract.LightRelay.md
@@ -4,11 +4,15 @@
 **Inherits:**
 Ownable, [ILightRelay](../../relay/LightRelay.sol/interface.ILightRelay.md)
 
-*THE RELAY MUST NOT BE USED BEFORE GENESIS AND AT LEAST ONE RETARGET.*
+*The LightRelay contract manages a relay for Bitcoin header information,
+allowing retargeting and validation of header chains.
+THE RELAY MUST NOT BE USED BEFORE GENESIS AND AT LEAST ONE RETARGET.*
 
 
 ## State Variables
 ### ready
+Flag indicating whether the relay is ready for use.
+
 
 ```solidity
 bool public ready;
@@ -16,6 +20,8 @@ bool public ready;
 
 
 ### authorizationRequired
+Flag indicating whether authorization is required for retarget submitters.
+
 
 ```solidity
 bool public authorizationRequired;
@@ -23,6 +29,8 @@ bool public authorizationRequired;
 
 
 ### proofLength
+Number of blocks required for each side of a retarget proof.
+
 
 ```solidity
 uint64 public proofLength;
@@ -30,6 +38,8 @@ uint64 public proofLength;
 
 
 ### genesisEpoch
+The number of the first epoch recorded by the relay.
+
 
 ```solidity
 uint64 public genesisEpoch;
@@ -37,6 +47,8 @@ uint64 public genesisEpoch;
 
 
 ### currentEpoch
+The number of the latest epoch whose difficulty is proven to the relay.
+
 
 ```solidity
 uint64 public currentEpoch;
@@ -44,6 +56,8 @@ uint64 public currentEpoch;
 
 
 ### currentEpochDifficulty
+Difficulty of the current epoch.
+
 
 ```solidity
 uint256 internal currentEpochDifficulty;
@@ -51,6 +65,8 @@ uint256 internal currentEpochDifficulty;
 
 
 ### prevEpochDifficulty
+Difficulty of the previous epoch.
+
 
 ```solidity
 uint256 internal prevEpochDifficulty;
@@ -58,6 +74,8 @@ uint256 internal prevEpochDifficulty;
 
 
 ### epochs
+Mapping of each epoch from genesis to the current one, keyed by their numbers.
+
 
 ```solidity
 mapping(uint256 => Epoch) internal epochs;
@@ -65,6 +83,8 @@ mapping(uint256 => Epoch) internal epochs;
 
 
 ### isAuthorized
+Mapping of authorized submitters.
+
 
 ```solidity
 mapping(address => bool) public isAuthorized;
@@ -73,6 +93,8 @@ mapping(address => bool) public isAuthorized;
 
 ## Functions
 ### relayActive
+
+Modifier to check if the relay is active.
 
 
 ```solidity

--- a/src/relay/LightRelay.sol
+++ b/src/relay/LightRelay.sol
@@ -55,42 +55,51 @@ library RelayUtils {
     }
 }
 
-/// @dev THE RELAY MUST NOT BE USED BEFORE GENESIS AND AT LEAST ONE RETARGET.
+/// @title LightRelay Contract
+/// @dev The LightRelay contract manages a relay for Bitcoin header information,
+/// allowing retargeting and validation of header chains.
+/// THE RELAY MUST NOT BE USED BEFORE GENESIS AND AT LEAST ONE RETARGET.
 contract LightRelay is Ownable, ILightRelay {
     using BytesLib for bytes;
     using BTCUtils for bytes;
     using ValidateSPV for bytes;
     using RelayUtils for bytes;
 
+    /// @notice Flag indicating whether the relay is ready for use.
     bool public ready;
     // Whether the relay requires the address submitting a retarget to be
     // authorised in advance by governance.
+    /// @notice Flag indicating whether authorization is required for retarget submitters.
     bool public authorizationRequired;
-    // Number of blocks required for each side of a retarget proof:
-    // a retarget must provide `proofLength` blocks before the retarget
+    /// @notice Number of blocks required for each side of a retarget proof.
+    // A retarget must provide `proofLength` blocks before the retarget
     // and `proofLength` blocks after it.
     // Governable
     // Should be set to a fairly high number (e.g. 20-50) in production.
     uint64 public proofLength;
-    // The number of the first epoch recorded by the relay.
+    /// @notice The number of the first epoch recorded by the relay.
     // This should equal the height of the block starting the genesis epoch,
     // divided by 2016, but this is not enforced as the relay has no
     // information about block numbers.
     uint64 public genesisEpoch;
-    // The number of the latest epoch whose difficulty is proven to the relay.
+    /// @notice The number of the latest epoch whose difficulty is proven to the relay.
     // If the genesis epoch's number is set correctly, and retargets along the
     // way have been legitimate, this equals the height of the block starting
     // the most recent epoch, divided by 2016.
     uint64 public currentEpoch;
 
+    /// @notice Difficulty of the current epoch.
     uint256 internal currentEpochDifficulty;
+    /// @notice Difficulty of the previous epoch.
     uint256 internal prevEpochDifficulty;
 
-    // Each epoch from genesis to the current one, keyed by their numbers.
+    /// @notice Mapping of each epoch from genesis to the current one, keyed by their numbers.
     mapping(uint256 => Epoch) internal epochs;
 
+    /// @notice Mapping of authorized submitters.
     mapping(address => bool) public isAuthorized;
 
+    /// @notice Modifier to check if the relay is active.
     modifier relayActive() {
         require(ready, "Relay is not ready for use");
         _;


### PR DESCRIPTION
The PR adds the following
- [x] Update btc core to `v25` in the docker file
- [x] Add docs to relay (State variables and contract overview was missing)