### PR TITLE
fix: compile contract with viaIR flag .

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv --via-ir --deny-warnings
+          forge test -vvv --deny-warnings
         id: test
 
       - name: Run Forge docs

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 solc = "0.8.17"
-# `viaIR` flag needs to unabled since `Lightrelay.t.sol` requires it
+# `viaIR` flag needs to enabled since `Lightrelay.t.sol` requires it
 viaIR = true
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,8 @@ src = "src"
 out = "out"
 libs = ["lib"]
 solc = "0.8.17"
-
+# `viaIR` flag needs to unabled since `Lightrelay.t.sol` requires it
+viaIR = true
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 
 remappings = [


### PR DESCRIPTION
The `viaIR` flag is currently disabled during the build process, leading to a compiler error. You can check the error [here](https://github.com/bob-collective/bob/actions/runs/7828910688/job/21359772350#step:5:10). It's recommended to enable this flag by default to avoid build errors.

Note: It doesn't add any security vulnerabilities, just a semantic change. 