### PR TITLE
Add websocket link to network page

### DIFF
--- a/docs/docs/build/getting-started/networks.md
+++ b/docs/docs/build/getting-started/networks.md
@@ -23,7 +23,8 @@ BOB Testnet (New)
 - Chain ID: 606808
 - Gas Token: ETH
 - RPC URL (BOB): https://sepolia-dencun.rpc.gobob.xyz/
-- Explorer (BOB): https://sepolia-dencun.explorer.gobob.xyz/
+- Websocket RPC URL (BOB): wss://sepolia-dencun.rpc.gobob.xyz/wss
+- Block Explorer (BOB): https://sepolia-dencun.explorer.gobob.xyz/
 - Bridge (BOB - Sepolia): https://bob-testnet.bridge.caldera.xyz/
 
 BOB Testnet (Old)


### PR DESCRIPTION
@nud3l, I left the https version of the RPC URL because it works correctly for the most common use-case, adding a network to a wallet. I'm not sure what the websocket version would be used for, but Nikolai helped verify this version (trailing /wss) works. 

If you'd like to list the websocket version of the RPC (alongside the https version) approve this PR. 