### PR TITLE
feat: extract evm address from op return

### DIFF
--- a/docs/docs/build/bob-sdk/relay.md
+++ b/docs/docs/build/bob-sdk/relay.md
@@ -80,7 +80,7 @@ This approach is still experimental and not yet fully supported by the SDK. To c
 
 ### Checking Output Amounts
 
-To extract the output amount `BitcoinTx.getTxOutputValue` can be be used to extract the amount transferred to a specific address. See [`test/BitcoinTx.t.sol`](https://github.com/bob-collective/bob/blob/master/test/BitcoinTx.t.sol) for an example. The address is the `keccak256` hash of the expected `scriptPubKey`.
+To extract the output amount `BitcoinTx.processTxOutputs` can be be used to extract the amount transferred to a specific address. See [`test/BitcoinTx.t.sol`](https://github.com/bob-collective/bob/blob/master/test/BitcoinTx.t.sol) for an example. The address is the `keccak256` hash of the expected `scriptPubKey`.
 
 :::tip BOB SDK
 

--- a/docs/docs/contracts/src/src/utils/BitcoinTx.sol/library.BitcoinTx.md
+++ b/docs/docs/contracts/src/src/utils/BitcoinTx.sol/library.BitcoinTx.md
@@ -56,48 +56,58 @@ function evaluateProofDifficulty(IRelay relay, uint256 txProofDifficultyFactor, 
 |`bitcoinHeaders`|`bytes`|Bitcoin headers chain being part of the SPV proof. Used to extract the observed proof difficulty.|
 
 
-### getTxOutputValue
+### processTxOutputs
 
 Processes the Bitcoin transaction output vector.
 
 
 ```solidity
-function getTxOutputValue(bytes32 scriptPubKeyHash, bytes memory txOutputVector) internal pure returns (uint64 value);
+function processTxOutputs(bytes memory txOutputVector, bytes32 scriptPubKeyHash)
+    internal
+    pure
+    returns (TxOutputsInfo memory resultInfo);
 ```
 **Parameters**
 
 |Name|Type|Description|
 |----|----|-----------|
-|`scriptPubKeyHash`|`bytes32`|Expected Bitcoin scriptPubKey keccak256 hash.|
 |`txOutputVector`|`bytes`|Bitcoin transaction output vector. This function assumes vector's structure is valid so it must be validated using e.g. `BTCUtils.validateVout` function before it is passed here.|
+|`scriptPubKeyHash`|`bytes32`|Expected Bitcoin scriptPubKey keccak256 hash.|
 
 **Returns**
 
 |Name|Type|Description|
 |----|----|-----------|
-|`value`|`uint64`|Outcomes of the processing.|
+|`resultInfo`|`TxOutputsInfo`|Outcomes of the processing.|
 
 
-### getTxOutputValue
+### processTxOutputs
 
 Processes all outputs from the transaction.
 
 
 ```solidity
-function getTxOutputValue(
-    bytes32 scriptPubKeyHash,
+function processTxOutputs(
     bytes memory txOutputVector,
+    bytes32 scriptPubKeyHash,
     TxOutputsProcessingInfo memory processInfo
-) internal pure returns (uint64 value);
+) internal pure returns (TxOutputsInfo memory resultInfo);
 ```
 **Parameters**
 
 |Name|Type|Description|
 |----|----|-----------|
-|`scriptPubKeyHash`|`bytes32`|Expected Bitcoin scriptPubKey keccak256 hash.|
 |`txOutputVector`|`bytes`|Bitcoin transaction output vector. This function assumes vector's structure is valid so it must be validated using e.g. `BTCUtils.validateVout` function before it is passed here.|
+|`scriptPubKeyHash`|`bytes32`|Expected Bitcoin scriptPubKey keccak256 hash.|
 |`processInfo`|`TxOutputsProcessingInfo`|TxOutputsProcessingInfo identifying output starting index and the number of outputs.|
 
+
+### extractEvmAddressFromOutput
+
+
+```solidity
+function extractEvmAddressFromOutput(bytes memory _output, uint256 _at) internal pure returns (address evmAddress);
+```
 
 ### reverseEndianness
 
@@ -163,6 +173,18 @@ and should not be exported outside of the transaction processing code.
 struct TxOutputsProcessingInfo {
     uint256 outputStartingIndex;
     uint256 outputsCount;
+}
+```
+
+### TxOutputsInfo
+Represents an outcome of the Bitcoin transaction
+outputs processing.
+
+
+```solidity
+struct TxOutputsInfo {
+    uint64 value;
+    address evmAddress;
 }
 ```
 

--- a/sdk/test/relay.test.ts
+++ b/sdk/test/relay.test.ts
@@ -1,8 +1,23 @@
 import { assert, describe, it } from "vitest";
 import { DefaultElectrsClient } from "../src/electrs";
 import { getBitcoinTxInfo, getBitcoinTxProof } from "../src/relay";
+import * as bitcoin from "bitcoinjs-lib";
+import { encodeRawOutput } from "../src/utils";
 
 describe("Relay Tests", () => {
+    // doesn't do anything, but left here to build more contract tests
+    it("should encode output and op return", async () => {
+        const tx = new bitcoin.Transaction();
+        const output = bitcoin.address.fromBech32("bcrt1qv9pt88qqwdnjmsuzhzdy9v57qcmghj4alhdg5y").data;
+        console.log(Buffer.concat([Buffer.from([output.length]), output]).toString("hex"));
+        tx.addOutput(output, 15000);
+        tx.addOutput(bitcoin.script.compile([
+            bitcoin.opcodes.OP_RETURN,
+            Buffer.from("675Ca18A04027fd50C88CcD03939E0e5C97b795f", "hex")
+        ]), 0);
+        console.log(encodeRawOutput(tx).toString("hex"));
+    });
+
     it("should get tx info", async () => {
         const client = new DefaultElectrsClient();
         const txId = "2ef69769cc0ee81141c79552de6b91f372ff886216dbfa84e5497a16b0173e79";

--- a/src/swap/Btc_Marketplace.sol
+++ b/src/swap/Btc_Marketplace.sol
@@ -404,7 +404,7 @@ contract BtcMarketPlace is ERC2771Recipient {
         bytes32 scriptPubKeyHash =
             keccak256(abi.encodePacked(uint8(bitcoinAddress.scriptPubKey.length), bitcoinAddress.scriptPubKey));
 
-        uint256 txOutputValue = BitcoinTx.getTxOutputValue(scriptPubKeyHash, transaction.outputVector);
+        uint256 txOutputValue = BitcoinTx.processTxOutputs(transaction.outputVector, scriptPubKeyHash).value;
 
         require(txOutputValue >= expectedBtcAmount, "Bitcoin transaction amount is lower than in accepted order.");
     }

--- a/src/swap/Ord_Marketplace.sol
+++ b/src/swap/Ord_Marketplace.sol
@@ -157,7 +157,7 @@ contract OrdMarketplace {
             keccak256(abi.encodePacked(uint8(bitcoinAddress.scriptPubKey.length), bitcoinAddress.scriptPubKey));
 
         // it will revert if no match for scriptPubKeyHash found in any outputScriptHash
-        BitcoinTx.getTxOutputValue(scriptPubKeyHash, transaction.outputVector);
+        BitcoinTx.processTxOutputs(transaction.outputVector, scriptPubKeyHash);
     }
 
     function withdrawOrdinalSellOrder(uint256 id) public {


### PR DESCRIPTION
So we can specify the recipient EVM address in the Bitcoin transaction