### PR TITLE
Add CTA links for builders to connect with BD

### DIFF
--- a/docs/docs/learn/guides/bob-fusion.md
+++ b/docs/docs/learn/guides/bob-fusion.md
@@ -9,6 +9,12 @@ sidebar_label: BOB Fusion
 
 BOB Fusion is the official points program of BOB, where users can harvest BOB Spice (points) based on their on-chain activity on the BOB mainnet. BOB Spice (points) represent your contribution to the BOB ecosystem - today and in the future.
 
+:::tip Add your project to Fusion
+
+Building on BOB? [Contact us](https://forms.gle/EKYmrAhPsyiQ3ua57) to join the Fusion campaign after you deploy on BOB.
+
+:::
+
 ## Season 1
 
 Season 1 started on 27/03/2024 and ended with the BOB mainnet launch on 1st May 2024.

--- a/docs/docs/learn/introduction/contribution.md
+++ b/docs/docs/learn/introduction/contribution.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-sidebar_label: 'How Can I Contribute?'
+sidebar_label: "How Can I Contribute?"
 ---
 
 # How Can I Contribute?
@@ -24,6 +24,7 @@ If you are keen to build on BOB or contribute to BOB itself:
 
 <!-- - Discuss ideas and share feedback on the [forum](https://forum.gobob.xyz/) -->
 
+- Join the [BOB Fusion campaign](https://forms.gle/EKYmrAhPsyiQ3ua57) after you deploy on BOB.
 - Checkout the [bob-collective GitHub](https://github.com/bob-collective/bob)
 - Deploy your first "[Hello Bitcoin](/docs/build/getting-started/helloworld)" contracts on BOB.
 - Try out our [Demos](/docs/build/getting-started/#examples)

--- a/docs/docs/learn/introduction/use-cases.md
+++ b/docs/docs/learn/introduction/use-cases.md
@@ -5,6 +5,12 @@ sidebar_label: What Can I Build on BOB?
 
 # What Can I Build on BOB?
 
+:::tip Add your project to BOB Fusion
+
+If you're interested in building any of these ideas, [contact us](https://forms.gle/EKYmrAhPsyiQ3ua57) to join the BOB Fusion campaign.
+
+:::
+
 ## Use Case Ideas
 
 - Decentralized Bitcoin interest (convert staking rewards of other tokens to Bitcoin)


### PR DESCRIPTION
This adds several callouts on relevant docs pages for builders to contact us. If we want something like this to be even more visible, we could consider a CTA in the header of all pages.

@nud3l, do you think a "Join Fusion" link next to Discord and GitHub in the header is too prominent, potentially leading to spam for Chris?