### PR TITLE
docs: Replace broken Conduit link with guides

### DIFF
--- a/docs/docs/build/how-to/full-node.md
+++ b/docs/docs/build/how-to/full-node.md
@@ -3,53 +3,30 @@ sidebar_position: 5
 sidebar_label: Run a Full Node
 ---
 
-# How to run a self-hosted full node for BOB
+# Run a Full Node
 
 :::info
-There is no protocol level incentive to run an BOB full node. If you’re interested in accessing the BOB chain, but you don’t want to set up your own node, see our [Node Providers](../tools/node-providers) to get RPC access to fully-managed nodes hosted by a third-party provider.
+There is no protocol level incentive to run a BOB full node. If you’re interested in accessing the BOB chain, but you don’t want to set up your own node, see our [Node Providers](../tools/node-providers) to get RPC access to fully-managed nodes hosted by a third-party provider.
 :::
 
 ## Requirements
-As of June 2024 we recommend you have at least the following hardware configuration to run a node:
+
+As of August 2024 we recommend you have at least the following hardware configuration to run a node:
 
 - at least 8 GB RAM
 - an SSD, preferably NVME drive with at least 100 GB free
 
 Software stack:
-- Python 3
-- Docker compose
 
+- [Python 3](https://www.python.org/downloads/)
+- [Docker](https://docs.docker.com/engine/install/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
 
-## Putting it all together
+## Resources
 
-1. Clone the [Conduit Nodes](https://github.com/conduitxyz/node) Github repository
-```
-git clone https://github.com/conduitxyz/node.git
-```
+Please follow [Conduit's node documentation](https://docs.conduit.xyz/guides/run-a-node/op-stack-node) for information on how to self-host a node for an OP Stack rollup deployed on Conduit such as BOB. Conduit extends [Optimism's guide for running a node with Docker](https://docs.optimism.io/builders/node-operators/tutorials/node-from-docker), the source of the specific hardware and software dependencies above.
 
-2. Create `.env` file containing all necessary environment variables. You will need to set RPC URLs to an Ethereum L1 execution client (geth, erigon) and L1 consensus client (lighthouse, nimbus, prysm)
+## External Links
 
-Example:
-```
-CONDUIT_NETWORK=bob-mainnet-0
-# Replace with your preferred L1 (Ethereum) execution node RPC URL:
-OP_NODE_L1_ETH_RPC=...
-# Replace with your preferred L1 (Ethereum) consensus node RPC URL:
-OP_NODE_L1_BEACON=...
-```
-
-3. Download the required chain configuration
-
-```
-./download-config.py bob-mainnet-0
-```
-
-4. Start the node
-
-```
-docker compose up --build
-```
-
-:::tip
-Use `docker compose logs` to retrieve the logs for op-node and op-geth
-:::
+1. [Conduit's node documentation](https://docs.conduit.xyz/guides/run-a-node/op-stack-node)
+1. [Optimism's guide for running a node with Docker](https://docs.optimism.io/builders/node-operators/tutorials/node-from-docker)


### PR DESCRIPTION
## Problem
The previous version of this page had a broken link, leading to time wasted helping node-runners get set up.

## Solution
Rather than track a moving target (i.e. maintain our own version of Conduit's and Optimism's steps for running a BOB node), we point to their resources and update links when necessary.

## Screenshot of Updated Page

<img width="780" alt="Screenshot 2024-08-26 at 12 03 28 PM" src="https://github.com/user-attachments/assets/bb2e2ea6-ac6b-42fc-a8b4-bc9becd3c02f">
