### PR TITLE
feat: optional amount for quote total

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/bob-sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -83,6 +83,8 @@ type GatewayStartOrderResult = GatewayCreateOrderResponse & {
     psbtBase64?: string;
 };
 
+type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>;
+
 /**
  * Base url for the mainnet Gateway API.
  * @default "https://gateway-api-mainnet.gobob.xyz"
@@ -133,7 +135,7 @@ export class GatewayApiClient {
      * 
      * @param params The parameters for the quote.
      */
-    async getQuote(params: GatewayQuoteParams): Promise<GatewayQuote> {
+    async getQuote(params: Optional<GatewayQuoteParams, "amount" | "toUserAddress">): Promise<GatewayQuote> {
         const isMainnet = params.toChain === 60808 || typeof params.toChain === "string" && params.toChain.toLowerCase() === Chains.BOB;
         const isTestnet = params.toChain === 808813 || typeof params.toChain === "string" && params.toChain.toLowerCase() === Chains.BOBSepolia;
 

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -49,6 +49,16 @@ describe("Gateway Tests", () => {
             toUserAddress: ZeroAddress,
             amount: 1000,
         }), mockQuote);
+
+        // get the total available without amount
+        nock(`${MAINNET_GATEWAY_BASE_URL}`)
+            .get(`/quote/${SYMBOL_LOOKUP["tbtc"].bob}/`)
+            .reply(200, mockQuote);
+        assert.deepEqual(await gatewaySDK.getQuote({
+            toChain: "BOB",
+            toToken: SYMBOL_LOOKUP["tbtc"].bob,
+            toUserAddress: ZeroAddress,
+        }), mockQuote);
     });
 
     it("should start order", async () => {


### PR DESCRIPTION
Allows `getQuote` to be used also to get the total liquidity