### PR TITLE
Create landing page for Safe Gas Station campaign

### DIFF
--- a/docs/docs/build/how-to/safe-gas-station.md
+++ b/docs/docs/build/how-to/safe-gas-station.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 0
+sidebar_label: Give Users Free Transactions
+---
+
+# Give Users Free Transactions
+
+## Sponsor Your Users' Transactions With Safe Gas Station
+
+BOB believes that users deserve next-gen UX, including abstracting away the complexity of transaction fees from users. That's why we're partnered with the [Safe\{Core\} Gas Station Program](https://safe.global/gas-station) to sponsor up to $150,000 of your users' transaction fees.
+
+## Spice Things Up With BOB Fusion
+
+In addition to sponsoring your users' transaction fees, we would like to invite any projects joining the Safe\{Core\} Gas Station Program to be a part of [BOB Fusion](/docs/learn/guides/bob-fusion/index.md). Check out the [BOB Fusion app](https://app.gobob.xyz/fusion) to see how we engage our community with weekly voting competitions, Spice harvesting bonuses, and links to our ecosystem of projects.
+
+:::tip Join BOB Fusion today!
+If free gas fees and Spice points to give your users sounds interesting to you, [contact us](https://forms.gle/EKYmrAhPsyiQ3ua57) to learn more and join the BOB Fusion campaign.
+:::
+
+## Resources
+
+- [Apply to the Safe\{Core\} Gas Station Program](https://wn2n6ocviur.typeform.com/gasstationapp)
+- [Learn more about Safe Modules and ERC-4337](https://docs.safe.global/advanced/erc-4337/4337-safe)
+- [Check out the Safe SDK](https://docs.safe.global/advanced/erc-4337/guides/safe-sdk)


### PR DESCRIPTION
A page for the Safe team to share with builders when referencing BOB's part in the [Safe{CORE} Gas Station](https://safe.global/gas-station) program.

<img width="1346" alt="Screenshot 2024-10-11 at 4 48 01 PM" src="https://github.com/user-attachments/assets/19cab1cd-175c-4425-8336-88ec0feec6fc">
