### PR TITLE
Add balance calculation logic

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/bob-sdk",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/bob-sdk",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/sdk/src/wallet/utxo.ts
+++ b/sdk/src/wallet/utxo.ts
@@ -399,3 +399,72 @@ export async function estimateTxFee(
 
     return transaction.fee;
 }
+
+/**
+ * Get balance of provided address in satoshis.
+ *
+ * @typedef { {confirmed: BigInt, unconfirmed: BigInt, total: bigint} } Balance
+ *
+ * @param {string} [address] The Bitcoin address. If no address specified returning object will contain zeros.
+ * @returns {Promise<Balance>} The balance object of provided address in satoshis.
+ *
+ * @example
+ * ```typescript
+ * const address = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+ *
+ * const balance = await getBalance(address);
+ * console.log(balance);
+ * ```
+ *
+ * @dev UTXOs that contain inscriptions or runes will not be used to calculate balance.
+ */
+export async function getBalance(address?: string) {
+    if (!address) {
+        return { confirmed: BigInt(0), unconfirmed: BigInt(0), total: BigInt(0) };
+    }
+
+    const addressInfo = getAddressInfo(address);
+
+    const esploraClient = new EsploraClient(addressInfo.network);
+    const ordinalsClient = new OrdinalsClient(addressInfo.network);
+
+    if (addressInfo.type === AddressType.p2tr) {
+        const [outputs, cardinalOutputs] = await Promise.all([
+            esploraClient.getAddressUtxos(address),
+            // cardinal = return UTXOs not containing inscriptions or runes
+            ordinalsClient.getOutputsFromAddress(address, 'cardinal'),
+        ]);
+
+        const cardinalOutputsSet = new Set(cardinalOutputs.map((output) => output.outpoint));
+
+        const total = outputs.reduce((acc, output) => {
+            if (cardinalOutputsSet.has(OutPoint.toString(output))) {
+                return acc + output.value;
+            }
+
+            return acc;
+        }, 0);
+
+        const confirmed = outputs.reduce((acc, output) => {
+            if (cardinalOutputsSet.has(OutPoint.toString(output)) && output.confirmed) {
+                return acc + output.value;
+            }
+
+            return acc;
+        }, 0);
+
+        return {
+            confirmed: BigInt(confirmed),
+            unconfirmed: BigInt(total - confirmed),
+            total: BigInt(total),
+        };
+    } else {
+        const { confirmed, unconfirmed, total } = await esploraClient.getBalance(address);
+
+        return {
+            confirmed: BigInt(confirmed),
+            unconfirmed: BigInt(unconfirmed),
+            total: BigInt(total),
+        };
+    }
+}

--- a/sdk/src/wallet/utxo.ts
+++ b/sdk/src/wallet/utxo.ts
@@ -416,7 +416,7 @@ export async function estimateTxFee(
  * console.log(balance);
  * ```
  *
- * @dev UTXOs that contain inscriptions or runes will not be used to calculate balance.
+ * @dev UTXOs that contain inscriptions or runes will not be used to calculate balance for taproot address.
  */
 export async function getBalance(address?: string) {
     if (!address) {

--- a/sdk/src/wallet/utxo.ts
+++ b/sdk/src/wallet/utxo.ts
@@ -416,7 +416,7 @@ export async function estimateTxFee(
  * console.log(balance);
  * ```
  *
- * @dev UTXOs that contain inscriptions or runes will not be used to calculate balance for taproot address.
+ * @dev For taproot address UTXOs that contain inscriptions or runes will not be used to calculate balance.
  */
 export async function getBalance(address?: string) {
     if (!address) {

--- a/sdk/test/utxo.test.ts
+++ b/sdk/test/utxo.test.ts
@@ -466,6 +466,5 @@ describe('UTXO Tests', () => {
 
         expect(balanceData.total).toBeLessThan(total);
         expect(balanceData.confirmed).toBeLessThan(confirmed);
-        expect(balanceData.unconfirmed).toBeLessThan(total - confirmed);
     });
 });

--- a/sdk/test/utxo.test.ts
+++ b/sdk/test/utxo.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, assert, Mock, expect } from 'vitest';
+import { vi, describe, it, assert, Mock, expect, beforeEach } from 'vitest';
 import { AddressType, getAddressInfo, Network } from 'bitcoin-address-validation';
 import { Address, NETWORK, OutScript, Script, Transaction, p2sh, p2wpkh, selectUTXO } from '@scure/btc-signer';
 import { hex, base64 } from '@scure/base';
@@ -37,6 +37,10 @@ vi.mock(import('../src/esplora'), async (importOriginal) => {
 // TODO: Add more tests using https://github.com/paulmillr/scure-btc-signer/tree/5ead71ea9a873d8ba1882a9cd6aa561ad410d0d1/test/bitcoinjs-test/fixtures/bitcoinjs
 // TODO: Ensure that the paymentAddresses have sufficient funds to create the transaction
 describe('UTXO Tests', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it('should spend from address to create a transaction with an OP return output', { timeout: 50000 }, async () => {
         // Addresses where randomly picked from blockstream.info
         const paymentAddresses = [
@@ -433,7 +437,6 @@ describe('UTXO Tests', () => {
     });
 
     it('returns smalled amount if address holds ordinals', async () => {
-        vi.clearAllMocks();
         const taprootAddress = 'bc1peqr5a5kfufvsl66444jm9y8qq0s87ph0zv4lfkcs7h40ew02uvsqkhjav0';
 
         const esploraClient = new EsploraClient('mainnet');

--- a/sdk/test/utxo.test.ts
+++ b/sdk/test/utxo.test.ts
@@ -464,8 +464,8 @@ describe('UTXO Tests', () => {
 
         const balanceData = await getBalance(taprootAddress);
 
-        expect(balanceData.total).toBeLessThanOrEqual(total);
-        expect(balanceData.confirmed).toBeLessThanOrEqual(confirmed);
-        expect(balanceData.unconfirmed).toBeLessThanOrEqual(total - confirmed);
+        expect(balanceData.total).toBeLessThan(total);
+        expect(balanceData.confirmed).toBeLessThan(confirmed);
+        expect(balanceData.unconfirmed).toBeLessThan(total - confirmed);
     });
 });

--- a/sdk/test/utxo.test.ts
+++ b/sdk/test/utxo.test.ts
@@ -432,17 +432,6 @@ describe('UTXO Tests', () => {
         assert(zeroBalance.total === 0n, 'If no address specified total must be 0');
     });
 
-    it('should call ordinals api if address type is p2tr', async () => {
-        vi.clearAllMocks();
-        const nativeSegwitAddress = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
-        const taprootAddress = 'bc1peqr5a5kfufvsl66444jm9y8qq0s87ph0zv4lfkcs7h40ew02uvsqkhjav0';
-
-        await getBalance(nativeSegwitAddress);
-        expect(OrdinalsClient.prototype.getOutputsFromAddress).not.toHaveBeenCalled();
-        await getBalance(taprootAddress);
-        expect(OrdinalsClient.prototype.getOutputsFromAddress).toHaveBeenCalledOnce();
-    });
-
     it('returns smalled amount if address holds ordinals', async () => {
         vi.clearAllMocks();
         const taprootAddress = 'bc1peqr5a5kfufvsl66444jm9y8qq0s87ph0zv4lfkcs7h40ew02uvsqkhjav0';

--- a/sdk/test/utxo.test.ts
+++ b/sdk/test/utxo.test.ts
@@ -5,7 +5,7 @@ import { hex, base64 } from '@scure/base';
 import { createBitcoinPsbt, getInputFromUtxoAndTx, estimateTxFee, Input, getBalance } from '../src/wallet/utxo';
 import { TransactionOutput } from '@scure/btc-signer/psbt';
 import { OrdinalsClient, OutPoint } from '../src/ordinal-api';
-import { beforeEach } from 'node:test';
+import { EsploraClient } from '../src/esplora';
 
 vi.mock(import('@scure/btc-signer'), async (importOriginal) => {
     const actual = await importOriginal();
@@ -26,12 +26,10 @@ vi.mock(import('../src/ordinal-api'), async (importOriginal) => {
     return actual;
 });
 
-vi.mock(import('../src/ordinal-api'), async (importOriginal) => {
+vi.mock(import('../src/esplora'), async (importOriginal) => {
     const actual = await importOriginal();
 
-    actual.OrdinalsClient.prototype.getOutputsFromAddress = vi.fn(
-        actual.OrdinalsClient.prototype.getOutputsFromAddress
-    );
+    actual.EsploraClient.prototype.getAddressUtxos = vi.fn(actual.EsploraClient.prototype.getAddressUtxos);
 
     return actual;
 });
@@ -443,5 +441,39 @@ describe('UTXO Tests', () => {
         expect(OrdinalsClient.prototype.getOutputsFromAddress).not.toHaveBeenCalled();
         await getBalance(taprootAddress);
         expect(OrdinalsClient.prototype.getOutputsFromAddress).toHaveBeenCalledOnce();
+    });
+
+    it('returns smalled amount if address holds ordinals', async () => {
+        vi.clearAllMocks();
+        const taprootAddress = 'bc1peqr5a5kfufvsl66444jm9y8qq0s87ph0zv4lfkcs7h40ew02uvsqkhjav0';
+
+        const esploraClient = new EsploraClient('mainnet');
+
+        const outputs = await esploraClient.getAddressUtxos(taprootAddress);
+
+        const total = outputs.reduce((acc, output) => acc + output.value, 0);
+
+        const confirmed = outputs.reduce((acc, output) => {
+            if (output.confirmed) {
+                return acc + output.value;
+            }
+
+            return acc;
+        }, 0);
+
+        // mock half of the UTXOs contain inscriptions or runes
+        (OrdinalsClient.prototype.getOutputsFromAddress as Mock).mockResolvedValueOnce(
+            outputs.slice(Math.ceil(outputs.length / 2)).map((output) => {
+                const outpoint = OutPoint.toString(output);
+
+                return { outpoint };
+            })
+        );
+
+        const balanceData = await getBalance(taprootAddress);
+
+        expect(balanceData.total).toBeLessThanOrEqual(total);
+        expect(balanceData.confirmed).toBeLessThanOrEqual(confirmed);
+        expect(balanceData.unconfirmed).toBeLessThanOrEqual(total - confirmed);
     });
 });

--- a/sdk/test/utxo.test.ts
+++ b/sdk/test/utxo.test.ts
@@ -439,7 +439,6 @@ describe('UTXO Tests', () => {
         const nativeSegwitAddress = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
         const taprootAddress = 'bc1peqr5a5kfufvsl66444jm9y8qq0s87ph0zv4lfkcs7h40ew02uvsqkhjav0';
 
-        expect(OrdinalsClient.prototype.getOutputsFromAddress).not.toHaveBeenCalled();
         await getBalance(nativeSegwitAddress);
         expect(OrdinalsClient.prototype.getOutputsFromAddress).not.toHaveBeenCalled();
         await getBalance(taprootAddress);


### PR DESCRIPTION
Also includes updates to 
- estimateTxFee
- createBitcoinPsbt

⚠️ Inputs that contain ordinals or runes no longer will be used in tx fee estimations or could be spent from (any, not just taproot) address