### PR TITLE
Remove safeMath reference from FullRelayWithVerify.sol

### DIFF
--- a/src/relay/FullRelayWithVerify.sol
+++ b/src/relay/FullRelayWithVerify.sol
@@ -9,7 +9,6 @@ import {BTCUtils} from "@bob-collective/bitcoin-spv/BTCUtils.sol";
 import {ValidateSPV} from "@bob-collective/bitcoin-spv/ValidateSPV.sol";
 
 contract FullRelayWithVerify is FullRelay {
-    using SafeMath for uint256;
     using BTCUtils for bytes;
     using BTCUtils for uint256;
 


### PR DESCRIPTION
safeMath is redundant in Solidity versions `>=0.8.0` as overflow/underflow is handled natively by the compiler, and in a more efficient and robust way than safeMath's implementation. This also just allows for removal of dependency on an external library.