### PR TITLE
Fix broken links in docs (Issue #423)

### DIFF
--- a/docs/docs/learn/reference/tools/oracles.md
+++ b/docs/docs/learn/reference/tools/oracles.md
@@ -10,7 +10,7 @@ Acurast provides [Chainlink-compatible Price Feeds](https://docs.acurast.com/int
 
 The [API3 Market](https://market.api3.org/bob) provides access to 200+ price feeds on [BOB Mainnet](https://market.api3.org/bob) and [Testnet](https://market.api3.org/bob-sepolia-testnet). The price feeds operate as a native push oracle and can be activated instantly via the Market UI.
 
-The price feeds are delivered by an aggregate of [first-party oracles](https://old-docs.api3.org/airnode/pre-alpha/#designed-for-first-party-oracles) using signed data and support [OEV recapture](https://docs.api3.org/explore/introduction/oracle-extractable-value.html).
+The price feeds are delivered by an aggregate of [first-party oracles](https://old-docs.api3.org/airnode/pre-alpha/#designed-for-first-party-oracles) using signed data and support [OEV recapture](https://docs.api3.org/oev-searchers/in-depth/oev-searching.html).
 
 Unlike traditional data feeds, reading [API3 price feeds](https://docs.api3.org/guides/dapis/) enables dApps to auction off the right to update the price feeds to searcher bots which facilitates more efficient liquidation processes for users and LPs of DeFi money markets. The OEV recaptured is returned to the dApp.
 

--- a/docs/docs/learn/reference/tools/oracles.md
+++ b/docs/docs/learn/reference/tools/oracles.md
@@ -10,7 +10,7 @@ Acurast provides [Chainlink-compatible Price Feeds](https://docs.acurast.com/int
 
 The [API3 Market](https://market.api3.org/bob) provides access to 200+ price feeds on [BOB Mainnet](https://market.api3.org/bob) and [Testnet](https://market.api3.org/bob-sepolia-testnet). The price feeds operate as a native push oracle and can be activated instantly via the Market UI.
 
-The price feeds are delivered by an aggregate of [first-party oracles](https://docs.api3.org/explore/airnode/why-first-party-oracles.html](https://old-docs.api3.org/airnode/pre-alpha/#designed-for-first-party-oracles)) using signed data and support [OEV recapture](https://docs.api3.org/explore/introduction/oracle-extractable-value.html).
+The price feeds are delivered by an aggregate of [first-party oracles](https://old-docs.api3.org/airnode/pre-alpha/#designed-for-first-party-oracles) using signed data and support [OEV recapture](https://docs.api3.org/explore/introduction/oracle-extractable-value.html).
 
 Unlike traditional data feeds, reading [API3 price feeds](https://docs.api3.org/guides/dapis/) enables dApps to auction off the right to update the price feeds to searcher bots which facilitates more efficient liquidation processes for users and LPs of DeFi money markets. The OEV recaptured is returned to the dApp.
 

--- a/docs/docs/learn/reference/tools/oracles.md
+++ b/docs/docs/learn/reference/tools/oracles.md
@@ -10,7 +10,7 @@ Acurast provides [Chainlink-compatible Price Feeds](https://docs.acurast.com/int
 
 The [API3 Market](https://market.api3.org/bob) provides access to 200+ price feeds on [BOB Mainnet](https://market.api3.org/bob) and [Testnet](https://market.api3.org/bob-sepolia-testnet). The price feeds operate as a native push oracle and can be activated instantly via the Market UI.
 
-The price feeds are delivered by an aggregate of [first-party oracles]([https://docs.api3.org/explore/airnode/why-first-party-oracles.html](https://old-docs.api3.org/airnode/pre-alpha/#designed-for-first-party-oracles)) using signed data and support [OEV recapture](https://docs.api3.org/explore/introduction/oracle-extractable-value.html).
+The price feeds are delivered by an aggregate of [first-party oracles](https://docs.api3.org/explore/airnode/why-first-party-oracles.html](https://old-docs.api3.org/airnode/pre-alpha/#designed-for-first-party-oracles)) using signed data and support [OEV recapture](https://docs.api3.org/explore/introduction/oracle-extractable-value.html).
 
 Unlike traditional data feeds, reading [API3 price feeds](https://docs.api3.org/guides/dapis/) enables dApps to auction off the right to update the price feeds to searcher bots which facilitates more efficient liquidation processes for users and LPs of DeFi money markets. The OEV recaptured is returned to the dApp.
 

--- a/docs/docs/learn/reference/tools/oracles.md
+++ b/docs/docs/learn/reference/tools/oracles.md
@@ -10,7 +10,7 @@ Acurast provides [Chainlink-compatible Price Feeds](https://docs.acurast.com/int
 
 The [API3 Market](https://market.api3.org/bob) provides access to 200+ price feeds on [BOB Mainnet](https://market.api3.org/bob) and [Testnet](https://market.api3.org/bob-sepolia-testnet). The price feeds operate as a native push oracle and can be activated instantly via the Market UI.
 
-The price feeds are delivered by an aggregate of [first-party oracles](https://docs.api3.org/explore/airnode/why-first-party-oracles.html) using signed data and support [OEV recapture](https://docs.api3.org/explore/introduction/oracle-extractable-value.html).
+The price feeds are delivered by an aggregate of [first-party oracles]([https://docs.api3.org/explore/airnode/why-first-party-oracles.html](https://old-docs.api3.org/airnode/pre-alpha/#designed-for-first-party-oracles)) using signed data and support [OEV recapture](https://docs.api3.org/explore/introduction/oracle-extractable-value.html).
 
 Unlike traditional data feeds, reading [API3 price feeds](https://docs.api3.org/guides/dapis/) enables dApps to auction off the right to update the price feeds to searcher bots which facilitates more efficient liquidation processes for users and LPs of DeFi money markets. The OEV recaptured is returned to the dApp.
 

--- a/docs/docs/learn/reference/tools/oracles.md
+++ b/docs/docs/learn/reference/tools/oracles.md
@@ -10,7 +10,7 @@ Acurast provides [Chainlink-compatible Price Feeds](https://docs.acurast.com/int
 
 The [API3 Market](https://market.api3.org/bob) provides access to 200+ price feeds on [BOB Mainnet](https://market.api3.org/bob) and [Testnet](https://market.api3.org/bob-sepolia-testnet). The price feeds operate as a native push oracle and can be activated instantly via the Market UI.
 
-The price feeds are delivered by an aggregate of [first-party oracles](https://old-docs.api3.org/airnode/pre-alpha/#designed-for-first-party-oracles) using signed data and support [OEV recapture](https://docs.api3.org/oev-searchers/in-depth/oev-searching.html).
+The price feeds are delivered by an aggregate of [first-party oracles](https://old-docs.api3.org/airnode/v0.10/#designed-for-first-party-oracles) using signed data and support [OEV recapture](https://docs.api3.org/oev-searchers/in-depth/oev-searching.html).
 
 Unlike traditional data feeds, reading [API3 price feeds](https://docs.api3.org/guides/dapis/) enables dApps to auction off the right to update the price feeds to searcher bots which facilitates more efficient liquidation processes for users and LPs of DeFi money markets. The OEV recaptured is returned to the dApp.
 

--- a/docs/docs/learn/reference/tools/rust-zkvm.md
+++ b/docs/docs/learn/reference/tools/rust-zkvm.md
@@ -50,7 +50,7 @@ To execute the demo, perform the following steps:
 
 #### 1. Account Creation and Funding
 
-Create a new Ethereum account using e.g. MetaMask, and fund the account using the l2 faucet on [this page](https://docs.metamask.io/services/how-to/get-testnet-tokens/). The private key of this account will be used in the commands below (substitute the `DEPLOYER_PRIVATE_KEY` variable).
+Create a new Ethereum account using e.g. MetaMask, and [bridge some Sepolia ETH to BOB Sepolia](https://puff-bob-jznbxtoq7h.testnets.rollbridge.app/) - after funding your account using a [Sepolia faucet](https://sepolia-faucet.pk910.de/), if necessary. The private key of this account will be used in the commands below (substitute the `DEPLOYER_PRIVATE_KEY` variable).
 
 #### 2. Deploy the Contracts
 
@@ -112,7 +112,7 @@ Now finally, initiate the proving of an address:
 cargo run --bin taproot-prover -- --address 0000000000000000000000000000000000000001 --taproot-address $TAPROOT_ADDRESS_FROM_PREVIOUS_STEP --bonsai-api-key=$API_KEY
 ```
 
-The command above, if it runs successfully, will initiate the generation of a zk-proof on the Bonsai server, and after completion (which can take a couple of minutes), it will submit it to BOB Sepolia (Testnet) for verification. After waiting a couple of minutes, you will be able to see the result in the explorer. Go to [the explorer](https://sepolia.etherscan.io/) and search for the previously logged `$TAPROOT_REGISTER` address. Go to the "Internal Transactions", click the latest transaction, and click "Logs". You should see an `OwnershipProven` event, showing your Ethereum and taproot address.
+The command above, if it runs successfully, will initiate the generation of a zk-proof on the Bonsai server, and after completion (which can take a couple of minutes), it will submit it to BOB Sepolia (Testnet) for verification. After waiting a couple of minutes, you will be able to see the result in the explorer. Go to [the explorer](https://bob-sepolia.explorer.gobob.xyz) and search for the previously logged `$TAPROOT_REGISTER` address. Go to the "Internal Transactions", click the latest transaction, and click "Logs". You should see an `OwnershipProven` event, showing your Ethereum and taproot address.
 
 ## Diving into the Code
 

--- a/docs/docs/learn/reference/tools/rust-zkvm.md
+++ b/docs/docs/learn/reference/tools/rust-zkvm.md
@@ -50,7 +50,7 @@ To execute the demo, perform the following steps:
 
 #### 1. Account Creation and Funding
 
-Create a new Ethereum account using e.g. MetaMask, and fund the account using the l2 faucet on [this page](https://app.conduit.xyz/published/view/fluffy-bob-7mjgi9pmtg). The private key of this account will be used in the commands below (substitute the `DEPLOYER_PRIVATE_KEY` variable).
+Create a new Ethereum account using e.g. MetaMask, and fund the account using the l2 faucet on [this page](https://docs.metamask.io/services/how-to/get-testnet-tokens/). The private key of this account will be used in the commands below (substitute the `DEPLOYER_PRIVATE_KEY` variable).
 
 #### 2. Deploy the Contracts
 

--- a/docs/docs/learn/reference/tools/rust-zkvm.md
+++ b/docs/docs/learn/reference/tools/rust-zkvm.md
@@ -112,7 +112,7 @@ Now finally, initiate the proving of an address:
 cargo run --bin taproot-prover -- --address 0000000000000000000000000000000000000001 --taproot-address $TAPROOT_ADDRESS_FROM_PREVIOUS_STEP --bonsai-api-key=$API_KEY
 ```
 
-The command above, if it runs successfully, will initiate the generation of a zk-proof on the Bonsai server, and after completion (which can take a couple of minutes), it will submit it to BOB Sepolia (Testnet) for verification. After waiting a couple of minutes, you will be able to see the result in the explorer. Go to [the explorer](https://explorerl2-fluffy-bob-7mjgi9pmtg.t.conduit.xyz/) and search for the previously logged `$TAPROOT_REGISTER` address. Go to the "Internal Transactions", click the latest transaction, and click "Logs". You should see an `OwnershipProven` event, showing your Ethereum and taproot address.
+The command above, if it runs successfully, will initiate the generation of a zk-proof on the Bonsai server, and after completion (which can take a couple of minutes), it will submit it to BOB Sepolia (Testnet) for verification. After waiting a couple of minutes, you will be able to see the result in the explorer. Go to [the explorer](https://sepolia.etherscan.io/) and search for the previously logged `$TAPROOT_REGISTER` address. Go to the "Internal Transactions", click the latest transaction, and click "Logs". You should see an `OwnershipProven` event, showing your Ethereum and taproot address.
 
 ## Diving into the Code
 


### PR DESCRIPTION
In Issue #423 there's reference to 4 broken links in the documentation which needed fixing. In summary this is how I've fixed them 

1.  The first link was in reference to `first party oracles` and referred to the Airnode API docs. I found the new section in airnode's API docs which discuss and give context for first party oracles.
2. The second broken link was in reference to `OEV Recapture` and was also a link to Airnode's API docs. I found a new section in their docs which discusses and gives context for this topic under a more generalized heading.
3. This hyperlink was to direct users on how to fund their metamask wallet on a testnet. I've replaced it with a link to the page from Metamask's own documentation on how to fund a Metamask wallet on a testnet.
4. This link was previously to a sepolia testnet block explorer, I replaced it with a  link to etherscan's sepolia testnet block explorer.

Feedback is welcomed, please let me know if you'd like anything changed.