### PR TITLE
chore: fix broken external link

### DIFF
--- a/docs/docs/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/index.md
+++ b/docs/docs/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/index.md
@@ -57,7 +57,7 @@ There are interesting use cases that account abstraction enables being pushed by
 
 - [Privy](https://docs.privy.io/): Privy allows users to choose from traditional crypto wallets and social logins to create accounts.
 - [Safe](https://docs.safe.global/getting-started/readme): Safe allows complex multi-sig setups, simple authentication, and onramping.
-- [Pimlico](https://pimlico.notion.site/Product-Directory-5d92fe60243b4c5aac6650de390e7cb3): Pimlico tracks several products around account abstraction and it is worthwhile checking out the rapid and new developments in this space.
+- [Pimlico](https://docs.pimlico.io/): Pimlico tracks several products around account abstraction and it is worthwhile checking out the rapid and new developments in this space.
 
 ## Local development
 


### PR DESCRIPTION
The previous link to Pimlico's site was a Notion page they have since deprecated. Now it points to their main docs site, https://docs.pimlico.io/