### PR TITLE
docs: rework AA page without live demo

### DIFF
--- a/docs/docs/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/index.md
+++ b/docs/docs/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/index.md
@@ -10,7 +10,7 @@ Check out the code of the demo in [this repository](https://github.com/bob-colle
 
 ## Smart Contract wallets
 
-This demo showcases wBTC transfer from the smart contract wallet. Smart contract wallets utilize smart contracts rather than single private keys found in Externally Owned Address (EOA) wallets. The programmable nature of smart contract wallets allows for diverse use cases. Unlike EOAs, smart contract wallets can contain logic but rely on EOAs to sign the user operations. Therefore, integration of the smart contract wallet into UI adds an additional complexity - users need to distinguish between the signer (EAO) and the account that holds assets (smart contract wallet).
+This demo showcases wBTC transfer from the smart contract wallet. Smart contract wallets utilize smart contracts rather than single private keys found in Externally Owned Address (EOA) wallets. The programmable nature of smart contract wallets allows for diverse use cases. Unlike EOAs, smart contract wallets can contain logic but rely on EOAs to sign the user operations. Therefore, integration of the smart contract wallet into UI adds an additional complexity - users need to distinguish between the signer (EOA) and the account that holds assets (smart contract wallet).
 
 ![preview](preview.png)
 

--- a/docs/docs/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/index.md
+++ b/docs/docs/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/index.md
@@ -2,12 +2,6 @@
 
 In this example, we will show how wBTC can be used for gas fee payment using the [ERC-4337 account abstraction standard](https://eips.ethereum.org/EIPS/eip-4337) on BOB Sepolia (Testnet). This enables users to use smart contract wallets and transact without the need to own ETH.
 
-:::tip Live Demo
-
-Check out the live demo at [demo-account-abstraction.gobob.xyz](https://demo-account-abstraction.gobob.xyz/).
-
-:::
-
 :::info Example Code
 
 Check out the code of the demo in [this repository](https://github.com/bob-collective/demo-account-abstraction-transfer/).

--- a/docs/docs/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/index.md
+++ b/docs/docs/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/index.md
@@ -28,17 +28,17 @@ Before the first user operation can be made, the paymaster smart contract has to
 
 #### Connecting MetaMask and funding your account
 
-1. Go to [demo-acccount-abstraction.gobob.xyz](https://demo-account-abstraction.gobob.xyz/)
-2. Fund your account with Sepolia ETH from the [Sepolia testnet faucet](https://faucetlink.to/sepolia).
-3. Transfer Sepolia ETH to BOB Sepolia (Testnet) using [our Bridge](https://app.gobob.xyz/).
-4. Connect with your MetaMask account and get wBTC by clicking on the 'Get Tokens' button in the application header. (You will receive 30,000 wBTC that you can spend.)
-5. Add wBTC to your MetaMask, wBTC address is `0x2868d708e442A6a940670d26100036d426F1e16b`
-6. Transfer wBTC to the smart contract account via MetaMask (displayed above the amount field in the form).
+1. Clone [the repo](https://github.com/bob-collective/demo-account-abstraction-transfer/) and [start the front-end locally](#local-development).
+1. Fund your account with Sepolia ETH from the [Sepolia testnet faucet](https://faucetlink.to/sepolia).
+1. Transfer Sepolia ETH to BOB Testnet using [Superbridge](https://puff-bob-jznbxtoq7h.testnets.rollbridge.app/).
+1. Connect with your MetaMask account and get wBTC by clicking on the `Get Tokens` button in the application header. (You will receive 30,000 wBTC that you can spend.)
+1. Add wBTC to your MetaMask, wBTC address is `0x2868d708e442A6a940670d26100036d426F1e16b`.
+1. Transfer wBTC to the smart contract account via MetaMask (displayed above the amount field in the form).
 
 #### Making a transfer
 
-1. Input the amount you wish to send and the recipient's address into the form fields.
-2. Click on 'Transfer'. This will require three interactions with MetaMask: first one will deposit small amount of ETH to the entry point contract so that you can sign the user operation that allows the paymaster contract to spend your wBTC. Then you will sign the approval user operation. Finally, you will sign the transfer user operation.
+1. Input the amount you wish to send and the recipient`s address into the form fields.
+2. Click on `Transfer`. This will require three interactions with MetaMask: first one will deposit small amount of ETH to the entry point contract so that you can sign the user operation that allows the paymaster contract to spend your wBTC. Then you will sign the approval user operation. Finally, you will sign the transfer user operation.
 3. Wait for the transfer user operation to be executed.
 
 ## Limitations


### PR DESCRIPTION
This PR updates the [ERC-4337 demo page](https://docs.gobob.xyz/learn/builder-guides/bridged-btc-gas-fee/account-abstraction/) in light of our deprecation of the corresponding live demo ([GH repo](https://github.com/bob-collective/demo-account-abstraction-transfer/)).

The most important diff is under `Connecting MetaMask and funding your account`, where I updated the steps to assume the user is running the FE locally. Our bridge app has long since switched to mainnet (woohoo), so I point to the Superbridge specific to _old_ testnet for the "bridging sepETH" step.