### PR TITLE
feat: add algolia search to docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -183,11 +183,11 @@ const config = {
           ],
         },
         gtag: {
-          trackingID: 'G-VX9XQWCCC5',
-          anonymizeIP: true
+          trackingID: "G-VX9XQWCCC5",
+          anonymizeIP: true,
         },
         googleTagManager: {
-          containerId: 'GTM-NSJLJ9D5',
+          containerId: "GTM-NSJLJ9D5",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -307,6 +307,35 @@ const config = {
         disableSwitch: true,
         respectPrefersColorScheme: false,
       },
+      // Docusaurus x Algolia documentation: https://docusaurus.io/docs/search#connecting-algolia
+      algolia: {
+        appId: "AO8XE1SP27",
+
+        // Public API key (safe to commit)
+        apiKey: "c9e55704810dd96a5013d44fb439186b",
+
+        indexName: "BOB Docs",
+        contextualSearch: true,
+
+        // Optional: Replace parts of the item URLs from Algolia.
+        // Useful when using the same search index for multiple deployments using a different baseUrl.
+        // You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
+        replaceSearchResultPathname: {
+          from: "localhost:3000",
+          to: "docs.gobob.xyz",
+        },
+
+        // Optional: path for dedicated search page (`false` to disable it)
+        searchPagePath: "search",
+
+        // Collect data on user events, such as search queries
+        insights: true,
+
+        // Other parameters: https://www.algolia.com/doc/api-reference/search-api-parameters/
+        searchParameters: {},
+
+        // Other options: https://docsearch.algolia.com/docs/api/
+      },
       // announcementBar: {
       //   id: "sign_up",
       //   content:
@@ -320,21 +349,7 @@ const config = {
   markdown: {
     mermaid: true,
   },
-  themes: [
-    "@docusaurus/theme-mermaid",
-    [
-      "@easyops-cn/docusaurus-search-local",
-      {
-        indexBlog: false,
-        indexDocs: true,
-        indexPages: false,
-        hashed: true,
-        highlightSearchTermsOnTargetPage: true,
-        language: ["en"],
-      },
-    ],
-    "docusaurus-theme-github-codeblock",
-  ],
+  themes: ["@docusaurus/theme-mermaid", "docusaurus-theme-github-codeblock"],
   scripts: [
     {
       src: "https://cdn.usefathom.com/script.js",

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow:
+# Algolia-Crawler-Verif: 6861211C3ECA4619


### PR DESCRIPTION
Improve the search experience on our docs pages by switching from native Docusaurus search to Algolia.

[Docusaurus has first-class support for Algolia](https://docusaurus.io/docs/search#using-algolia-docsearch), so this implementation relies on the default config. 
- The notable option is `insights: true`, which helps us see common searches and results. For example, this can help us discover if users are searching for a page that does not exist yet.

We can view this data and manage our Algolia account from [their dashboard](https://dashboard.algolia.com/apps/AO8XE1SP27/dashboard). Login details to follow privately.

Example of search UI:
<img width="1204" alt="Screenshot 2025-01-03 at 10 39 24 AM" src="https://github.com/user-attachments/assets/c3bb3eee-ab8d-4710-beba-2b9f2a79a803" />

Example of `docs.gobob.xyz/search` page:
<img width="1201" alt="Screenshot 2025-01-03 at 10 39 39 AM" src="https://github.com/user-attachments/assets/9b8ab9e3-f953-45ec-9209-29ed6cf9aef2" />

Also including a small commit for formatting lines 186-190, just to get it out of the way.