### PR TITLE
docs: add Status Page link to header

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,6 +8,7 @@ const darkCodeTheme = themes.dracula;
 const GITHUB_LINK = "https://github.com/bob-collective/bob";
 const LANDING_PAGE = "https://gobob.xyz";
 const DOCS_PAGE = "https://docs.gobob.xyz";
+const STATUS_PAGE = "https://conduit-bob.checkly-dashboards.com/";
 const DISCORD = "https://discord.gg/gobob";
 const TWITTER = "https://x.com/build_on_bob";
 const TELEGRAM = "https://t.me/+CyIcLW2nfaFlNDc1";
@@ -236,6 +237,11 @@ const config = {
           {
             href: GITHUB_LINK,
             label: "GitHub",
+            position: "right",
+          },
+          {
+            href: STATUS_PAGE,
+            label: "Status",
             position: "right",
           },
         ],


### PR DESCRIPTION
Adds an external link in the docs header to a [Status Page](https://conduit-bob.checkly-dashboards.com/) for BOB Mainnet and Sepolia.

Docs Header Bar
<img width="1031" alt="Screenshot 2025-01-06 at 3 46 28 PM" src="https://github.com/user-attachments/assets/669796f6-7a56-4acb-9bf2-9caa3a57a648" />

Status Page
<img width="1023" alt="Screenshot 2025-01-06 at 3 47 05 PM" src="https://github.com/user-attachments/assets/99509253-8ddc-4281-b6a6-a18bc2aabc11" />


I've asked Conduit whether it's possible to query the underlying API (Checkly) so we can provide a status preview icon next to the word `Status`. Example:
<img width="90" alt="Screenshot 2025-01-06 at 3 49 45 PM" src="https://github.com/user-attachments/assets/f8646a06-0495-4dd6-854c-30d16abacf47" />
