### PR TITLE
docs: add OP's faucet for BOB Sepolia to Network page

### DIFF
--- a/docs/docs/learn/user-guides/networks.md
+++ b/docs/docs/learn/user-guides/networks.md
@@ -42,6 +42,7 @@ If you are having issues with your RPC connection, try [BlastAPI's public endpoi
 - WS URL: [wss://bob-sepolia.rpc.gobob.xyz](wss://bob-sepolia.rpc.gobob.xyz)
 - Explorer: https://bob-sepolia.explorer.gobob.xyz/
 - Bridge: https://bob-sepolia.gobob.xyz/
+- Faucet: https://console.optimism.io/faucet
 
 ### Ethereum Sepolia (Testnet)
 


### PR DESCRIPTION
OP recently added a BOB Sepolia faucet to their docs. This adds an external link to that faucet within our Network page.

<img width="1042" alt="Screenshot 2025-02-06 at 10 11 45 AM" src="https://github.com/user-attachments/assets/defd60ce-9e67-4c7f-9814-8ea018532213" />

I have not been able to get [the faucet](https://console.optimism.io/faucet) to work; please try it yourself before merging.