### PR TITLE
Chore/gcd limit

### DIFF
--- a/contracts/script/init-bridge.sh
+++ b/contracts/script/init-bridge.sh
@@ -17,7 +17,7 @@ echo "swapped_endianness_blockhash = $swapped_endianness_blockhash"
 header=$(curl -s $ESPLORA/block/$block_hash/header)
 echo "header = $header"
 
-forge create ../src/relay/FullRelayWithVerify.sol:FullRelayWithVerify \
+forge create src/relay/FullRelayWithVerify.sol:FullRelayWithVerify \
     --rpc-url $BOB_RPC \
     --private-key $DEPLOYER_PRIVATE_KEY \
     --priority-gas-price 1 \

--- a/contracts/src/relay/FullRelayWithVerify.sol
+++ b/contracts/src/relay/FullRelayWithVerify.sol
@@ -41,7 +41,7 @@ contract FullRelayWithVerify is FullRelay {
         bytes32 _headerHash = _header.hash256();
         bytes32 _GCD = getLastReorgCommonAncestor();
 
-        require(_isAncestor(_headerHash, _GCD, 240), "GCD does not confirm header");
+        require(_isAncestor(_headerHash, _GCD, 2048), "GCD does not confirm header");
         require(_getConfs(_headerHash) >= _numConfs, "Insufficient confirmations");
     }
 


### PR DESCRIPTION
The relay checked that the last reorg is on the same chain as the provided header, up to a distance of 240 blocks. This pr increases that to 2048 so that we have slightly over 2 weeks to confirm blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the deployment configuration to ensure the system correctly locates necessary contract components.
  
- **Refactor**
  - Adjusted the confirmation process by broadening the validation range, enhancing the reliability of approval checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->