### PR TITLE
fix: add FAQ url redirect

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -55,6 +55,10 @@ const config = {
             to: "/learn/user-guides/faq",
           },
           {
+            from: "/learn/introduction/faq",
+            to: "/learn/user-guides/faq",
+          },
+          {
             from: "/docs/learn/bob-stack/merged-mining",
             to: "/learn/introduction/roadmap",
           },


### PR DESCRIPTION
Fixes a broken FAQ link that appears on the gobob.xyz landing page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved FAQ navigation: Requests from the introductory FAQ page now redirect to a unified FAQ section under user guides, ensuring easier and more consistent access to information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->