### PR TITLE
fix: relayer fork handling

### DIFF
--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -18,3 +18,4 @@ bitcoincore-rpc.workspace = true
 
 # Ethereum
 alloy = { workspace = true, features = ["full", "providers", "node-bindings"] }
+serde_json = "1.0.140"

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -37,6 +37,8 @@ async fn main() -> Result<()> {
     // env_logger::init();
     let app = App::parse();
 
+    println!("Starting relayer...");
+
     let privk = app.private_key.trim().strip_prefix("0x").expect("Requires private key");
     let signer: PrivateKeySigner = privk.parse().expect("should parse private key");
     let wallet = EthereumWallet::from(signer);


### PR DESCRIPTION
Added fork handling.

If the latest relayed block is no longer on the main bitcoin chain, there was a problem with relaying new blocks, as fetching the block from esplora would fail. Unfortunately, we need to supply the whole block header (not just the hash) when changing the tip, so I had to fetch the block header from elsewhere. The easiest would be to just store the latest blockheader in the contract, but that would require redeployment which I didn't really want to do because of Fiamma. Plus, it would increase gas cost, although that's maybe not _that_ big of deal

So I ended up starting a goldsky pipeline and get the blockheader from the calldata of the tx that submitted. Which works quite well but it does feel a bit over engineered