### PR TITLE
feat(sdk): add tvl to tokens via new getEnrichedTokens function

### DIFF
--- a/docs/docs/learn/builder-guides/create-strategy.md
+++ b/docs/docs/learn/builder-guides/create-strategy.md
@@ -75,7 +75,7 @@ At the moment, there is only one relayer for BOB Gateway. In addition to its oth
 
 In addition to the strategy contract described above, you also need to create an end-to-end integration test using Foundry’s ability to simulate the transactions on a live fork of BOB mainnet. That’s why the e2e test files follow a `[ProtocolName]StrategyForked.sol` naming convention, such as [SolvStrategyForked.sol](https://github.com/bob-collective/bob/blob/master/contracts/test/gateway/e2e-strategy-tests/SolvStrategyForked.sol#L40).
 
-Returning to the [xSolvBTC staking strategy](#one-intent-example-staking-wbtc-into-solvbtcbbn) from the beginning:
+Returning to the [xSolvBTC staking strategy](#one-intent-example-staking-wbtc-into-xsolvbtc) from the beginning:
 
 ```solidity title="SolvStrategyForked.sol"
 function testSolvLSTStrategy() public {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/bob-sdk",
-  "version": "3.1.7",
+  "version": "3.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -9,8 +9,8 @@
     "update-relay": "ts-node src/scripts/relay-retarget.ts",
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
-    "format": "prettier --write {examples,src,test}",
-    "format:check": "prettier --check {examples,src,test}"
+    "format": "prettier --write examples src test",
+    "format:check": "prettier --check examples src test"
   },
   "files": [
     "dist/**/*",

--- a/sdk/src/gateway/abi.ts
+++ b/sdk/src/gateway/abi.ts
@@ -1,3 +1,5 @@
+import { parseAbi } from 'viem';
+
 export const strategyCaller = [
     {
         type: 'function',
@@ -83,3 +85,10 @@ export const offRampCaller = [
         stateMutability: 'nonpayable',
     },
 ] as const;
+
+export const compoundV2CTokenAbi = parseAbi([
+    'function exchangeRateCurrent() external returns (uint256)',
+    'function underlying() external view returns (address)',
+]);
+
+export const aaveV2AtokenAbi = parseAbi(['function UNDERLYING_ASSET_ADDRESS() external view returns (address)']);

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -20,6 +20,7 @@ import {
     OffRampRequestPayload,
     OffRampGatewayCreateQuoteResponse,
     GatewayOffRampOrder,
+    EnrichedToken,
 } from './types';
 import { SYMBOL_LOOKUP, ADDRESS_LOOKUP } from './tokens';
 import { createBitcoinPsbt } from '../wallet';
@@ -28,6 +29,9 @@ import { EsploraClient } from '../esplora';
 import { offRampCaller, strategyCaller } from './abi';
 import { isAddress, Address, isAddressEqual } from 'viem';
 import * as bitcoin from 'bitcoinjs-lib';
+import { bob, bobSepolia } from 'viem/chains';
+import StrategyClient from './strategy';
+import { bigIntToFloatingNumber } from '../utils';
 
 type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>;
 
@@ -48,31 +52,36 @@ export const TESTNET_GATEWAY_BASE_URL = 'https://gateway-api-testnet.gobob.xyz';
  * @default "https://gateway-api-testnet.gobob.xyz"
  */
 export const SIGNET_GATEWAY_BASE_URL = 'https://gateway-api-signet.gobob.xyz';
+
 /**
  * Gateway REST HTTP API client
  */
 export class GatewayApiClient {
     private chain: Chain.BOB | Chain.BOB_SEPOLIA;
     private baseUrl: string;
+    private strategy: StrategyClient;
 
     /**
      * @constructor
      * @param chainName The chain name.
      */
-    constructor(chainName: string) {
+    constructor(chainName: string, options?: { rpcUrl?: string }) {
         switch (chainName) {
             case 'mainnet':
             case Chain.BOB:
                 this.chain = Chain.BOB;
                 this.baseUrl = MAINNET_GATEWAY_BASE_URL;
+                this.strategy = new StrategyClient(bob, options?.rpcUrl);
                 break;
             case 'testnet':
                 this.chain = Chain.BOB_SEPOLIA;
                 this.baseUrl = TESTNET_GATEWAY_BASE_URL;
+                this.strategy = new StrategyClient(bobSepolia, options?.rpcUrl);
                 break;
             case 'signet':
                 this.chain = Chain.BOB_SEPOLIA; // Same chain as testnet
                 this.baseUrl = SIGNET_GATEWAY_BASE_URL;
+                this.strategy = new StrategyClient(bobSepolia, options?.rpcUrl);
                 break;
             default:
                 throw new Error('Invalid chain');
@@ -555,6 +564,62 @@ export class GatewayApiClient {
         // https://github.com/ethereum-optimism/ecosystem/blob/c6faa01455f9e846f31c0343a0be4c03cbeb2a6d/packages/op-app/src/hooks/useOPTokens.ts#L10
         const tokens = await this.getTokenAddresses(includeStrategies);
         return tokens.map((token) => ADDRESS_LOOKUP[this.chainId][token]).filter((token) => token !== undefined);
+    }
+
+    // TODO: should get price from the gateway API
+    private async getPrices(): Promise<Map<string, number>> {
+        const response = await this.fetchGet('https://fusion-api.gobob.xyz/pricefeed');
+
+        if (!response.ok) {
+            console.error('Failed to fetch prices from Fusion API');
+            return new Map();
+        }
+
+        const list = await response.json();
+
+        return new Map(list.map((x) => [x.token_address.toLowerCase(), Number(x.price)]));
+    }
+
+    /**
+     * Same as {@link getTokens} but with additional info, like tvl.
+     *
+     * @param includeStrategies Also include output tokens via strategies (e.g. staking or lending).
+     * @returns {Promise<EnrichedToken[]>} The array of tokens.
+     */
+    async getEnrichedTokens(includeStrategies: boolean = true): Promise<EnrichedToken[]> {
+        const [tokens, prices] = await Promise.all([this.getTokenAddresses(includeStrategies), this.getPrices()]);
+
+        return Promise.all(
+            tokens.map(async (address) => {
+                const token = ADDRESS_LOOKUP[this.chainId][address];
+
+                const { address: underlyingAddress, totalUnderlying } =
+                    await this.strategy.getStrategyAssetState(token);
+
+                if (underlyingAddress === 'usd') {
+                    return {
+                        ...token,
+                        tvl: Number(totalUnderlying),
+                    };
+                }
+
+                const underlyingToken = ADDRESS_LOOKUP[this.chainId][underlyingAddress.toLowerCase()];
+
+                if (!underlyingToken) {
+                    return {
+                        ...token,
+                        tvl: 0,
+                    };
+                }
+
+                return {
+                    ...token,
+                    tvl:
+                        bigIntToFloatingNumber(totalUnderlying, underlyingToken.decimals) *
+                        (prices.get(underlyingAddress.toLowerCase()) ?? 0),
+                };
+            })
+        );
     }
 
     /**

--- a/sdk/src/gateway/strategy.ts
+++ b/sdk/src/gateway/strategy.ts
@@ -1,0 +1,165 @@
+import { createPublicClient, http, type PublicClient, type Chain, erc20Abi, Address } from 'viem';
+import { tokenToStrategyTypeMap } from './tokens';
+import type { StrategyAssetState, Token } from './types';
+import { aaveV2AtokenAbi, compoundV2CTokenAbi } from './abi';
+
+export default class StrategyClient {
+    private viemClient: PublicClient;
+
+    constructor(chain: Chain, rpcUrl?: string) {
+        // @ts-expect-error: prevent TS2589
+        this.viemClient = createPublicClient({
+            transport: http(),
+            chain: {
+                ...chain,
+                rpcUrls: {
+                    default: {
+                        http: [rpcUrl || chain.rpcUrls.default.http[0]],
+                    },
+                },
+            },
+        }) as PublicClient;
+    }
+
+    async getStrategyAssetState(token: Token): Promise<StrategyAssetState> {
+        const strategyType = tokenToStrategyTypeMap.get(token.address.toLowerCase()) ?? 'none';
+
+        switch (strategyType) {
+            case 'none': {
+                return this.getTokenAssetState(token);
+            }
+
+            case 'segment': {
+                return this.getCompoundV2StrategyAssetState(token);
+            }
+
+            case 'ionic': {
+                return this.getCompoundV2StrategyAssetState(token);
+            }
+
+            case 'veda': {
+                return this.getVedaStrategyAssetState(token);
+            }
+
+            case 'avalon': {
+                return this.getAAVEV2StrategyAssetState(token);
+            }
+
+            default: {
+                return {
+                    address: 'usd',
+                    totalUnderlying: 0n,
+                };
+            }
+        }
+    }
+
+    private async getTokenAssetState(token: Token): Promise<StrategyAssetState> {
+        const outputTokenAddress = token.address as Address;
+
+        const [{ result: totalSupply }] = await this.viemClient.multicall({
+            contracts: [
+                {
+                    address: outputTokenAddress,
+                    abi: erc20Abi,
+                    functionName: 'totalSupply',
+                    args: [],
+                },
+            ],
+        });
+
+        return {
+            address: outputTokenAddress,
+            totalUnderlying: totalSupply,
+        };
+    }
+
+    private async getCompoundV2StrategyAssetState(token: Token): Promise<StrategyAssetState> {
+        const outputTokenAddress = token.address as Address;
+
+        const [{ result: totalSupply }, { result: exchangeRate }, { result: underlyingAddress }] =
+            await this.viemClient.multicall({
+                contracts: [
+                    {
+                        address: outputTokenAddress,
+                        abi: erc20Abi,
+                        functionName: 'totalSupply',
+                        args: [],
+                    },
+                    {
+                        address: outputTokenAddress,
+                        abi: compoundV2CTokenAbi,
+                        functionName: 'exchangeRateCurrent',
+                        args: [],
+                    },
+                    {
+                        address: outputTokenAddress,
+                        abi: compoundV2CTokenAbi,
+                        functionName: 'underlying',
+                        args: [],
+                    },
+                ],
+            });
+
+        return {
+            address: underlyingAddress,
+            totalUnderlying: (exchangeRate * totalSupply) / 10n ** 18n,
+        };
+    }
+
+    private async getAAVEV2StrategyAssetState(token: Token): Promise<StrategyAssetState> {
+        const outputTokenAddress = token.address as Address;
+
+        const [{ result: totalSupply }, { result: underlyingAddress }] = await this.viemClient.multicall({
+            contracts: [
+                {
+                    address: outputTokenAddress,
+                    abi: erc20Abi,
+                    functionName: 'totalSupply',
+                    args: [],
+                },
+                {
+                    address: outputTokenAddress,
+                    abi: aaveV2AtokenAbi,
+                    functionName: 'UNDERLYING_ASSET_ADDRESS',
+                    args: [],
+                },
+            ],
+        });
+
+        return {
+            address: underlyingAddress,
+            totalUnderlying: totalSupply,
+        };
+    }
+
+    private async getVedaStrategyAssetState(token: Token): Promise<StrategyAssetState> {
+        // NOTE: remove 1 week so we are sure to pick up at least one historical data point
+        const timestamp = Math.floor(Date.now() / 1000) - 7 * 24 * 3600;
+
+        const res = await fetch(`https://api.sevenseas.capital/hourlyData/bob/${token.address}/${timestamp}/latest`);
+
+        if (!res.ok) {
+            return {
+                address: 'usd',
+                totalUnderlying: 0n,
+            };
+        }
+
+        const body = await res.json();
+
+        if (!body.Response?.[0]) {
+            return {
+                address: 'usd',
+                totalUnderlying: 0n,
+            };
+        }
+
+        const { tvl } = body.Response[0];
+
+        return {
+            address: 'usd',
+            totalUnderlying: BigInt(Math.floor(tvl)),
+        };
+    }
+}

--- a/sdk/src/gateway/tokens.ts
+++ b/sdk/src/gateway/tokens.ts
@@ -14,17 +14,6 @@ const bobTokens = [
         logoURI: 'https://ethereum-optimism.github.io/data/tBTC/logo.svg',
     },
     {
-        name: 'Hybrid Bitcoin',
-        symbol: 'HybridBTC.pendle',
-        decimals: 8,
-        tokens: {
-            bob: {
-                address: '0x9998e05030Aee3Af9AD3df35A34F5C51e1628779',
-            },
-        },
-        logoURI: 'https://raw.githubusercontent.com/bob-collective/bob/master/assets/hybridBTC-pendle.svg',
-    },
-    {
         name: 'Wrapped BTC',
         symbol: 'WBTC',
         decimals: 8,
@@ -252,6 +241,20 @@ const ionicTokens = [
     },
 ];
 
+const vedaTokens = [
+    {
+        name: 'Hybrid Bitcoin',
+        symbol: 'HybridBTC.pendle',
+        decimals: 8,
+        tokens: {
+            bob: {
+                address: '0x9998e05030Aee3Af9AD3df35A34F5C51e1628779',
+            },
+        },
+        logoURI: 'https://raw.githubusercontent.com/bob-collective/bob/master/assets/hybridBTC-pendle.svg',
+    },
+];
+
 const TOKENS: Array<{
     name: string;
     symbol: string;
@@ -266,7 +269,15 @@ const TOKENS: Array<{
         };
     };
     logoURI: string;
-}> = [...bobTokens, ...bobSepoliaTokens, ...shoebillTokens, ...segmentTokens, ...avalonTokens, ...ionicTokens];
+}> = [
+    ...bobTokens,
+    ...bobSepoliaTokens,
+    ...shoebillTokens,
+    ...segmentTokens,
+    ...avalonTokens,
+    ...ionicTokens,
+    ...vedaTokens,
+];
 
 /** @description Tokens supported on BOB and BOB Sepolia */
 export const SYMBOL_LOOKUP: { [key in number]: { [key in string]: Token } } = {};
@@ -302,3 +313,12 @@ for (const token of TOKENS) {
         addToken(token.tokens['bob-sepolia'].address, token, ChainId.BOB_SEPOLIA);
     }
 }
+
+export const tokenToStrategyTypeMap = new Map([
+    ...bobTokens.map((token) => [token.tokens['bob'].address.toLowerCase(), 'none'] as const),
+    ...bobSepoliaTokens.map((token) => [token.tokens['bob-sepolia'].address.toLowerCase(), 'none'] as const),
+    ...segmentTokens.map((token) => [token.tokens['bob'].address.toLowerCase(), 'segment'] as const),
+    ...ionicTokens.map((token) => [token.tokens['bob'].address.toLowerCase(), 'ionic'] as const),
+    ...vedaTokens.map((token) => [token.tokens['bob'].address.toLowerCase(), 'veda'] as const),
+    ...avalonTokens.map((token) => [token.tokens['bob'].address.toLowerCase(), 'avalon'] as const),
+]);

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -70,6 +70,10 @@ export interface Token {
     logoURI: string;
 }
 
+export interface EnrichedToken extends Token {
+    tvl: number;
+}
+
 /**
  * Designed to be compatible with the Swing SDK.
  * https://developers.swing.xyz/reference/sdk/get-a-quote
@@ -387,4 +391,11 @@ export interface GatewayStrategy {
     projectLogo?: string;
     inputTokenAddress: string;
     outputTokenAddress?: string;
+}
+
+/** @dev Internal */
+
+export interface StrategyAssetState {
+    address: Address | 'usd';
+    totalUnderlying: bigint;
 }

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -182,3 +182,12 @@ export function getMerkleProof(block: Block, txHash: string, forWitness?: boolea
         root: merkleAndRoot.root.toString('hex'),
     };
 }
+
+export function bigIntToFloatingNumber(value: bigint, decimals: number): number {
+    const valueStr = value.toString();
+
+    const integerPart = valueStr.slice(0, -decimals) || '0';
+    const decimalPart = valueStr.slice(-decimals).padStart(decimals, '0');
+
+    return Number(integerPart + '.' + decimalPart);
+}

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from 'vitest';
+import { afterEach, assert, describe, expect, it } from 'vitest';
 import { GatewaySDK } from '../src/gateway';
 import { MAINNET_GATEWAY_BASE_URL, SIGNET_GATEWAY_BASE_URL, toHexScriptPubKey } from '../src/gateway/client';
 import { SYMBOL_LOOKUP } from '../src/gateway/tokens';
@@ -21,6 +21,10 @@ const TBTC = SYMBOL_LOOKUP[ChainId.BOB]['tbtc'];
 const TBTC_ADDRESS = TBTC.address;
 const SOLVBTC = SYMBOL_LOOKUP[ChainId.BOB]['solvbtc'];
 const SOLVBTC_ADDRESS = SOLVBTC.address;
+
+afterEach(() => {
+    nock.cleanAll();
+});
 
 describe('Gateway Tests', () => {
     it('should get chains', async () => {
@@ -241,6 +245,24 @@ describe('Gateway Tests', () => {
 
         const gatewaySDK = new GatewaySDK('bob');
         assert.deepEqual(await gatewaySDK.getTokenAddresses(false), [ZeroAddress]);
+    });
+
+    it.skip('should get enriched tokens', async () => {
+        const gatewaySDK = new GatewaySDK('bob');
+
+        const tokens = await gatewaySDK.getTokens(true);
+        const enrichedTokens = await gatewaySDK.getEnrichedTokens(true);
+
+        assert.lengthOf(enrichedTokens, tokens.length);
+
+        enrichedTokens.forEach((enrichedToken, i) => {
+            assert.strictEqual(tokens[i].address, enrichedToken.address);
+            assert.strictEqual(tokens[i].name, enrichedToken.name);
+            assert.strictEqual(tokens[i].symbol, enrichedToken.symbol);
+            assert.strictEqual(tokens[i].decimals, enrichedToken.decimals);
+            assert.isDefined(enrichedToken.tvl);
+            assert.notEqual(enrichedToken.tvl, 0);
+        });
     });
 
     it('should get orders', async () => {


### PR DESCRIPTION
## Description

- add new function `getEnrichedTokens`:
  - returns the same as `getTokens` (didn't want to break that function as it follows the token standard)
  - return tvl for tokens and startegies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Now delivers enriched token information by incorporating real-time pricing and total value locked (TVL) insights for a more comprehensive asset overview.
  - Expanded token offerings with the addition of a new token group, introducing an extra asset option.
  - Improved token data processing by integrating multiple token strategy approaches for enhanced asset state evaluation.

- **Bug Fixes**
  - Ensured proper cleanup of mocks in the test suite to prevent interference between tests.

- **Tests**
  - Added automated tests to ensure the consistency and reliability of the enriched token data.

- **Chores**
  - Simplified formatting commands in the package configuration for improved readability.

- **Style**
  - Enhanced code structure and clarity through the addition of new constants and interfaces.

- **Documentation**
  - Corrected hyperlink reference in documentation for accurate navigation regarding the xSolvBTC staking strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->