### PR TITLE
Fix: add missing methods used in gateway + update constants

### DIFF
--- a/crates/utils/src/bitcoin_core.rs
+++ b/crates/utils/src/bitcoin_core.rs
@@ -64,6 +64,12 @@ impl BitcoinCoreInstance {
         client.generate_to_address(101, &address)?;
         Ok(())
     }
+
+    pub fn fund_to_specific_address(&self, address: &bitcoin::Address) -> Result<()> {
+        let client = self.client(None)?;
+        client.generate_to_address(101, address)?;
+        Ok(())
+    }
 }
 
 impl Drop for BitcoinCoreInstance {

--- a/crates/utils/src/esplora_client.rs
+++ b/crates/utils/src/esplora_client.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 use std::str::FromStr;
 use tracing::*;
 
-const ESPLORA_MAINNET_URL: &str = "https://blockstream.info/api/";
-const ESPLORA_TESTNET_URL: &str = "https://blockstream.info/testnet/api/";
+const ESPLORA_TESTNET_URL: &str = "https://btc-testnet.interlay.io";
+const ESPLORA_MAINNET_URL: &str = "https://btc-mainnet.interlay.io";
 const ESPLORA_LOCALHOST_URL: &str = "http://localhost:3002";
 const ESPLORA_SIGNET_URL: &str = "https://btc-signet.gobob.xyz";
 

--- a/crates/utils/src/esplora_client.rs
+++ b/crates/utils/src/esplora_client.rs
@@ -2,7 +2,7 @@ use bitcoin::{
     block::Header, consensus, hashes::hex::FromHex, BlockHash, CompactTarget, MerkleBlock, Network,
     Transaction, TxMerkleNode, Txid,
 };
-use eyre::Result;
+use eyre::{Error, Result};
 use reqwest::{Client, Url};
 use serde::Deserialize;
 use std::str::FromStr;
@@ -11,6 +11,7 @@ use tracing::*;
 const ESPLORA_MAINNET_URL: &str = "https://blockstream.info/api/";
 const ESPLORA_TESTNET_URL: &str = "https://blockstream.info/testnet/api/";
 const ESPLORA_LOCALHOST_URL: &str = "http://localhost:3002";
+const ESPLORA_SIGNET_URL: &str = "https://btc-signet.gobob.xyz";
 
 // https://github.com/Blockstream/electrs/blob/adedee15f1fe460398a7045b292604df2161adc0/src/util/transaction.rs#L17-L26
 #[derive(Debug, Deserialize)]
@@ -76,6 +77,7 @@ impl EsploraClient {
                     match network {
                         Network::Bitcoin => ESPLORA_MAINNET_URL,
                         Network::Testnet => ESPLORA_TESTNET_URL,
+                        Network::Signet => ESPLORA_SIGNET_URL,
                         _ => ESPLORA_LOCALHOST_URL,
                     }
                     .to_owned()
@@ -178,6 +180,18 @@ impl EsploraClient {
                 info!("Sending transaction");
                 self.send_transaction(tx).await
             }
+        }
+    }
+
+    pub async fn get_bitcoin_network(&self) -> Result<Network> {
+        let url_str = self.url.as_str();
+
+        match url_str {
+            _ if url_str.contains(ESPLORA_MAINNET_URL) => Ok(Network::Bitcoin),
+            _ if url_str.contains(ESPLORA_TESTNET_URL) => Ok(Network::Testnet),
+            _ if url_str.contains(ESPLORA_LOCALHOST_URL) => Ok(Network::Regtest),
+            _ if url_str.contains(ESPLORA_SIGNET_URL) => Ok(Network::Signet),
+            _ => Err(Error::msg("Unknown network for URL: {url_str}")),
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to fund a specific Bitcoin address directly.
  - Introduced support for the Signet Bitcoin network in the Esplora client.
  - Added a method to detect and return the current Bitcoin network based on the Esplora client URL.

- **Chores**
  - Updated default Esplora client endpoints to use new Interlay-hosted URLs for mainnet and testnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->