### PR TITLE
chore: downgrade typescript to 5.7.3

### DIFF
--- a/docs/docs/learn/builder-guides/gateway.md
+++ b/docs/docs/learn/builder-guides/gateway.md
@@ -38,9 +38,9 @@ npm install @gobob/bob-sdk
 Import the `GatewaySDK` class from `@gobob/bob-sdk` and create an instance of it.
 
 ```ts title="/src/utils/gateway.ts"
-import { GatewayQuoteParams, GatewaySDK } from "@gobob/bob-sdk";
+import { GatewayQuoteParams, GatewaySDK } from '@gobob/bob-sdk';
 
-const gatewaySDK = new GatewaySDK("bob"); // or "bob-sepolia"
+const gatewaySDK = new GatewaySDK('bob'); // or "testnet"
 ```
 
 ### Get Available Tokens
@@ -61,12 +61,12 @@ We recommend rendering `quote.fee` and [its other fields](https://github.com/bob
 
 ```ts
 const quoteParams: GatewayQuoteParams = {
-  fromToken: "BTC",
-  fromChain: "Bitcoin",
-  fromUserAddress: "bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d",
-  toChain: "BOB",
-  toUserAddress: "0x2D2E86236a5bC1c8a5e5499C517E17Fb88Dbc18c",
-  toToken: "tBTC", // or e.g. "SolvBTC"
+  fromToken: 'BTC',
+  fromChain: 'Bitcoin',
+  fromUserAddress: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
+  toChain: 'BOB',
+  toUserAddress: '0x2D2E86236a5bC1c8a5e5499C517E17Fb88Dbc18c',
+  toToken: 'tBTC', // or e.g. "SolvBTC"
   amount: 10000000, // 0.1 BTC
   gasRefill: 10000, // 0.0001 BTC. The amount of BTC to swap for ETH for tx fees.
 };
@@ -81,7 +81,7 @@ The SDK will handle automatically when the `toToken` has a fungible ERC20 token,
 ```ts
 const strategies = await gatewaySDK.getStrategies();
 const strategy = strategies.find(
-  (contract) => contract.integration.name === "pell-wbtc"
+  (contract) => contract.integration.name === 'pell-wbtc',
 )!;
 const quoteParamsStaking: GatewayQuoteParams = {
   ...quoteParams,

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -33,7 +33,7 @@
                 "prettier": "^3.5.3",
                 "tiny-secp256k1": "^2.2.3",
                 "ts-node": "^10.0.0",
-                "typescript": "^5.8.3",
+                "typescript": "^5.7.3",
                 "vitest": "^3.1.2",
                 "yargs": "^17.5.1"
             }
@@ -4829,9 +4829,9 @@
             "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
         },
         "node_modules/typescript": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
             "devOptional": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -34,7 +34,7 @@
         "prettier": "^3.5.3",
         "tiny-secp256k1": "^2.2.3",
         "ts-node": "^10.0.0",
-        "typescript": "^5.8.3",
+        "typescript": "^5.7.3",
         "vitest": "^3.1.2",
         "yargs": "^17.5.1"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the TypeScript development dependency version.
  - Switched network environment identifiers from "bob" to standard "mainnet" and "testnet" across documentation, examples, and tests for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->