### PR TITLE
feat: add esplora builder

### DIFF
--- a/crates/utils/src/esplora.rs
+++ b/crates/utils/src/esplora.rs
@@ -1,11 +1,9 @@
-use crate::{unused_port, BitcoinCoreInstance};
-use crate::{BITCOIN_RPC_PASSWORD, BITCOIN_RPC_USER};
-use std::io::BufRead;
-use std::io::BufReader;
-use std::time::{Duration, Instant};
+use crate::{unused_port, BitcoinCoreInstance, BITCOIN_RPC_PASSWORD, BITCOIN_RPC_USER};
 use std::{
+    io::{BufRead, BufReader},
     path::PathBuf,
     process::{Child, Command},
+    time::{Duration, Instant},
 };
 use tempfile::TempDir;
 

--- a/crates/utils/src/esplora.rs
+++ b/crates/utils/src/esplora.rs
@@ -1,0 +1,134 @@
+use crate::{unused_port, BitcoinCoreInstance};
+use crate::{BITCOIN_RPC_PASSWORD, BITCOIN_RPC_USER};
+use std::io::BufRead;
+use std::io::BufReader;
+use std::time::{Duration, Instant};
+use std::{
+    path::PathBuf,
+    process::{Child, Command},
+};
+use tempfile::TempDir;
+
+const ESPLORA_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
+
+pub struct EsploraInstance {
+    pid: Child,
+    _db_dir: TempDir,
+    port: u16,
+}
+
+impl Drop for EsploraInstance {
+    fn drop(&mut self) {
+        self.pid.kill().expect("could not kill esplora");
+    }
+}
+
+impl EsploraInstance {
+    pub fn endpoint(&self) -> String {
+        format!("http://localhost:{}", self.port)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EsploraBuilder {
+    program: Option<PathBuf>,
+    port: Option<u16>,
+    timeout: Option<u64>,
+}
+
+impl EsploraBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn at(path: impl Into<PathBuf>) -> Self {
+        Self::new().path(path)
+    }
+
+    pub fn path<T: Into<PathBuf>>(mut self, path: T) -> Self {
+        self.program = Some(path.into());
+        self
+    }
+
+    pub fn port<T: Into<u16>>(mut self, port: T) -> Self {
+        self.port = Some(port.into());
+        self
+    }
+
+    pub fn timeout<T: Into<u64>>(mut self, timeout: T) -> Self {
+        self.timeout = Some(timeout.into());
+        self
+    }
+
+    pub fn spawn(self, bitcoin: &BitcoinCoreInstance) -> EsploraInstance {
+        self.spawn_with_port(bitcoin.rpcport())
+    }
+
+    pub fn spawn_with_port(self, bitcoin_port: u16) -> EsploraInstance {
+        let mut cmd = self.program.as_ref().map_or_else(|| Command::new("electrs"), Command::new);
+        cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::piped());
+
+        let http_port = self.port.unwrap_or_else(|| unused_port());
+        let db_dir = TempDir::new().expect("Couldn't create temp directory");
+
+        cmd.arg("-vvvv");
+        cmd.arg("--network");
+        cmd.arg("regtest");
+        cmd.arg("--jsonrpc-import");
+        cmd.arg("--cors");
+        cmd.arg("*");
+        cmd.arg("--cookie");
+        cmd.arg(format!("{BITCOIN_RPC_USER}:{BITCOIN_RPC_PASSWORD}"));
+        cmd.arg("--daemon-rpc-addr");
+        cmd.arg(format!("127.0.0.1:{bitcoin_port}"));
+        cmd.arg("--http-addr");
+        cmd.arg(format!("[::0]:{}", http_port));
+        cmd.arg("--index-unspendables");
+        cmd.arg(format!("--db-dir={}", db_dir.path().to_str().unwrap()));
+
+        let mut child = cmd.spawn().expect("Couldn't start esplora");
+
+        let stdout = child.stderr.take().expect("Unable to get stdout for esplora child process");
+
+        let start = Instant::now();
+        let mut reader = BufReader::new(stdout);
+
+        loop {
+            if start + Duration::from_millis(self.timeout.unwrap_or(ESPLORA_STARTUP_TIMEOUT_MILLIS))
+                <= Instant::now()
+            {
+                panic!("Timed out waiting for esplora to start. Is electrs installed?")
+            }
+
+            let mut line = String::new();
+            // TODO: this will block if no stdout (electrs uses stderr)
+            reader.read_line(&mut line).expect("Failed to read line from esplora process");
+            if line.contains("RPC server running") {
+                break;
+            }
+        }
+
+        EsploraInstance { pid: child, _db_dir: db_dir, port: http_port }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BitcoinCore, EsploraClient};
+    use eyre::Result;
+
+    #[tokio::test]
+    async fn can_launch_esplora() -> Result<()> {
+        let bitcoin = BitcoinCore::new().spawn();
+        bitcoin.fund_wallet("Alice").expect("Should fund Alice");
+
+        let esplora = EsploraBuilder::new().spawn(&bitcoin);
+
+        let esplora_client = EsploraClient::new_with_url(esplora.endpoint())?;
+
+        let height = esplora_client.get_chain_height().await?;
+        assert_eq!(101, height);
+        Ok(())
+    }
+}

--- a/crates/utils/src/esplora_client.rs
+++ b/crates/utils/src/esplora_client.rs
@@ -70,21 +70,20 @@ pub struct EsploraClient {
 }
 
 impl EsploraClient {
-    pub fn new(esplora_url: Option<String>, network: Network) -> Result<Self> {
-        Ok(Self {
-            url: esplora_url
-                .unwrap_or_else(|| {
-                    match network {
-                        Network::Bitcoin => ESPLORA_MAINNET_URL,
-                        Network::Testnet => ESPLORA_TESTNET_URL,
-                        Network::Signet => ESPLORA_SIGNET_URL,
-                        _ => ESPLORA_LOCALHOST_URL,
-                    }
-                    .to_owned()
-                })
-                .parse()?,
-            cli: Client::new(),
-        })
+    pub fn new(network: Network) -> Result<Self> {
+        Self::new_with_url(
+            match network {
+                Network::Bitcoin => ESPLORA_MAINNET_URL,
+                Network::Testnet => ESPLORA_TESTNET_URL,
+                Network::Signet => ESPLORA_SIGNET_URL,
+                _ => ESPLORA_LOCALHOST_URL,
+            }
+            .to_owned(),
+        )
+    }
+
+    pub fn new_with_url(esplora_url: String) -> Result<Self> {
+        Ok(Self { url: esplora_url.parse()?, cli: Client::new() })
     }
 
     async fn get(&self, path: &str) -> Result<String> {
@@ -214,7 +213,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_esplora() -> Result<()> {
-        let esplora_client = EsploraClient::new(None, Network::Bitcoin)?;
+        let esplora_client = EsploraClient::new(Network::Bitcoin)?;
         let txid =
             Txid::from_str("aaddbc39689a3d63b3bcaafc6d1440ef911ac30bc0fe4679b891bf3e389fb053")?;
         let left = esplora_client.get_merkleblock_proof(&txid).await?;
@@ -241,7 +240,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_esplora_get_block_value() -> Result<()> {
-        let esplora_client = EsploraClient::new(None, Network::Bitcoin)?;
+        let esplora_client = EsploraClient::new(Network::Bitcoin)?;
 
         let block_hash = BlockHash::from_str(
             "00000000000000000000e4726002778d999b973fe138208ed5f6c23df0af7898",

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,12 +1,23 @@
 mod bitcoin_client;
 mod bitcoin_core;
+mod esplora;
 mod esplora_client;
 mod mempool_client;
 
 pub use bitcoin_client::*;
 pub use bitcoin_core::*;
+pub use esplora::*;
 pub use esplora_client::*;
 pub use mempool_client::*;
+
+pub(crate) fn unused_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("Failed to create TCP listener to find unused port");
+
+    let local_addr =
+        listener.local_addr().expect("Failed to read TCP listener local_addr to find unused port");
+    local_addr.port()
+}
 
 #[cfg(test)]
 mod tests {

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -42,7 +42,10 @@ async fn main() -> Result<()> {
     let wallet = EthereumWallet::from(signer);
     let rpc_url: Url = app.eth_rpc_url.parse()?;
     let provider = ProviderBuilder::new().wallet(wallet).on_http(rpc_url);
-    let esplora_client = EsploraClient::new(app.esplora_url, bitcoin::Network::Bitcoin)?;
+    let esplora_client = app
+        .esplora_url
+        .map(EsploraClient::new_with_url)
+        .unwrap_or(EsploraClient::new(bitcoin::Network::Bitcoin))?;
 
     let relayer = Relayer::new(BitcoinRelay::new(app.relay_address, provider), esplora_client);
     relayer.run().await?;
@@ -71,7 +74,7 @@ mod tests {
 
         let provider = ProviderBuilder::new().wallet(wallet).on_http(rpc_url);
 
-        let esplora_client = EsploraClient::new(None, bitcoin::Network::Bitcoin)?;
+        let esplora_client = EsploraClient::new(bitcoin::Network::Bitcoin)?;
 
         let period_start_height = 201600;
         // change this to test different headers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for managing and launching Esplora blockchain explorer instances, including configuration options and automatic process cleanup.
  - Introduced new builder methods for improved argument handling when launching Bitcoin Core instances.
  - Added a utility to obtain an unused network port automatically.

- **Improvements**
  - Simplified and clarified the way Esplora clients are created, making it easier to specify custom endpoints or use network defaults.
  - Exposed Bitcoin Core RPC user and password constants for broader use within the application.

- **Bug Fixes**
  - Enhanced argument handling for Bitcoin Core processes to better support OS-native string types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->