### PR TITLE
feat: `fetchOfframpLiquidity` method and add `orderOwner` argument in  ABI

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "3.4.0",
+    "version": "3.3.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/abi.ts
+++ b/sdk/src/gateway/abi.ts
@@ -73,6 +73,11 @@ export const offrampCreateOrderCaller = [
                         type: 'address',
                         internalType: 'address',
                     },
+                    {
+                        name: 'orderOwner',
+                        type: 'address',
+                        internalType: 'address',
+                    },
                 ],
             },
         ],

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -354,6 +354,7 @@ export class GatewayApiClient {
                     orderCreationDeadline: offrampQuote.deadline,
                     outputScript: receiverAddress,
                     token: offrampQuote.token,
+                    orderOwner: params.fromUserAddress as Address,
                 },
             ],
         };

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -211,7 +211,7 @@ export class GatewayApiClient {
         let outputTokenAddress = '';
         const toToken = token.toLowerCase();
 
-        if (toToken.startsWith('0x')) {
+        if (isAddress(toToken)) {
             outputTokenAddress = toToken;
         } else if (SYMBOL_LOOKUP[this.chainId][toToken]) {
             outputTokenAddress = SYMBOL_LOOKUP[this.chainId][toToken].address;

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -373,6 +373,16 @@ export interface OfframpQuote {
     token: Address;
 }
 
+/** @dev Offramp Available Liquidity */
+export interface OfframpLiquidity {
+    /** @dev Token address used for payment */
+    token: Address;
+    /** @dev Max token amount a *single* order can be served with (in token decimals) */
+    maxOrderAmount: bigint;
+    /** @dev Total liquidity across all solver addresses (in token decimals) */
+    totalOfframpLiquidity: bigint;
+}
+
 /** @dev Params used for createOrder call on the off-ramp contract */
 export type OfframpCreateOrderParams = {
     quote: OfframpQuote;

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -400,6 +400,8 @@ export type OfframpCreateOrderParams = {
             outputScript: string;
             /** @dev Token to use for payment */
             token: Address;
+            /** @dev EVM address of the user who can unlock the order or bump its fee */
+            orderOwner: Address;
         },
     ];
 };

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -565,6 +565,7 @@ describe('Gateway Tests', () => {
             orderCreationDeadline: result.offrampArgs[0].orderCreationDeadline,
             outputScript: '0x1600149d5e60f3b5cc2d246f990692ee4b267d1cd58477',
             token: '0xda472456b1a6a2fc9ae7edb0e007064224d4284c',
+            orderOwner: '0xFAEe001465dE6D7E8414aCDD9eF4aC5A35B2B808',
         });
     });
 

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -676,4 +676,30 @@ describe('Gateway Tests', () => {
         // Assert the result is true (claim delay has passed)
         expect(result).toBe(true);
     });
+
+    it('fetches the correct offramp liquidity', async () => {
+        const gatewaySDK = new GatewaySDK('signet');
+        const tokenAddress = '0x4496ebE7C8666a8103713EE6e0c08cA0cD25b888'.toLowerCase();
+        nock(SIGNET_GATEWAY_BASE_URL).persist().get(`/offramp-liquidity/${tokenAddress}`).reply(200, {
+            tokenAddress,
+            maxOrderAmount: '861588',
+            totalOfframpLiquidity: '861588',
+        });
+
+        const offrampLiquidityTokenAddressAsParam = await gatewaySDK.fetchOfframpLiquidity(tokenAddress);
+
+        expect(offrampLiquidityTokenAddressAsParam).toEqual({
+            token: tokenAddress,
+            maxOrderAmount: BigInt('861588'),
+            totalOfframpLiquidity: BigInt('861588'),
+        });
+
+        const offrampLiquidityTokenSymbolAsParam = await gatewaySDK.fetchOfframpLiquidity('bobBTC');
+
+        expect(offrampLiquidityTokenSymbolAsParam).toEqual({
+            token: tokenAddress,
+            maxOrderAmount: BigInt('861588'),
+            totalOfframpLiquidity: BigInt('861588'),
+        });
+    });
 });


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to fetch offramp liquidity details for supported tokens.
  - Introduced support for specifying an order owner when creating offramp orders.

- **Tests**
  - Added tests to verify fetching offramp liquidity and updated tests to include the order owner field in offramp order creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->