### PR TITLE
fix: refactor offrampArgs to tuple for compatibility with `walletClient.writeContract`

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -366,7 +366,7 @@ export class GatewayApiClient {
      * @param orderId The ID of the existing order.
      * @returns Parameters for onchain `bumpFeeOfExistingOrder` call.
      */
-    async bumpFeeForOfframpOrder(orderId: bigint): Promise<OfframpBumpFeeParams[]> {
+    async bumpFeeForOfframpOrder(orderId: bigint): Promise<OfframpBumpFeeParams> {
         // check order status via viem should be Active/Accepted
         const orderDetails: OnchainOfframpOrderDetails = await this.fetchOfframpOrder(orderId);
 
@@ -390,18 +390,14 @@ export class GatewayApiClient {
             );
         }
 
-        return [
-            {
-                offrampABI: offrampBumpFeeCaller,
-                offrampFunctionName: 'bumpFeeOfExistingOrder',
-                offrampArgs: [
-                    {
-                        orderId: orderId,
-                        newFeeSat: newFeeSat,
-                    },
-                ],
-            },
-        ];
+        const offrampRegistryAddress: Address = await this.fetchOfframpRegistryAddress();
+
+        return {
+            offrampABI: offrampBumpFeeCaller,
+            offrampRegistryAddress: offrampRegistryAddress,
+            offrampFunctionName: 'bumpFeeOfExistingOrder' as const,
+            offrampArgs: [orderId, newFeeSat],
+        };
     }
 
     /**
@@ -411,7 +407,7 @@ export class GatewayApiClient {
      * @param receiver The address to receive the funds.
      * @returns Parameters for onchain `unlockFunds` call.
      */
-    async unlockOfframpOrder(orderId: bigint, receiver: Address): Promise<OfframpUnlockFundsParams[]> {
+    async unlockOfframpOrder(orderId: bigint, receiver: Address): Promise<OfframpUnlockFundsParams> {
         // check order status via viem should be Active/Accepted
         const orderDetails: OnchainOfframpOrderDetails = await this.fetchOfframpOrder(orderId);
 
@@ -429,18 +425,12 @@ export class GatewayApiClient {
             throw new Error(`Offramp order is still within the 7-day claim delay and cannot be unlocked yet.`);
         }
 
-        return [
-            {
-                offrampABI: offrampUnlockFundsCaller,
-                offrampFunctionName: 'unlockFunds',
-                offrampArgs: [
-                    {
-                        orderId: orderId,
-                        receiver: receiver,
-                    },
-                ],
-            },
-        ];
+        return {
+            offrampABI: offrampUnlockFundsCaller,
+            offrampRegistryAddress: offrampRegistryAddress,
+            offrampFunctionName: 'unlockFunds',
+            offrampArgs: [orderId, receiver],
+        };
     }
 
     /**

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -409,29 +409,25 @@ export type OfframpCreateOrderParams = {
 /** @dev Params used to bump fee for an existing order */
 export type OfframpBumpFeeParams = {
     offrampABI: typeof offrampBumpFeeCaller;
+    offrampRegistryAddress: Address;
     offrampFunctionName: 'bumpFeeOfExistingOrder';
-    offrampArgs: [
-        {
-            /** @dev The order ID to bump fee for */
-            orderId: bigint;
-            /** @dev The new fee amount in satoshis */
-            newFeeSat: bigint;
-        },
-    ];
+    /**
+     * @param orderId The order ID to bump fee for
+     * @param newFeeSat The new fee amount in satoshis
+     */
+    offrampArgs: [orderId: bigint, newFeeSat: bigint];
 };
 
 /** @dev Params used to unlock funds after order completion or refund */
 export type OfframpUnlockFundsParams = {
     offrampABI: typeof offrampUnlockFundsCaller;
+    offrampRegistryAddress: Address;
     offrampFunctionName: 'unlockFunds';
-    offrampArgs: [
-        {
-            /** @dev The order ID to unlock funds for */
-            orderId: bigint;
-            /** @dev Receiver address to send unlocked funds to */
-            receiver: Address;
-        },
-    ];
+    /**
+     * @param orderId The order ID to bump fee for
+     * @param receiver address to send unlocked funds to
+     */
+    offrampArgs: [orderId: bigint, receiver: Address];
 };
 
 /** @dev Final state of an offramp order used in UI/backend */


### PR DESCRIPTION
### PR Summary:
- **Refactor** return type to an object for `bumpFeeForOfframpOrder` and `unlockOfframpOrder` methods.
- **Update** `offrampArgs` to use a tuple, enabling direct use with `walletClient.writeContract` without the need for additional conversion.

Example:
```ts
// Send the transaction using the received quote
const txHash = await walletClient.writeContract({
    address: unlockOfframpOrder.offrampRegistryAddress as `0x${string}`, 
    abi: unlockOfframpOrder.offrampABI,
    functionName: unlockOfframpOrder.offrampFunctionName,
    args: unlockOfframpOrder.offrampArgs,
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new field to bump fee and unlock order parameters, providing additional address information.

- **Improvements**
  - Simplified the structure and format of parameters returned by bump fee and unlock order actions for easier integration.

- **Chores**
  - Updated SDK version to 3.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->