### PR TITLE
docs (index.mdx): update 404-error link 

### DIFF
--- a/docs/docs/learn/builder-guides/hello-bitcoin/index.mdx
+++ b/docs/docs/learn/builder-guides/hello-bitcoin/index.mdx
@@ -32,7 +32,7 @@ Solidity and a toolchain are sufficient to get you started deploying contracts o
 ### Overview of the contract
 
 - The contract allows swapping between BTC->USDT and Ordinal->USDT using the BTC relay on testnet without requiring the BTC or ordinals to be bridged to BOB.
-- The contract integrates the [BTC relay](https://github.com/bob-collective/bob/blob/master/src/relay/LightRelay.sol) to enable trustless communication between the Bitcoin blockchain and BOB Sepolia (Testnet).
+- The contract integrates the [BTC relay](https://github.com/bob-collective/bob/blob/master/contracts/src/relay/LightRelay.sol) to enable trustless communication between the Bitcoin blockchain and BOB Sepolia (Testnet).
 
 ### Objectives
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the URL path for the BTC relay contract import link to reflect its accurate location in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->