### PR TITLE
fix: use unique ports for esplora electrum and monitoring

### DIFF
--- a/crates/utils/src/esplora.rs
+++ b/crates/utils/src/esplora.rs
@@ -83,6 +83,8 @@ impl EsploraBuilder {
         cmd.arg(format!("[::0]:{}", http_port));
         cmd.arg("--index-unspendables");
         cmd.arg(format!("--db-dir={}", db_dir.path().to_str().unwrap()));
+        cmd.arg("--electrum-rpc-addr=127.0.0.1:0");
+        cmd.arg("--monitoring-addr=127.0.0.1:0");
 
         let mut child = cmd.spawn().expect("Couldn't start esplora");
 


### PR DESCRIPTION
Without this change, multiple concurrent instances would try to listen to the same ports, which made all but one of them fail to start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying Electrum RPC and monitoring server addresses when starting the service, now binding both to localhost on dynamic ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->