### PR TITLE
chore: stricter types for esplora

### DIFF
--- a/sdk/src/esplora.ts
+++ b/sdk/src/esplora.ts
@@ -158,7 +158,7 @@ export class EsploraClient {
      * Create an instance of the `EsploraClient` with the specified network or URL.
      * If the `networkOrUrl` parameter is omitted, it defaults to "mainnet."
      *
-     * @param networkOrUrl The Bitcoin network (e.g., "mainnet," "testnet," "regtest")
+     * @param chainName The Bitcoin network (e.g., "mainnet," "testnet," "regtest")
      *
      * @returns An instance of the `EsploraClient` configured for the specified network or URL.
      *
@@ -170,8 +170,8 @@ export class EsploraClient {
      * // Create a client for the mainnet using the default URL.
      * const esploraClientMainnet = new EsploraClient();
      */
-    constructor(networkOrUrl: string = 'mainnet') {
-        switch (networkOrUrl) {
+    constructor(chainName: 'mainnet' | 'signet' | 'testnet' | 'regtest' = 'mainnet') {
+        switch (chainName) {
             case 'mainnet':
                 this.basePath = MAINNET_ESPLORA_BASE_PATH;
                 break;
@@ -185,7 +185,7 @@ export class EsploraClient {
                 this.basePath = REGTEST_ESPLORA_BASE_PATH;
                 break;
             default:
-                this.basePath = networkOrUrl;
+                throw new Error('Invalid chain');
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated network selection to only allow standard Bitcoin chains (mainnet, signet, testnet, regtest) when initializing the client.
  - Improved error handling for invalid chain selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->