### PR TITLE
Fix broken link to BOB Gateway documentation

### DIFF
--- a/docs/docs/learn/builder-guides/gateway.md
+++ b/docs/docs/learn/builder-guides/gateway.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Integrate BOB Gateway in Your App
 
-[BOB Gateway](https://docs.gobob.xyz/learn/guides/bitcoin-bridge/) is a Bitcoin intent bridge that unlocks Bitcoin liquidity by reducing the number of steps to onboard users to your app, saving time and money. For example, users can go from **BTC** on Bitcoin to **staked BTC LSTs** with a single Bitcoin transaction.
+[BOB Gateway](https://docs.gobob.xyz/learn/introduction/gateway/) is a Bitcoin intent bridge that unlocks Bitcoin liquidity by reducing the number of steps to onboard users to your app, saving time and money. For example, users can go from **BTC** on Bitcoin to **staked BTC LSTs** with a single Bitcoin transaction.
 
 Our SDK makes it possible for you to bring this UX directly into your app.
 


### PR DESCRIPTION
Replaced the outdated link to the BOB Gateway Bitcoin bridge documentation (https://docs.gobob.xyz/learn/guides/bitcoin-bridge/) with the current and correct URL (https://docs.gobob.xyz/learn/introduction/gateway/) in the builder guide. This ensures users are directed to the up-to-date BOB Gateway introduction page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the hyperlink for "BOB Gateway" in the introductory paragraph to direct to the correct page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->