### PR TITLE
fix: remove `satsToConvertToEth` from v4 `startOnrampOrder` method

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -541,7 +541,6 @@ export class GatewayApiClient {
         const request: GatewayCreateOrderRequestPayload = {
             gatewayAddress: gatewayQuote.gatewayAddress,
             strategyAddress: gatewayQuote.strategyAddress,
-            satsToConvertToEth: params.gasRefill || 0,
             userAddress: params.toUserAddress,
             gatewayExtraData: undefined,
             strategyExtraData: params.message,

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -84,7 +84,7 @@ export interface GatewayQuoteParams {
     feeRate?: number;
 
     // NOTE: the following are new fields added by us
-    /** @description Amount of satoshis to swap for ETH */
+    /** @description Amount of ETH to get to pay for fees */
     gasRefill?: number;
     /** @description Wallet public key on source chain */
     fromUserPublicKey?: string;
@@ -264,7 +264,6 @@ export type GatewayCreateOrderRequest = {
 export type GatewayCreateOrderRequestPayload = {
     gatewayAddress: Address;
     strategyAddress?: Address;
-    satsToConvertToEth: number;
     userAddress: Address;
     gatewayExtraData?: Hex;
     strategyExtraData?: Hex;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of documentation for fee-related fields.
  * Removed an unused field from the order creation process to streamline onramp orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->