### PR TITLE
docs: broken link in what-is-bob.md

### DIFF
--- a/docs/docs/docs/quick-start/what-is-bob.md
+++ b/docs/docs/docs/quick-start/what-is-bob.md
@@ -50,7 +50,7 @@ BOB is an optimistic rollup with ZK proofs on Ethereum secured by billions of do
 
 ### Ecosystem (Home of BTC DeFi)
 
-- Best-in-class EVM and DeFi infrastructure based on the [OP stack](https://www.optimism.io/developers/op-stack)
+- Best-in-class EVM and DeFi infrastructure based on the [OP stack](https://docs.optimism.io/stack/getting-started)
 - [Tier 1 DeFi choosing BOB](https://app.gobob.xyz/en/apps): Uniswap, Euler, Aave, LiFi, Lombard, Chainlink, Babylon, Solv
 - Institutions choosing BOB: Fireblocks, Cobo, ForDeFi and more to be announced
 - Strong/fast stablecoin infrastructure with USDC, USDT, Chainlink CCIP, LayerZero


### PR DESCRIPTION
trying to fix a broken link but dunno which link will be suitable, thought maybe you could help me

there alternatives to what I implemented already:

1) https://docs.optimism.io/app-developers/tutorials

2) another link you think will be better than my proposals

3) we can simply delete this line that mentions link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OP stack documentation link in the "Ecosystem (Home of BTC DeFi)" section to a new URL for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->