### PR TITLE
feat(gateway): list orders's output tokens

### DIFF
--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -838,6 +838,13 @@ export class GatewayApiClient {
                     }
                     return getFinal(amount, order.outputTokenAmount);
                 },
+                getOutputs() {
+                    return order.outputTokenAddresses?.map((address, i) => {
+                        const token = ADDRESS_LOOKUP[this.chainId][address];
+                        const amount = order.outputTokenAmounts?.[i];
+                        return [token, amount];
+                    });
+                },
                 getConfirmations,
                 async getStatus(esploraClient: EsploraClient, latestHeight?: number): Promise<OrderStatus> {
                     const confirmations = await getConfirmations(esploraClient, latestHeight);

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -310,6 +310,10 @@ export interface OnrampOrderResponse {
     /** @description The output amount (from strategies) */
     outputTokenAmount?: string;
     /** @description The tx hash on the EVM chain */
+    outputTokenAddresses?: EvmAddress[];
+    /** @description The output amount (from strategies) */
+    outputTokenAmounts?: string[];
+    /** @description The tx hash on the EVM chain */
     txHash?: string;
     /** @description V4 order details */
     orderDetails?: OrderDetails;
@@ -348,11 +352,16 @@ export type OnrampOrder = Omit<
     'satsToConvertToEth'
 > & {
     /** @description Get the actual token address received */
+    /** @deprecated use getOutputTokenAmounts instead */
     getTokenAddress(): string | undefined;
     /** @description Get the actual token received */
+    /** @deprecated use getOutputTokenAmounts instead */
     getToken(): Token | undefined;
     /** @description Get the actual amount received of the token */
+    /** @deprecated use getOutputTokenAmounts instead */
     getTokenAmount(): string | number | undefined;
+    /** @description get all received tokens and the amounts */
+    getOutputs(): [Token, string][];
     /** @description Get the number of confirmations */
     getConfirmations(esploraClient: EsploraClient, latestHeight?: number): Promise<number>;
     /** @description Get the actual order status */


### PR DESCRIPTION
## Description

We want to be able to list multiple output tokens from an order instead of just one. The existing functions will continue to work but if there are multiple output tokens on an order, it will only return one token. Hence, it's recommended to use the new `getOutputs` method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Onramp orders now support multiple output tokens and amounts.
  - Added a unified way to retrieve all received tokens with their corresponding amounts.

- Documentation
  - Updated guides to cover multi-output retrieval.
  - Marked legacy single-output accessors as deprecated and provided migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->