### PR TITLE
fix: rename `maxSatsToSwapToEth` to `satsToSwapToEth`

### DIFF
--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -212,7 +212,7 @@ export type OrderDetailsRaw = {
     version: string;
     data: {
         ethAmountToReceive: string;
-        maxSatsToSwapToEth: number;
+        satsToSwapToEth: number;
         ethTransferGasLimit: string;
         strategyGasLimit: string;
         totalUserGasLimit: string;
@@ -229,8 +229,8 @@ export type OrderDetails = {
     data: {
         /** @description The amount of ETH (in wei) that the user will receive */
         ethAmountToReceive: bigint;
-        /** @description Maximum amount of satoshis allowed to be swapped to ETH */
-        maxSatsToSwapToEth: number;
+        /** @description Amount of satoshis to be swapped to ETH */
+        satsToSwapToEth: number;
         /** @description Estimated gas limit for the ETH transfer step */
         ethTransferGasLimit: bigint;
         /** @description Estimated gas limit for executing the strategy logic */

--- a/sdk/src/gateway/utils.ts
+++ b/sdk/src/gateway/utils.ts
@@ -72,7 +72,7 @@ export function convertOrderDetailsRawToOrderDetails(order: OrderDetailsRaw): Or
         version: order.version,
         data: {
             ethAmountToReceive: parseU256(order.data.ethAmountToReceive),
-            maxSatsToSwapToEth: order.data.maxSatsToSwapToEth,
+            satsToSwapToEth: order.data.satsToSwapToEth,
             ethTransferGasLimit: parseU256(order.data.ethTransferGasLimit),
             strategyGasLimit: parseU256(order.data.strategyGasLimit),
             totalUserGasLimit: parseU256(order.data.totalUserGasLimit),
@@ -88,7 +88,7 @@ export function convertOrderDetailsToRaw(order: OrderDetails): OrderDetailsRaw {
         version: order.version,
         data: {
             ethAmountToReceive: order.data.ethAmountToReceive.toString(), // bigint to string
-            maxSatsToSwapToEth: order.data.maxSatsToSwapToEth,
+            satsToSwapToEth: order.data.satsToSwapToEth,
             ethTransferGasLimit: order.data.ethTransferGasLimit.toString(),
             strategyGasLimit: order.data.strategyGasLimit.toString(),
             totalUserGasLimit: order.data.totalUserGasLimit.toString(),

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -25,7 +25,7 @@ const MOCK_ORDER_DETAILS_RAW: OrderDetailsRaw = {
     version: 'v4',
     data: {
         ethAmountToReceive: '0x0',
-        maxSatsToSwapToEth: 0,
+        satsToSwapToEth: 0,
         ethTransferGasLimit: '0x8fc',
         strategyGasLimit: '0x0',
         totalUserGasLimit: '0x30d40',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the API field maxSatsToSwapToEth to satsToSwapToEth across order details types and related conversion logic. This is a breaking change; update integrations accordingly.
* **Documentation**
  * Updated the field description to “Amount of satoshis to be swapped to ETH.”
* **Tests**
  * Updated test mocks to use satsToSwapToEth instead of maxSatsToSwapToEth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->