### PR TITLE
feat: layerzero

### DIFF
--- a/sdk/src/gateway/layerzero.ts
+++ b/sdk/src/gateway/layerzero.ts
@@ -1,0 +1,42 @@
+export class LayerZeroClient {
+    private basePath: string;
+
+    constructor() {
+        this.basePath = 'https://metadata.layerzero-api.com/v1/metadata';
+    }
+
+    async getSupportedChains(): Promise<Array<string>> {
+        const params = new URLSearchParams({
+            symbols: 'WBTC',
+        });
+
+        const data = await this.getJson<{
+            WBTC: [{ deployments: { [chainKey: string]: { address: string } } }];
+        }>(`${this.basePath}/experiment/ofts/list?${params.toString()}`);
+
+        return Object.keys(data.WBTC[0].deployments);
+    }
+
+    async getEidForChain(chainKey: string) {
+        const data = await this.getJson<{
+            [chainKey: string]: {
+                deployments: [
+                    {
+                        version: number;
+                        eid: string;
+                    },
+                ];
+            };
+        }>(`${this.basePath}`);
+
+        return data[chainKey]?.deployments.find((item) => item.version === 2)?.eid || null;
+    }
+
+    private async getJson<T>(url: string): Promise<T> {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(response.statusText);
+        }
+        return (await response.json()) as Promise<T>;
+    }
+}

--- a/sdk/test/layerzero.test.ts
+++ b/sdk/test/layerzero.test.ts
@@ -1,0 +1,13 @@
+import { assert, describe, it } from 'vitest';
+import { LayerZeroClient } from '../src/gateway/layerzero';
+
+describe('LayerZero Tests', () => {
+    it('should get chains', async () => {
+        const client = new LayerZeroClient();
+        const chains = await client.getSupportedChains();
+        assert.containSubset(chains, ['ethereum', 'bob']);
+
+        const dstEid = await client.getEidForChain('ethereum');
+        assert.equal(dstEid, '30101');
+    });
+});


### PR DESCRIPTION
Adds L0 methods to get supported chains and lookup EIDs for send txs.

Once the new L0 strategy has been developed we can include an extension to the client to automatically route Gateway calls through L0.