### PR TITLE
docs: add llms.txt

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,6 +45,7 @@ const config = {
   },
 
   plugins: [
+    'docusaurus-plugin-llms',
     [
       "@docusaurus/plugin-client-redirects",
       {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,7 +45,7 @@ const config = {
   },
 
   plugins: [
-    'docusaurus-plugin-llms',
+    [ 'docusaurus-plugin-llms', {  pathTransformation: { ignorePaths: ['docs'] } } ],
     [
       "@docusaurus/plugin-client-redirects",
       {

--- a/docs/package.json
+++ b/docs/package.json
@@ -38,6 +38,7 @@
     "@docusaurus/module-type-aliases": "^3.8.1",
     "@docusaurus/types": "^3.8.1",
     "@tsconfig/docusaurus": "^2.0.0",
+    "docusaurus-plugin-llms": "^0.2.0",
     "typedoc": "^0.25.13",
     "typedoc-plugin-markdown": "^3.16.0",
     "typescript": "^5.1.6"


### PR DESCRIPTION
This pull request introduces the `docusaurus-plugin-llms` plugin to the documentation site. The main changes involve updating the configuration and dependencies to enable this plugin which will generate llms.txt and llms-full.txt in the root path of the docs website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Integrated an additional documentation plugin to enhance site capabilities.
  * No visible changes to documentation content or navigation.

* **Chores**
  * Added a new development dependency to support the documentation build.
  * No changes to runtime dependencies, scripts, or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->