### PR TITLE
chore: update `getOrderDetails`  ABI

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/abi.ts
+++ b/sdk/src/gateway/abi.ts
@@ -122,7 +122,7 @@ export const offrampCaller = [
     },
     {
         type: 'function',
-        name: 'getOfframpOrder',
+        name: 'getOrderDetails',
         inputs: [
             {
                 name: 'orderId',
@@ -138,13 +138,13 @@ export const offrampCaller = [
                 components: [
                     { name: 'satAmountLocked', type: 'uint256', internalType: 'uint256' },
                     { name: 'satFeesMax', type: 'uint256', internalType: 'uint256' },
-                    { name: 'sender', type: 'address', internalType: 'address' },
-                    { name: 'receiver', type: 'address', internalType: 'address' },
+                    { name: 'owner', type: 'address', internalType: 'address' },
                     { name: 'outputScript', type: 'bytes', internalType: 'bytes' },
                     { name: 'status', type: 'uint8', internalType: 'enum OfframpOrderStatus' },
                     { name: 'timestamp', type: 'uint256', internalType: 'uint256' },
                     { name: 'token', type: 'address', internalType: 'address' },
-                    { name: 'owner', type: 'address', internalType: 'address' },
+                    { name: 'solverOwner', type: 'address', internalType: 'address' },
+                    { name: 'solverRecipient', type: 'address', internalType: 'address' },
                 ],
             },
         ],

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -443,7 +443,7 @@ export class GatewayApiClient {
             orderDetails.token,
             orderDetails.satAmountLocked,
             orderDetails.satFeesMax,
-            orderDetails.sender
+            orderDetails.owner
         );
 
         if (error) {
@@ -618,7 +618,7 @@ export class GatewayApiClient {
         const order = await publicClient.readContract({
             address: offrampRegistryAddress,
             abi: offrampCaller,
-            functionName: 'getOfframpOrder',
+            functionName: 'getOrderDetails',
             args: [orderId],
         });
 
@@ -627,9 +627,10 @@ export class GatewayApiClient {
             token: order.token as Address,
             satAmountLocked: order.satAmountLocked,
             satFeesMax: order.satFeesMax,
-            sender: order.sender as Address,
-            receiver: order.receiver !== (zeroAddress as Address) ? (order.receiver as Address) : null,
-            owner: order.owner !== (zeroAddress as Address) ? (order.owner as Address) : null,
+            owner: order.owner as Address,
+            solverOwner: order.solverOwner !== (zeroAddress as Address) ? (order.solverOwner as Address) : null,
+            solverRecipient:
+                order.solverRecipient !== (zeroAddress as Address) ? (order.solverRecipient as Address) : null,
             outputScript: order.outputScript,
             status: parseOrderStatus(Number(order.status)) as OnchainOfframpOrderDetails['status'],
             orderTimestamp: Number(order.timestamp),

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -478,11 +478,11 @@ export type OnchainOfframpOrderDetails = {
     /** @dev Max sats for fee */
     satFeesMax: bigint;
     /** @dev Address that created the order */
-    sender: Address;
-    /** @dev Optional receiver address for order payout */
-    receiver: Address | null;
-    /** @dev Optional owner address of the order */
-    owner: Address | null;
+    owner: Address;
+    /** @dev Optional solver owner address */
+    solverOwner: Address | null;
+    /** @dev Optional solver recipient address */
+    solverRecipient: Address | null;
     /** @dev Output script for Bitcoin tx */
     outputScript: string;
     /** @dev Order status */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated offramp order retrieval method name to “getOrderDetails.”
  - Restructured order details: removed sender/receiver; owner is now required; added solverOwner and solverRecipient.
  - Adjusted fee-bump logic to use owner as the address context.
  - Downstream consumers of fetchOfframpOrder must adapt to the new data shape.

- Chores
  - Bumped SDK version to 4.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->