### PR TITLE
fix: chain name for strategies

### DIFF
--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -992,7 +992,7 @@ export class GatewayApiClient {
     async getStrategies(): Promise<GatewayStrategyContract[]> {
         const response = await this.fetchGet(`${this.baseUrl}/strategies`);
 
-        const chainName = this.chain.toString();
+        const chainName = this.chain.name;
         const chainId = this.chainId;
 
         const strategies: GatewayStrategy[] = await response.json();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Strategy results now display the correct chain name/slug by using the configured chain name, ensuring consistent and accurate chain identifiers.
  - Improves reliability for consumers parsing chain metadata and prevents mismatches across environments.
  - No changes to public APIs; behavior is corrected in returned data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->