### PR TITLE
chore: update necessary types from u32 to u64

### DIFF
--- a/crates/utils/src/esplora_client.rs
+++ b/crates/utils/src/esplora_client.rs
@@ -53,7 +53,7 @@ pub struct VoutFormat {
     pub scriptpubkey_asm: String,
     pub scriptpubkey_type: String,
     pub scriptpubkey_address: Option<String>,
-    pub value: u32,
+    pub value: u64,
 }
 
 #[derive(Deserialize, Debug)]
@@ -72,9 +72,9 @@ pub struct TransactionFormat {
     pub txid: String,
     pub version: u32,
     pub locktime: u32,
-    pub size: u32,
-    pub weight: u32,
-    pub fee: u32,
+    pub size: u64,
+    pub weight: u64,
+    pub fee: u64,
     pub vin: Vec<VinFormat>,
     pub vout: Vec<VoutFormat>,
     pub status: TransactionStatus,
@@ -134,7 +134,7 @@ impl EsploraClient {
         Ok(Self { url: esplora_url.parse()?, cli: Client::new() })
     }
 
-    async fn get(&self, path: &str) -> Result<String> {
+    pub async fn get(&self, path: &str) -> Result<String> {
         let url = self.url.join(path)?;
         Ok(self.cli.get(url).send().await?.error_for_status()?.text().await?)
     }

--- a/crates/utils/src/esplora_client.rs
+++ b/crates/utils/src/esplora_client.rs
@@ -134,7 +134,7 @@ impl EsploraClient {
         Ok(Self { url: esplora_url.parse()?, cli: Client::new() })
     }
 
-    pub async fn get(&self, path: &str) -> Result<String> {
+    async fn get(&self, path: &str) -> Result<String> {
         let url = self.url.join(path)?;
         Ok(self.cli.get(url).send().await?.error_for_status()?.text().await?)
     }


### PR DESCRIPTION
Recently received the following error on regtest tx: 
```
    EsploraClientError(
        "invalid value: integer `5000000000`, expected u32 at line 1 column 468",
    ),
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents overflows when handling very large transaction amounts, sizes, weights, and fees.
  - Ensures accurate display and reporting of transaction metrics for high-value or complex transactions.

- Refactor
  - Increased numeric precision for transaction-related fields to better support large values and improve overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->