### PR TITLE
fix: await promise inside try/catch to handle runtime errors

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.6",
+    "version": "4.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@gobob/bob-sdk",
-            "version": "4.2.6",
+            "version": "4.2.7",
             "dependencies": {
                 "@eslint/eslintrc": "^3.3.1",
                 "@eslint/js": "^9.34.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.6",
+    "version": "4.2.7",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -1202,7 +1202,7 @@ export class GatewayApiClient {
         ];
     }
 
-    private safeFetch(url: URL | string, init: RequestInit | undefined, errorMessage: string) {
+    private async safeFetch(url: URL | string, init: RequestInit | undefined, errorMessage: string) {
         const defaultInit = {
             method: 'GET',
             headers: {
@@ -1212,7 +1212,9 @@ export class GatewayApiClient {
         };
 
         try {
-            return fetch(url, init || defaultInit);
+            // NOTE: await inside try/catch to handle runtime error
+            const response = await fetch(url, init || defaultInit);
+            return response;
         } catch (err) {
             this.handleFetchError(err, errorMessage);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network requests now properly handle runtime failures, reducing unhandled errors and improving reliability during intermittent connectivity, timeouts, and other request failures. Users should see more consistent error reporting and fewer silent failures. No behavioral changes expected beyond improved robustness.

* **Chores**
  * Updated SDK version to 4.2.7 with no public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->