### PR TITLE
fix: check eth estimate in offramp

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.8",
+    "version": "4.2.9",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -758,10 +758,11 @@ export class GatewayApiClient {
             const esploraClient = new EsploraClient(this.chain.id === bob.id ? Network.mainnet : Network.signet);
 
             // TODO: refactor to construct the PSBT instead since it may fund from other inputs
-            const availableBtcBalance = await esploraClient.getBalance(quote.bitcoinAddress);
+            const availableBtcBalance = await esploraClient.getBalance(params.fromUserAddress!);
+            console.log(availableBtcBalance);
             if (availableBtcBalance.total < BigInt(quote.satoshis)) {
                 throw new Error(
-                    `Insufficient BTC balance in address ${quote.bitcoinAddress}. Required: ${formatBtc(BigInt(quote.satoshis))}`
+                    `Insufficient BTC balance in address ${quote.bitcoinAddress}. Required: ${formatBtc(BigInt(quote.satoshis))}, Got: ${formatBtc(BigInt(availableBtcBalance.total))}`
                 );
             }
 

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -755,6 +755,16 @@ export class GatewayApiClient {
             const { onrampQuote, params } = executeQuoteParams;
             const quote = onrampQuote!;
 
+            const esploraClient = new EsploraClient(this.chain.id === bob.id ? Network.mainnet : Network.signet);
+
+            // TODO: refactor to construct the PSBT instead since it may fund from other inputs
+            const availableBtcBalance = await esploraClient.getBalance(quote.bitcoinAddress);
+            if (availableBtcBalance.total < BigInt(quote.satoshis)) {
+                throw new Error(
+                    `Insufficient BTC balance in address ${quote.bitcoinAddress}. Required: ${formatBtc(BigInt(quote.satoshis))}`
+                );
+            }
+
             const { uuid, psbtBase64, bitcoinAddress, satoshis, opReturnHash } = await this.startOnrampOrder(
                 quote,
                 params

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -710,6 +710,14 @@ describe('Gateway Tests', () => {
         const mockPublicClient = {
             multicall: () => Promise.resolve([10_000n, 8]),
             readContract: () => Promise.resolve(10_000n),
+            getBalance: () => Promise.resolve(1000000000000000000n), // 1 ETH in wei
+            estimateContractGas: () => Promise.resolve(21000n),
+            estimateFeesPerGas: () =>
+                Promise.resolve({
+                    maxFeePerGas: 20000000000n,
+                    maxPriorityFeePerGas: 1000000000n,
+                }),
+            getGasPrice: () => Promise.resolve(20000000000n),
             simulateContract: () => Promise.resolve({ request: '🎉' }),
             waitForTransactionReceipt: () =>
                 Promise.resolve('0x35f5bca7f984f4ed97888944293b979f3abb198a5716d04e10c6bdc023080075'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds preflight BTC balance check for onramps.
  * Adds detailed ETH gas budgeting for offramp (approval vs order creation), enforces sufficient ETH before proceeding, and performs ERC20 approval only when required.
  * Validates token decimals minimum and improves gas/balance error messages (values shown in wei/satoshis).

* **Tests**
  * Expands gateway tests to mock balance, gas estimation, and fee APIs to cover new preflight flows.

* **Chores**
  * Package version bumped (4.2.9).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->