### PR TITLE
refactor: remove expired HybridBTC APY override hack

### DIFF
--- a/sdk/src/gateway/strategy.ts
+++ b/sdk/src/gateway/strategy.ts
@@ -173,7 +173,7 @@ const tokenToSolvStrategyMap = new Map<string, string>([
     ],
 ]);
 
-const hybridBTCEndDate = new Date('2025-09-08T00:00:00.000Z');
+
 
 export default class StrategyClient {
     private viemClient: PublicClient;
@@ -211,11 +211,7 @@ export default class StrategyClient {
 
             if (defillamaPool) {
                 return {
-                    // HACK: set HybridBTC APY to 2% until 2025-09-08
-                    apyBase:
-                        defillamaPoolId === 'e8bfea35-ff6d-48db-aa08-51599b363219' && new Date() < hybridBTCEndDate
-                            ? 2
-                            : (defillamaPool?.apyBase ?? 0),
+                    apyBase: defillamaPool?.apyBase ?? 0,
                     apyReward: defillamaPool?.apyReward ?? 0,
                     rewardTokens: this.resolveTokens(defillamaPool?.rewardTokens),
                     points,


### PR DESCRIPTION
Remove obsolete HybridBTC APY hardcoded override that expired on 2025-09-08.

The condition `new Date() < hybridBTCEndDate` is always false since the expiration date has passed, making this dead code. Simplifies the APY calculation logic by removing the unused conditional and constant.

- Removes expired hack setting HybridBTC APY to 2%  
- Removes unused `hybridBTCEndDate` constant
- Cleanup technical debt in strategy APY calculation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HybridBTC pool APY now reflects live data instead of a temporary 2% override.
  * Removed date-based gating to ensure consistent APY behavior across time.
  * If no APY is available from the data source, the value defaults to 0 for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->