### PR TITLE
feat: pass user btc address to offramp quote for compliance check

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.9",
+    "version": "4.2.10",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -360,7 +360,7 @@ export class GatewayApiClient {
         token: Address,
         amountInToken: bigint,
         userAddress: Address,
-        toUserAddress?: string | null
+        toUserAddress?: string
     ): Promise<OfframpQuote> {
         const queryParams = new URLSearchParams({
             amountInWrappedToken: amountInToken.toString(),

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -288,7 +288,8 @@ export class GatewayApiClient {
         const quote = await this.fetchOfframpQuote(
             tokenAddress,
             BigInt(params.amount || 0),
-            params.fromUserAddress as Address
+            params.fromUserAddress as Address,
+            params.toUserAddress
         );
 
         return quote;
@@ -350,15 +351,26 @@ export class GatewayApiClient {
      *
      * @param token ERC20 token address
      * @param amountInToken Amount in token's smallest unit
+     * @param userAddress User EVM Address
+     * @param toUserAddress User BTC Address
      * @returns Promise resolving to offramp quote with fee breakdown
      * @throws {Error} If API request fails
      */
-    async fetchOfframpQuote(token: Address, amountInToken: bigint, userAddress: Address): Promise<OfframpQuote> {
+    async fetchOfframpQuote(
+        token: Address,
+        amountInToken: bigint,
+        userAddress: Address,
+        toUserAddress?: string | null
+    ): Promise<OfframpQuote> {
         const queryParams = new URLSearchParams({
             amountInWrappedToken: amountInToken.toString(),
             token,
             userAddress: userAddress,
         });
+
+        if (toUserAddress) {
+            queryParams.append('userBtcAddress', toUserAddress);
+        }
 
         const response = await this.safeFetch(
             `${this.baseUrl}/offramp-quote?${queryParams}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SDK now lets integrators include a BTC destination address when requesting an offramp quote. An optional field can be provided to route payouts to a specific user BTC address for more precise payout handling.

- **Chores**
  - Package version bumped to 4.2.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->