### PR TITLE
chore: add `reqwest-rustls-tls` feature to fix CI

### DIFF
--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -16,6 +16,6 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 bitcoin = { workspace = true, features = ["serde"] }
 
 # Ethereum
-alloy = { workspace = true, features = ["full", "providers", "node-bindings"] }
+alloy = { workspace = true, features = ["full", "providers", "node-bindings","reqwest-rustls-tls"] }
 serde_json = "1.0.140"
 tracing = "0.1.41"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -16,6 +16,6 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 bitcoin = { workspace = true, features = ["serde"] }
 
 # Ethereum
-alloy = { workspace = true, features = ["full", "providers", "node-bindings","reqwest-rustls-tls"] }
+alloy = { workspace = true, features = ["full", "providers", "node-bindings", "reqwest-rustls-tls"] }
 serde_json = "1.0.140"
 tracing = "0.1.41"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enabled Rustls-based TLS for outbound network requests via a dependency update, improving cross-platform reliability and security (reduces reliance on system OpenSSL).
  - No changes to user interfaces or workflows; behavior is internal and backward-compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->