### PR TITLE
feat: add output amount for onramp quote

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.10",
+    "version": "4.2.11",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -267,6 +267,7 @@ export class GatewayApiClient {
 
         return {
             ...quote,
+            outputSatoshis: quote.satoshis - quote.fee,
             baseToken: ADDRESS_LOOKUP[this.chainId][quote.baseTokenAddress],
             outputToken: quote.strategyAddress ? ADDRESS_LOOKUP[this.chainId][outputTokenAddress] : undefined,
         };

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -197,8 +197,10 @@ export type GatewayQuote = {
     baseTokenAddress: Address;
     /** @description The minimum amount of Bitcoin to send */
     dustThreshold: number;
-    /** @description The satoshi output amount */
+    /** @description The satoshi input amount */
     satoshis: number;
+    /** @description The satoshi output amount (amount user receives after fees) */
+    outputSatoshis: number;
     /** @description The fee paid in satoshis (includes gas refill, l1 data fee and estimated prove tx fee) */
     fee: number;
     /** @description The Bitcoin address to send BTC */

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -68,6 +68,7 @@ describe('Gateway Tests', () => {
 
         const assertMockQuote = {
             ...mockQuote,
+            outputSatoshis: mockQuote.satoshis - mockQuote.fee,
             orderDetails: orderDetails,
         };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onramp quotes now include outputSatoshis, showing the net satoshis users receive after fees.
* **Documentation**
  * Clarified that satoshis represents the input amount; documented the new outputSatoshis as the post-fee amount.
* **Tests**
  * Updated test coverage to validate the new outputSatoshis field in onramp quotes.
* **Chores**
  * Bumped SDK version to 4.2.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->