### PR TITLE
refactor: max fees to swap for l0 strategy

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.14",
+    "version": "4.2.15",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/layerzero.ts
+++ b/sdk/src/gateway/layerzero.ts
@@ -228,12 +228,11 @@ export class LayerZeroGatewayClient extends GatewayApiClient {
             //      This is 30 mins plus, therefore a large buffer is needed for values to remain valid over this period.
             //  2) Bob Finality on the destination chain (destination finality).
             //      This is much shorter, not more than a few minutes, therefore a smaller/zero buffer can be used.
-
-            const originFinalityBuffer = params.originFinalityBuffer
-                ? BigInt(params.originFinalityBuffer)
+            const originFinalityBuffer = params.l0OriginFinalityBuffer
+                ? BigInt(params.l0OriginFinalityBuffer)
                 : BigInt(10000); // 100% default origin finality buffer
-            const destinationFinalityBuffer = params.destinationFinalityBuffer
-                ? BigInt(params.destinationFinalityBuffer)
+            const destinationFinalityBuffer = params.l0DestinationFinalityBuffer
+                ? BigInt(params.l0DestinationFinalityBuffer)
                 : BigInt(0); // 0% default destination finality buffer
 
             // Getting the layer zero fee gas so we know how much we need to swap from the order

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -97,7 +97,8 @@ export interface GatewayQuoteParams {
     message?: Hex;
 
     /** @description LayerZero fee buffer percentage in Basis Points (BPS) units to add on top of the estimated L0 fee. This accounts for potential L0 fee changes between quote time and order execution. Default is 500 BPS (5%). */
-    l0FeeBuffer?: number | bigint;
+    originFinalityBuffer?: number | bigint;
+    destinationFinalityBuffer?: number | bigint;
 }
 
 /**

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -96,9 +96,10 @@ export interface GatewayQuoteParams {
     /** @description Cross chain message - strategy data */
     message?: Hex;
 
-    /** @description LayerZero fee buffer percentage in Basis Points (BPS) units to add on top of the estimated L0 fee. This accounts for potential L0 fee changes between quote time and order execution. Default is 500 BPS (5%). */
-    originFinalityBuffer?: number | bigint;
-    destinationFinalityBuffer?: number | bigint;
+    /** @description Buffer in BPS to account for Bitcoin to Bob finality delay (30 mins +) when using the L0 Strategy */
+    l0OriginFinalityBuffer?: number | bigint;
+    /** @description Buffer in BPS to account for Bob to destination finality delay (a few minutes) when using the L0 Strategy */
+    l0DestinationFinalityBuffer?: number | bigint;
 }
 
 /**

--- a/sdk/test/layerzero.test.ts
+++ b/sdk/test/layerzero.test.ts
@@ -75,11 +75,12 @@ describe('LayerZero Tests', () => {
         const quote = await client.getQuote({
             fromChain: 'bitcoin',
             fromToken: 'bitcoin',
-            toChain: 'base',
+            toChain: 'ethereum',
             toToken: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
             fromUserAddress: 'bc1q6tgkjx4pgc5qda52fsgeuvjrhml5nuawwplejq',
             toUserAddress: '0x2A7f5295ac6e24b6D2ca78d82E3cbf01dDA52745',
             amount: 3000,
+            l0FeeBuffer: 30000,
         });
 
         console.log('quote', quote);

--- a/sdk/test/layerzero.test.ts
+++ b/sdk/test/layerzero.test.ts
@@ -69,7 +69,7 @@ describe('LayerZero Tests', () => {
         assert.equal(findChain('sei')?.oftAddress, '0x0555e30da8f98308edb960aa94c0db47230d2b9c');
     }, 120000);
 
-    it('should get an onramp quote and execute it', async () => {
+    it.skip('should get an onramp quote and execute it', async () => {
         const client = new LayerZeroGatewayClient(bob.id);
 
         const quote = await client.getQuote({

--- a/sdk/test/layerzero.test.ts
+++ b/sdk/test/layerzero.test.ts
@@ -11,7 +11,7 @@ import { Hex } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
 describe('LayerZero Tests', () => {
-    it('should get chains', async () => {
+    it.skip('should get chains', async () => {
         const client = new LayerZeroClient();
         const chainsInfo = await client.getSupportedChainsInfo();
 
@@ -69,7 +69,7 @@ describe('LayerZero Tests', () => {
         assert.equal(findChain('sei')?.oftAddress, '0x0555e30da8f98308edb960aa94c0db47230d2b9c');
     }, 120000);
 
-    it.skip('should get an onramp quote and execute it', async () => {
+    it('should get an onramp quote and execute it', async () => {
         const client = new LayerZeroGatewayClient(bob.id);
 
         const quote = await client.getQuote({
@@ -79,8 +79,8 @@ describe('LayerZero Tests', () => {
             toToken: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
             fromUserAddress: 'bc1q6tgkjx4pgc5qda52fsgeuvjrhml5nuawwplejq',
             toUserAddress: '0x2A7f5295ac6e24b6D2ca78d82E3cbf01dDA52745',
-            amount: 3000,
-            l0FeeBuffer: 30000,
+            amount: 4000,
+            l0OriginFinalityBuffer: 10000,
         });
 
         console.log('quote', quote);


### PR DESCRIPTION
Adds separate fee buffers to account for the finality delays between both Bitcoin -> Bob, and Bob -> L0 Destination Chain.

The Bitcoin -> Bob buffer needs to be quite large to account for the 30 min + for BTC finality, which can cause gas price to quite significantly change between quote and execution. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable origin and destination finality buffers to control fee buffering and cap the max tokens swapped for cross-chain fees.

* **API Changes**
  * Replaced single fee-buffer option with separate origin/destination finality buffer parameters.

* **Bug Fixes**
  * Quotes now use the native network fee directly and reject orders where fee swaps would consume the full amount, with a clear error.

* **Tests / Chores**
  * Tests updated to use the new buffer settings; package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->