### PR TITLE
chore: add `tokensReceived` in onramp order response

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.17",
+    "version": "4.2.18",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -286,6 +286,11 @@ export type OfframpGatewayCreateQuoteResponse = {
     gateway: Address;
 };
 
+export interface TokenReceived {
+    token_address: Address;
+    amount: string;
+}
+
 export interface OnrampOrderResponse {
     /** @description The gateway address */
     gatewayAddress: Address;
@@ -322,6 +327,8 @@ export interface OnrampOrderResponse {
     orderDetails?: OrderDetailsRaw;
     /** layerzero dst eid if the order being routed through layerzero */
     layerzeroDstEid?: number;
+    /** @description The tokens received by the user */
+    tokensReceived?: TokenReceived[] | null;
 }
 
 export type OrderStatusData = {

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -287,7 +287,7 @@ export type OfframpGatewayCreateQuoteResponse = {
 };
 
 export interface TokenReceived {
-    token_address: Address;
+    tokenAddress: Address;
     amount: string;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onramp order responses can optionally include a list of tokens received (addresses and amounts), enabling apps to display received token details; backward compatible and non-breaking.

* **Chores**
  * SDK version bumped to 4.2.18 with no other behavioral or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->