### PR TITLE
feat: add offramp refunded evm tx

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.2.18",
+    "version": "4.2.19",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -514,6 +514,7 @@ export interface OfframpRawOrder {
     btcTx: string | null;
     submitOrderEvmTx: string | null;
     shouldFeesBeBumped: boolean;
+    refundedEvmTx: string | null;
 }
 
 /** @dev Internal */

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -469,6 +469,8 @@ export type OfframpOrder = {
     orderTimestamp: number;
     /** @dev The user submit order transaction hash on the EVM chain */
     submitOrderEvmTx: string | null;
+    /** @dev The user refunded order transaction hash on the EVM chain */
+    refundedEvmTx: string | null;
     /** @dev The transaction ID on the Bitcoin network */
     btcTx: string | null;
     /** @dev Indicates whether the fees for this order should be bumped based on current network conditions */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Offramp orders now include an optional refunded EVM transaction hash when available, making refunded orders easier to identify while remaining backwards-compatible.

- **Chores**
  - Bumped SDK version to 4.2.19.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->