### PR TITLE
chore: remove mica link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,7 +45,7 @@ const config = {
   },
 
   plugins: [
-    [ 'docusaurus-plugin-llms', {  pathTransformation: { ignorePaths: ['docs'] } } ],
+    ['docusaurus-plugin-llms', { pathTransformation: { ignorePaths: ['docs'] } }],
     [
       "@docusaurus/plugin-client-redirects",
       {
@@ -87,12 +87,7 @@ const config = {
           {
             from: "/learn/user-guides/bob-pay",
             to: "/docs/deprecated/bob-pay",
-          },
-          // External document redirects
-          {
-            from: "/docs/reference/mica-whitepaper",
-            to: "https://docs.google.com/document/d/1T3OzCNTS9NVEixAFKW1bRWffrPswiL_m/edit?usp=sharing&ouid=112528513121405423589&rtpof=true&sd=true",
-          },
+          }
         ],
       },
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the redirect for /docs/reference/mica-whitepaper. The old URL will no longer auto-forward; please navigate via the updated documentation path. Update any bookmarks or external links to the current location.

* **Style**
  * Minor formatting cleanup in documentation configuration (spacing/quotes) with no impact on behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->