### PR TITLE
feat: offramp orders now provides `offrampRegistryAddress`

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -494,6 +494,8 @@ export type OfframpOrder = {
     shouldFeesBeBumped: boolean;
     /** @dev Indicates whether the user can unlock this order (typically if it's still active) */
     canOrderBeUnlocked: boolean;
+    /** @dev The offramp registry address the order is related to */
+    offrampRegistryAddress: string
 };
 
 /** @dev Internal, On-chain fetched state of an active/processed/refunded order */

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -495,7 +495,7 @@ export type OfframpOrder = {
     /** @dev Indicates whether the user can unlock this order (typically if it's still active) */
     canOrderBeUnlocked: boolean;
     /** @dev The offramp registry address the order is related to */
-    offrampRegistryAddress: string;
+    offrampRegistryAddress: Address;
 };
 
 /** @dev Internal, On-chain fetched state of an active/processed/refunded order */

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -495,7 +495,7 @@ export type OfframpOrder = {
     /** @dev Indicates whether the user can unlock this order (typically if it's still active) */
     canOrderBeUnlocked: boolean;
     /** @dev The offramp registry address the order is related to */
-    offrampRegistryAddress: string
+    offrampRegistryAddress: string;
 };
 
 /** @dev Internal, On-chain fetched state of an active/processed/refunded order */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Off-ramp order responses now include the associated registry address as an additional field. This enhances the information available to clients when handling off-ramp orders. Existing integrations remain compatible, and the new field can be consumed optionally where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->