### PR TITLE
chore: add blockchain fees for get quote method

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -226,8 +226,13 @@ export class GatewayApiClient {
                 params,
                 finalOutputSats: data.amountReceiveInSat,
                 finalFeeSats: data.feeBreakdown.overallFeeSats,
-                data,
-                blockchainFee: createOrderGasCost,
+                data: {
+                    ...data,
+                    feeBreakdown: {
+                        ...data.feeBreakdown,
+                        gasFee: createOrderGasCost,
+                    },
+                },
             };
         }
 

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -13,6 +13,8 @@ import {
     Chain as ViemChain,
     WalletClient,
     zeroAddress,
+    parseEther,
+    toHex,
 } from 'viem';
 import { bob, bobSepolia } from 'viem/chains';
 import { EsploraClient } from '../esplora';
@@ -20,7 +22,7 @@ import { bigIntToFloatingNumber } from '../utils';
 import { createBitcoinPsbt } from '../wallet';
 import { claimDelayAbi, offrampCaller, strategyCaller } from './abi';
 import StrategyClient from './strategy';
-import { ADDRESS_LOOKUP, getTokenAddress, getTokenDecimals } from './tokens';
+import { ADDRESS_LOOKUP, getTokenAddress, getTokenDecimals, getTokenSlots } from './tokens';
 import {
     BitcoinSigner,
     BumpFeeParams,
@@ -51,6 +53,8 @@ import {
     UnlockOrderParams,
 } from './types';
 import {
+    computeAllowanceSlot,
+    computeBalanceSlot,
     convertOnrampFeeBreakdown,
     convertOrderDetailsRawToOrderDetails,
     convertOrderDetailsToRaw,
@@ -198,28 +202,14 @@ export class GatewayApiClient {
                 data,
             };
         } else if (params.toChain.toString().toLowerCase() === 'bitcoin') {
-            const chain = getChainConfig(params.fromChain);
-            const publicClient = viemClient(chain);
             const data = await this.getOfframpQuote(params);
-
-            const [offrampOrder, offrampRegistryAddress, feeValues, gasPrice] = await Promise.all([
-                this.createOfframpOrder(data, params),
-                this.fetchOfframpRegistryAddress(),
-                publicClient.estimateFeesPerGas(),
-                publicClient.getGasPrice(),
-            ]);
-
-            const fee = feeValues.maxFeePerGas ?? gasPrice;
-
-            const createOrderGasEstimate = await publicClient.estimateContractGas({
-                address: offrampRegistryAddress,
-                abi: offrampOrder.offrampABI,
-                functionName: offrampOrder.offrampFunctionName,
-                args: offrampOrder.offrampArgs,
-                account: params.fromUserAddress as Address,
-            });
-
-            const createOrderGasCost = createOrderGasEstimate * fee;
+            let createOrderGasCost = 0n;
+            // Even if we fail to estimate the create order gas cost, we still return a quote to the user.
+            try {
+                createOrderGasCost = await this.getOfframpCreateOrderGasCost(params, data);
+            } catch (err) {
+                console.warn('Failed to get create order gas cost, defaulting to 0', err);
+            }
 
             return {
                 type: 'offramp',
@@ -237,6 +227,79 @@ export class GatewayApiClient {
         }
 
         throw new Error('Invalid quote arguments');
+    }
+
+    /**
+     * Estimates the gas cost for creating an offramp order on-chain.
+     *
+     * This uses a state override to simulate max token allowance and balance for the user,
+     * ensuring the gas estimate accounts for sufficient funds and approvals.
+     *
+     * @param params - Quote parameters containing user address and chain info
+     * @param offrampQuote - Offramp quote containing token and amount info
+     * @returns Promise resolving to the estimated gas cost in wei (as bigint)
+     */
+    async getOfframpCreateOrderGasCost(params: GetQuoteParams, offrampQuote: OfframpQuote): Promise<bigint> {
+        const chain = getChainConfig(params.fromChain);
+        const publicClient = viemClient(chain);
+
+        const [offrampOrder, offrampRegistryAddress, feeValues, gasPrice] = await Promise.all([
+            this.createOfframpOrder(offrampQuote, params),
+            this.fetchOfframpRegistryAddress(),
+            publicClient.estimateFeesPerGas(),
+            publicClient.getGasPrice(),
+        ]);
+
+        const fee = feeValues.maxFeePerGas ?? gasPrice;
+
+        const slots = getTokenSlots(offrampOrder.quote.token as Address, this.chainId);
+        const user = params.fromUserAddress ?? '0x1111111111111111111111111111111111111111';
+
+        const allowanceSlot = computeAllowanceSlot(
+            user as Address,
+            offrampRegistryAddress as Address,
+            slots.allowanceSlot
+        );
+        const balanceSlot = computeBalanceSlot(user as Address, slots.balanceSlot);
+
+        // Ensure the owner inside offrampArgs is set
+        const args: readonly [(typeof offrampOrder.offrampArgs)[0]] = [
+            {
+                ...offrampOrder.offrampArgs[0],
+                owner: user as Address,
+            },
+        ];
+
+        const createOrderGasEstimate = await publicClient.estimateContractGas({
+            address: offrampRegistryAddress,
+            abi: offrampOrder.offrampABI,
+            functionName: offrampOrder.offrampFunctionName,
+            args,
+            account: user as Address,
+            stateOverride: [
+                // ERC20 token override
+                {
+                    address: offrampOrder.quote.token as Address,
+                    stateDiff: [
+                        {
+                            slot: allowanceSlot,
+                            value: toHex(maxUint256),
+                        },
+                        {
+                            slot: balanceSlot,
+                            value: toHex(maxUint256),
+                        },
+                    ],
+                },
+                // Ether balance override
+                {
+                    address: user as Address,
+                    balance: parseEther('1'), // set 1 ETH for the user
+                },
+            ],
+        });
+
+        return createOrderGasEstimate * fee;
     }
 
     /**

--- a/sdk/src/gateway/tokens.ts
+++ b/sdk/src/gateway/tokens.ts
@@ -36,6 +36,8 @@ const bobTokens = [
             },
         },
         logoURI: 'https://raw.githubusercontent.com/bob-collective/bob/master/assets/wbtc.svg',
+        allowanceSlot: 6n,
+        balanceSlot: 5n,
     },
     {
         name: 'Solv BTC',
@@ -105,6 +107,8 @@ const bobSepoliaTokens = [
             },
         },
         logoURI: 'https://raw.githubusercontent.com/bob-collective/bob/master/assets/btc.svg',
+        allowanceSlot: 1n,
+        balanceSlot: 0n,
     },
     {
         name: 'Staked mtBTC',
@@ -360,6 +364,8 @@ const TOKENS: Array<{
         };
     };
     logoURI: string;
+    allowanceSlot?: bigint; // optional
+    balanceSlot?: bigint; // optional
 }> = [
     ...bobTokens,
     ...bobSepoliaTokens,
@@ -446,4 +452,27 @@ export function getTokenAddress(chainId: number, token: string): Address {
     } else {
         throw new Error('Unknown output token');
     }
+}
+export function getTokenSlots(tokenAddress: Address, chainId: number): { allowanceSlot: bigint; balanceSlot: bigint } {
+    const lowerAddress = tokenAddress.toLowerCase();
+
+    // Look up the token in the master TOKENS array
+    const token = TOKENS.find((t) => {
+        const chainToken = t.tokens[bob.id === chainId ? 'bob' : 'bob-sepolia'];
+        return chainToken?.address.toLowerCase() === lowerAddress;
+    });
+
+    if (!token) {
+        throw new Error(`Token not found for address ${tokenAddress} on chain ${chainId}`);
+    }
+
+    // Check if slots are defined
+    if (token.allowanceSlot === undefined || token.balanceSlot === undefined) {
+        throw new Error(`Slots not defined for token ${token.symbol} at address ${tokenAddress}`);
+    }
+
+    return {
+        allowanceSlot: token.allowanceSlot,
+        balanceSlot: token.balanceSlot,
+    };
 }

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -418,6 +418,8 @@ export interface OfframpFeeBreakdown {
     affiliateFeeSats: number;
     /** @dev Fastest available fee rate (e.g., sat/vB) */
     fastestFeeRate: number;
+    /** @dev Fastest gas fees on the source chain */
+    gasFee?: bigint;
 }
 
 /** @dev Offramp order quote returned by the quoting logic */
@@ -584,7 +586,6 @@ export type OnrampExecuteQuoteParams<T = {}> = BaseExecuteQuoteParams<T> & {
 export type OfframpExecuteQuoteParams<T = {}> = BaseExecuteQuoteParams<T> & {
     type: 'offramp';
     data: OfframpQuote;
-    blockchainFee?: bigint;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/sdk/src/gateway/types.ts
+++ b/sdk/src/gateway/types.ts
@@ -584,6 +584,7 @@ export type OnrampExecuteQuoteParams<T = {}> = BaseExecuteQuoteParams<T> & {
 export type OfframpExecuteQuoteParams<T = {}> = BaseExecuteQuoteParams<T> & {
     type: 'offramp';
     data: OfframpQuote;
+    blockchainFee?: bigint;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/sdk/src/gateway/utils.ts
+++ b/sdk/src/gateway/utils.ts
@@ -10,7 +10,6 @@ import {
 import { encodeAbiParameters, parseAbiParameters, keccak256, parseUnits, formatUnits } from 'viem';
 import * as bitcoin from 'bitcoinjs-lib';
 import { avalanche, base, berachain, bob, bsc, mainnet, optimism, sei, soneium, sonic, unichain } from 'viem/chains';
-import { number } from 'yargs';
 
 /**
  * Should compute the same OP_RETURN hash as the Gateway API and smart contracts.
@@ -142,8 +141,6 @@ const supportedChains = [
     optimism,
 ] as const;
 
-type ViemChain = (typeof supportedChains)[number];
-
 const chainIdToChainConfigMapping = supportedChains.reduce(
     (acc, chain) => {
         acc[chain.id] = chain;
@@ -173,7 +170,9 @@ function getChainIdByName(chainName: string) {
 function getChainConfigById(chainId: number) {
     const config = chainIdToChainConfigMapping[chainId];
     if (!config) {
-        throw Error(`Chain id for "${chainId}" not found. Allowed values ${supportedChains.map((chain) => chain.id)}`);
+        throw new Error(
+            `Chain id for "${chainId}" not found. Allowed values ${supportedChains.map((chain) => chain.id)}`
+        );
     }
 
     return config;

--- a/sdk/src/gateway/utils.ts
+++ b/sdk/src/gateway/utils.ts
@@ -7,7 +7,7 @@ import {
     OrderDetails,
     OrderDetailsRaw,
 } from './types';
-import { encodeAbiParameters, parseAbiParameters, keccak256, parseUnits, formatUnits } from 'viem';
+import { encodeAbiParameters, parseAbiParameters, keccak256, parseUnits, formatUnits, Address, Hex } from 'viem';
 import * as bitcoin from 'bitcoinjs-lib';
 import { avalanche, base, berachain, bob, bsc, mainnet, optimism, sei, soneium, sonic, unichain } from 'viem/chains';
 
@@ -185,4 +185,44 @@ export function getChainConfig(fromChain: string | number) {
     }
 
     return getChainConfigById(fromChain);
+}
+
+// Compute the final ERC20 allowance storage slot
+export function computeAllowanceSlot(user: Address, offrampRegistryAddress: Address, tokenAllowanceSlot: bigint): Hex {
+    const innerSlot = keccak256(
+        encodeAbiParameters(
+            [
+                { name: 'owner', type: 'address' },
+                { name: 'slot', type: 'uint256' },
+            ],
+            [user, tokenAllowanceSlot]
+        )
+    );
+
+    const allowanceSlot = keccak256(
+        encodeAbiParameters(
+            [
+                { name: 'spender', type: 'address' },
+                { name: 'innerSlot', type: 'bytes32' },
+            ],
+            [offrampRegistryAddress, innerSlot]
+        )
+    );
+    return allowanceSlot;
+}
+
+// Compute the final ERC20 balance storage slot for a user
+export function computeBalanceSlot(user: Address, balancesMappingSlot: bigint): Hex {
+    // Compute the storage slot for the user's balance
+    const balanceSlot = keccak256(
+        encodeAbiParameters(
+            [
+                { name: 'owner', type: 'address' },
+                { name: 'slot', type: 'uint256' },
+            ],
+            [user, balancesMappingSlot]
+        )
+    );
+
+    return balanceSlot;
 }

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -836,4 +836,81 @@ describe('Gateway Tests', () => {
         expect(getOnrampOrdersSpy).toHaveBeenCalledOnce();
         expect(getOfframpOrdersSpy).toHaveBeenCalledOnce();
     });
+
+    it(
+        'get offramp gas cost for BOB and Ethereum',
+        async () => {
+            const gatewaySDK = new GatewaySDK(bob.id);
+
+            // deployed offramp registry address
+            nock(MAINNET_GATEWAY_BASE_URL)
+                .persist()
+                .get('/offramp-registry-address')
+                .reply(200, '0x3d65cd168f27aeddeb08ca31cac5e5c12f3bb16d');
+
+            nock(MAINNET_GATEWAY_BASE_URL)
+                .persist()
+                .get('/offramp-quote')
+                .query(true)
+                .reply(200, {
+                    amountLockInSat: 4000,
+                    registryAddress: '0xd7b27b178f6bf290155201109906ad203b6d99b1',
+                    feeBreakdown: {
+                        overallFeeSats: 886,
+                        inclusionFeeSats: 886,
+                        protocolFeeSats: 0,
+                        affiliateFeeSats: 0,
+                        fastestFeeRate: 2,
+                    },
+                });
+
+            // Test for BOB
+            const bobQuote = await gatewaySDK.getQuote({
+                fromChain: 'BOB',
+                fromToken: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
+                toChain: 'Bitcoin',
+                toToken: 'bitcoin',
+                toUserAddress: 'bc1qcwcjsc0mltyt293877552grdktjhnvnn2zh52t',
+                fromUserAddress: '0xFAEe001465dE6D7E8414aCDD9eF4aC5A35B2B808',
+                amount: 40000,
+            });
+            if ('gasFee' in bobQuote.data.feeBreakdown) {
+                expect(bobQuote.data.feeBreakdown.gasFee).toBeGreaterThan(0);
+            } else {
+                throw new Error('Expected gasFee to exist on feeBreakdown, but it does not.');
+            }
+
+            // Test for Ethereum
+            const ethQuote = await gatewaySDK.getQuote({
+                fromChain: 'ethereum',
+                fromToken: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
+                toChain: 'Bitcoin',
+                toToken: 'bitcoin',
+                toUserAddress: 'bc1qcwcjsc0mltyt293877552grdktjhnvnn2zh52t',
+                fromUserAddress: '0xFAEe001465dE6D7E8414aCDD9eF4aC5A35B2B808',
+                amount: 40000,
+            });
+            if ('gasFee' in ethQuote.data.feeBreakdown) {
+                expect(ethQuote.data.feeBreakdown.gasFee).toBeGreaterThan(0);
+            } else {
+                throw new Error('Expected gasFee to exist on feeBreakdown, but it does not.');
+            }
+
+            // Test for BOB with no from user address
+            const bobQuoteWithNoUserAddress = await gatewaySDK.getQuote({
+                fromChain: 'BOB',
+                fromToken: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
+                toChain: 'Bitcoin',
+                toToken: 'bitcoin',
+                toUserAddress: 'bc1qcwcjsc0mltyt293877552grdktjhnvnn2zh52t',
+                amount: 40000,
+            });
+            if ('gasFee' in bobQuoteWithNoUserAddress.data.feeBreakdown) {
+                expect(bobQuoteWithNoUserAddress.data.feeBreakdown.gasFee).toBeGreaterThan(0);
+            } else {
+                throw new Error('Expected gasFee to exist on feeBreakdown, but it does not.');
+            }
+        },
+        { timeout: 5000 } // 5 seconds
+    );
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Offramp quotes now include an estimated on-chain gas fee in the fee breakdown and a new public gas-cost estimation method for on-chain order creation.
  - Automatic chain-aware resolution for on-chain cost estimates.

- Behavior
  - Gas estimation is error-tolerant: failures fall back to a zero gas fee and emit warnings.

- Documentation
  - SDK types updated to expose an optional gasFee in offramp fee breakdowns.

- Tests
  - Added tests verifying gas fee presence across offramp scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->