### PR TITLE
docs: GW remove warning, update description

### DIFF
--- a/docs/docs/docs/gateway/index.md
+++ b/docs/docs/docs/gateway/index.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # BOB Gateway
 
-BOB Gateway is a Bitcoin intent/RFQ-based swap protocol that allows users to swap BTC on Bitcoin for ERC20 assets on BOB and other connected chains including Base, BNB, Unichain, AVAX, and more. Users can also swap ERC20 asssets back to BTC from any chain. The swap mechanism is trust-minimized: BOB Gateway uses smart contracts and cross-chain BTC proofs to ensure that swaps are always executed correctly.
+BOB Gateway is a Bitcoin intent/RFQ-based swap protocol that allows users to swap BTC on Bitcoin for ERC20 assets on BOB and other connected chains including Base, BNB, Unichain, AVAX, and more. Users can also swap ERC20 assets back to BTC from any chain. The swap mechanism is trust-minimized: BOB Gateway uses smart contracts and cross-chain BTC proofs to ensure that swaps are always executed correctly.
 
 :::info Gateway Overview
 For a detailed explanation of Gateway's architecture and user flow, see the [technical overview](./overview.md).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Gateway docs to list additional supported chains (Base, BNB, Unichain, AVAX, and others).
  * Clarified cross-chain behavior, including ability to swap ERC20 assets back to BTC from any connected chain.
  * Removed an outdated Gateway v4 deployment warning.
  * Added a direct link to the BOB Gateway in the “Current Platforms Using BOB Gateway” section.
  * Reflowed and improved wording to reflect current platform coverage and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->