### PR TITLE
refactor: reuse prebuilt offramp arguments in gas estimation

### DIFF
--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -286,13 +286,8 @@ export class GatewayApiClient extends BaseClient {
         );
         const balanceSlot = computeBalanceSlot(user as Address, slots.balanceSlot);
 
-        // Ensure the owner inside offrampArgs is set
-        const args: readonly [(typeof offrampOrder.offrampArgs)[0]] = [
-            {
-                ...offrampOrder.offrampArgs[0],
-                owner: user as Address,
-            },
-        ];
+        // Reuse the pre-built args that already include the correct owner
+        const args = offrampOrder.offrampArgs;
 
         const createOrderGasEstimate = await publicClient.estimateContractGas({
             address: offrampRegistryAddress,


### PR DESCRIPTION

  ## Summary
  - drop the redundant reconstruction of `offrampArgs` when estimating create-order gas
  - rely on the object returned by `createOfframpOrder`, keeping the logic single-sourced

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of gas cost calculation logic in the gateway client to reduce redundant argument handling while maintaining identical functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->