### PR TITLE
fix: ordinals test case add `properties` type

### DIFF
--- a/sdk/src/ordinal-api/index.ts
+++ b/sdk/src/ordinal-api/index.ts
@@ -277,6 +277,34 @@ export interface SatJson<InscriptionId> {
     inscriptions: InscriptionId[];
 }
 
+type TraitValue = string | number | boolean | null;
+
+type Traits = Record<string, TraitValue>;
+
+type Attributes = {
+    title?: string | null;
+    traits?: Traits;
+    // allow forward‑compat extra fields
+    [key: string]: unknown;
+};
+
+type GalleryItem = {
+    // serialized inscription id: 32‑byte txid + 4‑byte LE index (possibly trimmed)
+    id: string;
+    attributes?: Attributes;
+    // allow forward‑compat extra fields
+    [key: string]: unknown;
+};
+
+type Properties = {
+    // inscription-level attributes
+    attributes?: Attributes;
+    // gallery items
+    gallery?: GalleryItem[];
+    // allow forward‑compat extra top‑level fields
+    [key: string]: unknown;
+};
+
 /**
  * @ignore
  */
@@ -369,6 +397,11 @@ export interface InscriptionJson<InscriptionId, SatPoint> {
      * The output value of the inscription.
      */
     value: number | null;
+
+    /**
+     * New properties object.
+     */
+    properties: Properties;
 }
 
 export class OrdinalsClient {

--- a/sdk/test/ordinal-api.test.ts
+++ b/sdk/test/ordinal-api.test.ts
@@ -31,6 +31,13 @@ describe('Ordinal API Tests', () => {
             satpoint: SatPoint.fromString('b61b0172d95e266c18aea0c624db987e971a5d6d4ebc2aaed85da4642d635735:0:0'),
             timestamp: 1678248991,
             value: 10000,
+            properties: {
+                attributes: {
+                    title: null,
+                    traits: {},
+                },
+                gallery: [],
+            },
         };
 
         assert.deepStrictEqual(inscriptionJson, expectedInscriptionJson);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended inscription data capabilities: Inscriptions now support properties for storing attributes, traits, and gallery items, enabling richer metadata management while maintaining full backward compatibility with existing integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->