### PR TITLE
refactor: use estimated l0 fee without buffer

### DIFF
--- a/sdk/src/gateway/layerzero.ts
+++ b/sdk/src/gateway/layerzero.ts
@@ -333,8 +333,8 @@ export class LayerZeroGatewayClient extends GatewayApiClient {
             const baseQuote = await super.getQuote(params);
             return {
                 ...baseQuote,
-                finalOutputSats: baseQuote.finalOutputSats - Number(maxTokensToSwapForLayerZeroFees),
-                finalFeeSats: baseQuote.finalFeeSats + Number(maxTokensToSwapForLayerZeroFees),
+                finalOutputSats: baseQuote.finalOutputSats - Number(tokensToSwapForLayerZeroFees),
+                finalFeeSats: baseQuote.finalFeeSats + Number(tokensToSwapForLayerZeroFees),
             };
         } else if (fromChain !== 'bitcoin' && toChain === 'bitcoin') {
             const dstEid = await this.l0Client.getEidForChain(fromChain);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of fee calculations for cross-chain Bitcoin transfers to non-Bitcoin destinations. Transaction quotes now correctly apply bridge fees to calculate final outputs and transaction costs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->