### PR TITLE
docs: add fusaka mainnet upgrade notice

### DIFF
--- a/docs/docs/docs/bob-chain/full-node.md
+++ b/docs/docs/docs/bob-chain/full-node.md
@@ -29,11 +29,6 @@ Nodes that are not upgraded correctly will stop syncing after activation.
 
 - Use existing external RPC nodes directly
 
-**Required Actions for Chain Operators**
-
-- **op-node**: Update to [v1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.16.2)
-- **op-geth**: Update to [v1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5)
-
 **More Info**
 For full details, please refer to the [Fusaka Upgrade Notice](https://docs.optimism.io/notices/fusaka-notice#for-node-operators)
 Feel free to reach out with any questions or concerns.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Confirmed Fusaka mainnet activation: December 3, 2025 21:49:11 UTC.
  * Updated node operator guidance with explicit mainnet upgrade requirements (op-node v1.16.2, op-geth v1.101603.5) and a clear "NO action required" note for other components.
  * Added warning that nodes not upgraded will stop syncing after activation.
  * Updated hardware requirement date and "More Info" link to the official Fusaka notice.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->