### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/docs/docs/docs/user-hub/networks.md
+++ b/docs/docs/docs/user-hub/networks.md
@@ -48,10 +48,10 @@ BOB Sepolia is the test network where you can experiment without risking real as
 
 To get testnet ETH for BOB Sepolia:
 
-1. Get BOB Sepolia ETH from a faucet:
-   - [ethfaucet.com](https://ethfaucet.com?utm_source=bob_docs&utm_medium=docs)
+- **Get BOB Sepolia ETH directly from a faucet:**
+  - [ethfaucet.com](https://ethfaucet.com?utm_source=bob_docs&utm_medium=docs)
   
-or
+- **Or, get Sepolia ETH and bridge it:**
 
 1. Get Sepolia ETH from a faucet:
    - [Alchemy Sepolia Faucet](https://sepoliafaucet.com/)


### PR DESCRIPTION
Description
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with 0.1 BOB Sepolia ETH for free, claimable once every 24 hours.

Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.