### PR TITLE
Fix: Add validation for missing transaction in `getMerkleProof`

### DIFF
--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -174,6 +174,11 @@ export function getMerkleProof(block: Block, txHash: string, forWitness?: boolea
     const txIds = block.transactions!.map((tx) => tx.getHash(forWitness));
     const pos = txIds.map((value) => value.toString('hex')).indexOf(txHash);
 
+    // Fail fast when the transaction is absent to avoid constructing an invalid proof.
+    if (pos < 0) {
+        throw new Error('Transaction not found in block');
+    }
+
     const merkleAndRoot = createMerkleBranchAndRoot(txIds, pos);
     return {
         pos: pos,


### PR DESCRIPTION


The `getMerkleProof` function in `sdk/src/utils.ts` doesn't validate whether the requested transaction exists in the block before constructing a Merkle proof. When `indexOf` returns `-1` (transaction not found), the function proceeds to build a proof using an invalid index, which can lead to:

- Incorrect Merkle proof generation
- Potential runtime errors when accessing array elements with negative indices
- Silent failures where invalid proofs are returned as valid results

