### PR TITLE
docs: add vercel.json for gateway api-reference

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -11,6 +11,14 @@
       "destination": "https://distributedcrafts.mintlify.app/_mintlify/api/request"
     },
     {
+      "source": "/api-reference",
+      "destination": "https://distributedcrafts.mintlify.app/api-reference"
+    },
+    {
+      "source": "/api-reference/:path*",
+      "destination": "https://distributedcrafts.mintlify.app/api-reference/:path*"
+    },
+    {
       "source": "/gateway",
       "destination": "https://distributedcrafts.mintlify.app/gateway"
     },


### PR DESCRIPTION
This pull request updates the Vercel rewrite rules to support routing for the API reference documentation. Two new rewrite rules are added to ensure that requests to `/api-reference` and any of its subpaths are correctly forwarded to the external documentation site.

Routing improvements:

* Added a rewrite rule to forward `/api-reference` requests to `https://distributedcrafts.mintlify.app/api-reference`.
* Added a rewrite rule to forward all `/api-reference/:path*` requests to the corresponding path on the external documentation site.