### PR TITLE
feat(gateway-cli): enriched error context on tx revert

### DIFF
--- a/gateway-cli/src/cli.ts
+++ b/gateway-cli/src/cli.ts
@@ -48,7 +48,7 @@ function withErrorHandling(fn: (...args: any[]) => Promise<void>) {
             const d = (err as any).dstAsset;
             console.error(`Route:    ${s.symbol}:${s.chain} → ${d.symbol}:${d.chain}`);
           }
-          if ("functionSelector" in err) console.error(`Selector: ${(err as any).functionSelector}`);
+          if ("functionSelector" in err && (err as any).functionSelector) console.error(`Selector: ${(err as any).functionSelector}`);
           if ("revertData" in err && (err as any).revertData) console.error(`Revert:   ${(err as any).revertData}`);
         }
       }

--- a/gateway-cli/src/cli.ts
+++ b/gateway-cli/src/cli.ts
@@ -28,10 +28,29 @@ function withErrorHandling(fn: (...args: any[]) => Promise<void>) {
         if (err instanceof Error) {
           if ("orderId" in err) errJson.error.orderId = (err as any).orderId;
           if ("txId" in err) errJson.error.txId = (err as any).txId;
+          if ("txParams" in err) errJson.error.txParams = (err as any).txParams;
+          if ("srcAsset" in err) errJson.error.srcAsset = (err as any).srcAsset;
+          if ("dstAsset" in err) errJson.error.dstAsset = (err as any).dstAsset;
+          if ("functionSelector" in err) errJson.error.functionSelector = (err as any).functionSelector;
+          if ("revertData" in err) errJson.error.revertData = (err as any).revertData;
         }
         console.log(JSON.stringify(errJson, null, 2));
       } else {
         console.error(msg);
+        if (err instanceof Error) {
+          if ("orderId" in err) console.error(`Order:    ${(err as any).orderId}`);
+          if ("txParams" in err) {
+            const tp = (err as any).txParams;
+            console.error(`Contract: ${tp.to} (${tp.chainName})`);
+          }
+          if ("srcAsset" in err && "dstAsset" in err) {
+            const s = (err as any).srcAsset;
+            const d = (err as any).dstAsset;
+            console.error(`Route:    ${s.symbol}:${s.chain} → ${d.symbol}:${d.chain}`);
+          }
+          if ("functionSelector" in err) console.error(`Selector: ${(err as any).functionSelector}`);
+          if ("revertData" in err && (err as any).revertData) console.error(`Revert:   ${(err as any).revertData}`);
+        }
       }
       process.exitCode = 1;
     }

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -182,13 +182,33 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
 
     const txInfo = (order as any)[variant]?.tx;
     if (!txInfo) throw new Error("Gateway did not return EVM transaction data for this order.");
-    txId = await walletClient.sendTransaction({
-      account: walletClient.account!,
-      chain: walletClient.chain,
-      to: txInfo.to as `0x${string}`,
-      data: txInfo.data as `0x${string}`,
-      value: BigInt(txInfo.value || "0"),
-    });
+    try {
+      txId = await walletClient.sendTransaction({
+        account: walletClient.account!,
+        chain: walletClient.chain,
+        to: txInfo.to as `0x${string}`,
+        data: txInfo.data as `0x${string}`,
+        value: BigInt(txInfo.value || "0"),
+      });
+    } catch (err) {
+      const enriched = err instanceof Error ? err : new Error(String(err));
+      (enriched as any).orderId = orderId;
+      (enriched as any).txParams = {
+        to: txInfo.to,
+        from: walletClient.account!.address,
+        value: txInfo.value || "0",
+        data: txInfo.data,
+        chainId: walletClient.chain!.id,
+        chainName: walletClient.chain!.name,
+      };
+      (enriched as any).srcAsset = { symbol: srcAsset.symbol, address: srcAsset.address, chain: srcAsset.chain };
+      (enriched as any).dstAsset = { symbol: dstAsset.symbol, address: dstAsset.address, chain: dstAsset.chain };
+      (enriched as any).functionSelector = typeof txInfo.data === "string" && txInfo.data.length >= 10 ? txInfo.data.slice(0, 10) : undefined;
+      // Extract revert data from viem error cause chain
+      const cause = (err as any)?.cause;
+      (enriched as any).revertData = cause?.data ?? undefined;
+      throw enriched;
+    }
   }
 
   // ── Register (retryable) ───────────────────────────────────────────────────

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -205,8 +205,14 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
       (enriched as any).dstAsset = { symbol: dstAsset.symbol, address: dstAsset.address, chain: dstAsset.chain };
       (enriched as any).functionSelector = typeof txInfo.data === "string" && txInfo.data.length >= 10 ? txInfo.data.slice(0, 10) : undefined;
       // Extract revert data from viem error cause chain
-      const cause = (err as any)?.cause;
-      (enriched as any).revertData = cause?.data ?? undefined;
+      // viem nests: TransactionExecutionError -> ExecutionRevertedError -> RpcRequestError (has .data)
+      let revertData: unknown;
+      let cursor: unknown = err;
+      while (cursor && typeof cursor === 'object') {
+        if ('data' in cursor && (cursor as any).data) { revertData = (cursor as any).data; break; }
+        cursor = (cursor as any).cause;
+      }
+      (enriched as any).revertData = revertData ?? undefined;
       throw enriched;
     }
   }

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -195,11 +195,11 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
       (enriched as any).orderId = orderId;
       (enriched as any).txParams = {
         to: txInfo.to,
-        from: walletClient.account!.address,
+        from: walletClient.account?.address,
         value: txInfo.value || "0",
         data: txInfo.data,
-        chainId: walletClient.chain!.id,
-        chainName: walletClient.chain!.name,
+        chainId: walletClient.chain?.id,
+        chainName: walletClient.chain?.name,
       };
       (enriched as any).srcAsset = { symbol: srcAsset.symbol, address: srcAsset.address, chain: srcAsset.chain };
       (enriched as any).dstAsset = { symbol: dstAsset.symbol, address: dstAsset.address, chain: dstAsset.chain };

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -298,7 +298,7 @@ describe("handleSwap", () => {
       chain: { id: 8453, name: "Base" },
       sendTransaction: vi.fn().mockRejectedValue(
         Object.assign(new Error("Execution reverted for an unknown reason."), {
-          cause: { data: "0xdeadbeef" },
+          cause: { cause: { data: "0xdeadbeef" } },
         })
       ),
     };

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -273,4 +273,76 @@ describe("handleSwap", () => {
     expect(mockCreateOrder).toHaveBeenCalledTimes(1);
   });
 
+  it("EVM sendTransaction revert attaches enriched context to error", async () => {
+    // Reconfigure mocks for an EVM offramp flow (not BTC onramp)
+    const { resolveSwapInputs } = await import("../../src/util/input-resolver.js");
+    (resolveSwapInputs as any).mockResolvedValue({
+      srcAsset: { chain: "base", address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 },
+      dstAsset: { chain: "bitcoin", address: "BTC", symbol: "BTC", decimals: 8 },
+      atomicUnits: "10000000",
+      display: "10 USDC",
+    });
+
+    const { parseAssetChain } = await import("../../src/util/input-resolver.js");
+    (parseAssetChain as any).mockImplementation((asset: string) =>
+      asset.includes("BTC") ? { chain: "bitcoin", address: "BTC", symbol: "BTC", decimals: 8 }
+                             : { chain: "base", address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 }
+    );
+
+    const { getChainFamily, resolveSigner, resolveRecipient } = await import("../../src/chains/index.js");
+    (getChainFamily as any).mockImplementation((chain: string) => chain === "bitcoin" ? "bitcoin" : "evm");
+    (resolveRecipient as any).mockResolvedValue("bc1qtest");
+
+    const mockWalletClient = {
+      account: { address: "0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb" },
+      chain: { id: 8453, name: "Base" },
+      sendTransaction: vi.fn().mockRejectedValue(
+        Object.assign(new Error("Execution reverted for an unknown reason."), {
+          cause: { data: "0xdeadbeef" },
+        })
+      ),
+    };
+    const mockPublicClient = {
+      getTransactionCount: vi.fn().mockResolvedValue(0),
+    };
+    (resolveSigner as any).mockResolvedValue({ walletClient: mockWalletClient, publicClient: mockPublicClient });
+
+    const mockOfframpQuote = {
+      offramp: {
+        inputAmount: { amount: "10000000", address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", chain: "base" },
+        outputAmount: { amount: "15000", address: "BTC", chain: "bitcoin" },
+        sender: "0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb",
+      },
+    };
+    const mockOfframpOrder = {
+      offramp: {
+        orderId: "revert-order-123",
+        tx: { to: "0x96C33FB0b058c341F5567b0b91E1Fc5F2E5cB1be", data: "0xe5c65df5aabbccdd", value: "369441375065843" },
+      },
+    };
+    mockGetQuote.mockResolvedValue(mockOfframpQuote);
+    mockCreateOrder.mockResolvedValue(mockOfframpOrder);
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    try {
+      await handleSwap({ ...baseOpts, src: "USDC:base", dst: "BTC", privateKey: "0xTestEvmKey" }, silentLogger);
+      expect.unreachable("should have thrown");
+    } catch (err: any) {
+      expect(err.message).toContain("Execution reverted");
+      expect(err.orderId).toBe("revert-order-123");
+      expect(err.txParams).toEqual({
+        to: "0x96C33FB0b058c341F5567b0b91E1Fc5F2E5cB1be",
+        from: "0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb",
+        value: "369441375065843",
+        data: "0xe5c65df5aabbccdd",
+        chainId: 8453,
+        chainName: "Base",
+      });
+      expect(err.srcAsset).toEqual({ symbol: "USDC", address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", chain: "base" });
+      expect(err.dstAsset).toEqual({ symbol: "BTC", address: "BTC", chain: "bitcoin" });
+      expect(err.functionSelector).toBe("0xe5c65df5");
+      expect(err.revertData).toBe("0xdeadbeef");
+    }
+  });
+
 });


### PR DESCRIPTION
## Summary
- Wrap `walletClient.sendTransaction()` in `swap.ts` with a try-catch that attaches orderId, txParams, srcAsset, dstAsset, functionSelector, and revertData to viem revert errors
- Walk the full viem cause chain to extract revert data (handles nested `TransactionExecutionError > ExecutionRevertedError > RpcRequestError`)
- Update `withErrorHandling` in `cli.ts` to format enriched properties in both JSON and human output modes
- JSON mode: all fields in error object for machine consumption (gateway-bot alert.ts)
- Human mode: labeled lines (Order, Contract, Route, Selector, Revert) for interactive debugging

## Test plan
- [x] Unit test: "EVM sendTransaction revert attaches enriched context to error" — verifies all 6 properties
- [x] Manual: run `gateway-cli swap --src USDC:base --dst BTC --amount 1USD --json` against staging, verify enriched JSON
- [x] Manual: same without `--json`, verify human-readable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)