### PR TITLE
docs: redirect legacy hashed BOB DAO Charter PDF URL

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "npx turbo-ignore --fallback=HEAD^1",
+  "redirects": [
+    {
+      "source": "/assets/files/bob-dao-charter-v1-0-82d9bf1cc29070c51df8965e9dba786c.pdf",
+      "destination": "/documents/bob-dao-charter-v1-0.pdf",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     {
       "source": "/_mintlify/:path*",


### PR DESCRIPTION
The old Docusaurus-hashed asset URL for the v1.0 charter is still linked from external sources; redirect it to the stable /documents/bob-dao-charter-v1-0.pdf path so existing links keep working.