### PR TITLE
docs: highlight Reown partnership in wallet docs

### DIFF
--- a/docs/gateway/gateway/integration.mdx
+++ b/docs/gateway/gateway/integration.mdx
@@ -241,7 +241,7 @@ const txId = await gatewaySDK.executeQuote({
 </CodeGroup>
 
 <Note>
-For detailed wallet integration options including sats-wagmi, Dynamic.xyz, and more, see the [Bitcoin Wallets](/gateway/wallets) guide.
+For detailed wallet integration options including Reown AppKit, sats-wagmi, Dynamic.xyz, and more, see the [Bitcoin Wallets](/gateway/wallets) guide.
 </Note>
 
 ## Monitor Orders

--- a/docs/gateway/gateway/wallets.mdx
+++ b/docs/gateway/gateway/wallets.mdx
@@ -12,6 +12,8 @@ To use BOB Gateway, your application needs to integrate Bitcoin wallet support s
 
 [Reown AppKit](https://reown.com/appkit) (formerly WalletConnect AppKit) provides a unified interface with broad wallet support including Unisat, Leather, Xverse, OKX, and more.
 
+BOB has partnered with Reown to improve Bitcoin wallet support tooling for WalletConnect / Reown.
+
 ### Installation
 
 <CodeGroup>


### PR DESCRIPTION
## Summary
- Mention Reown AppKit alongside sats-wagmi and Dynamic.xyz in the integration guide callout linking to the Bitcoin Wallets page.
- Note the BOB ↔ Reown partnership for improving Bitcoin wallet support tooling for WalletConnect / Reown in the Recommended: Reown AppKit section.

## Test plan
- [x] Render docs locally and confirm both pages display the updated copy correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)