### PR TITLE
chore: add callback property to execute quote method (#1064)

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "5.5.4",
+    "version": "5.5.5",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "repository": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -362,7 +362,7 @@ export class GatewayApiClient {
                     address: tokenAddress,
                     abi: isAddressEqual(tokenAddress, ETHEREUM_USDT_ADDRESS) ? USDTApproveAbi : erc20Abi,
                     functionName: 'approve',
-                    args: [spenderAddress, maxUint256],
+                    args: [spenderAddress, requiredAmount],
                 });
 
                 callback?.({ step: needsReset ? 2 : 1, type: ExecuteQuoteStepType.Approve, totalSteps });
@@ -455,7 +455,7 @@ export class GatewayApiClient {
                         address: tokenAddress,
                         abi: isAddressEqual(tokenAddress, ETHEREUM_USDT_ADDRESS) ? USDTApproveAbi : erc20Abi,
                         functionName: 'approve',
-                        args: [receiver, maxUint256],
+                        args: [receiver, requiredAmount],
                     });
 
                     callback?.({ step: needsReset ? 2 : 1, type: ExecuteQuoteStepType.Approve, totalSteps });
@@ -530,7 +530,7 @@ export class GatewayApiClient {
                 address: params.token,
                 abi: erc20Abi,
                 functionName: 'approve',
-                args: [params.strategyAddress, maxUint256],
+                args: [params.strategyAddress, BigInt(params.amount)],
             });
 
             const approveTxHash = await walletClient.writeContract(request);

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -783,7 +783,7 @@ describe('Gateway Tests', () => {
 
         expect(result.tx).toBe('0xtxhash');
         expect(simulateContractMock).toHaveBeenCalledTimes(1);
-        expect(simulateContractMock.mock.calls[0][0].args).toEqual([spenderAddress, maxUint256]);
+        expect(simulateContractMock.mock.calls[0][0].args).toEqual([spenderAddress, 1000n]);
         expect(mockWalletClient.writeContract).toHaveBeenCalledTimes(1);
     });
 
@@ -873,7 +873,7 @@ describe('Gateway Tests', () => {
         expect(result.tx).toBe('0xtxhash');
         expect(simulateContractMock).toHaveBeenCalledTimes(2);
         expect(simulateContractMock.mock.calls[0][0].args).toEqual([spenderAddress, 0n]);
-        expect(simulateContractMock.mock.calls[1][0].args).toEqual([spenderAddress, maxUint256]);
+        expect(simulateContractMock.mock.calls[1][0].args).toEqual([spenderAddress, 1000n]);
         expect(mockWalletClient.writeContract).toHaveBeenCalledTimes(2);
     });
 


### PR DESCRIPTION
* chore: add callback property to execute quote

* chore: 5.5.4-rc0

* Apply suggestion from @gemini-code-assist[bot]


* chore: run format

* chore: fix failing tests

* chore: version 5.5.4

---------