### PR TITLE
docs(gateway): add Fees & Refunds pages, drop onramp/offramp terminology

### DIFF
--- a/docs/gateway/api-reference/overview.mdx
+++ b/docs/gateway/api-reference/overview.mdx
@@ -30,7 +30,7 @@ V2 adds:
 - **`priceImpact` / `priceImpactUsd`** — exposed on all V2 quote variants.
 - **Paginated `GET /v2/get-orders`** — accepts `cursor` and `limit` query parameters and returns `{ orders: GatewayOrderInfoV2[], nextCursor: string | null }` instead of a bare array. Pass back `nextCursor` to fetch the next page; a null/missing value means there are no more orders.
 - **Settlement details in order status** — `success` and `refunded` statuses are now objects (`{ success: { received_tokens: [...] } }`, `{ refunded: { refunded_tokens: [...] } }`) where each token entry carries `chain`, `token`, `amount`, and the settlement `txHash`. In V1 these statuses were bare string enums and the destination `txHash` lived on `dstInfo`; V2 `dstInfo` no longer carries a `txHash`.
-- **`pending_btc_payment` on offramp in-progress orders** — `status.inProgress.pending_btc_payment` exposes the gateway's outgoing Bitcoin `{ txid, amount }` while it's still pending. The V1 `bump_fee_tx` field is no longer returned (the gateway manages BTC fee bumps internally).
+- **`pending_btc_payment` on in-progress X-to-BTC orders** — `status.inProgress.pending_btc_payment` exposes the gateway's outgoing Bitcoin `{ txid, amount }` while it's still pending. The V1 `bump_fee_tx` field is no longer returned (the gateway manages BTC fee bumps internally).
 
 ## Authentication
 
@@ -71,8 +71,8 @@ Gateway transactions follow a 7-step flow to execute Bitcoin↔chain swaps and E
 
   <Step title="Create an Order">
     Pass the quote to `POST /v2/create-order` to lock in the quote and create an order. This reserves liquidity with the market maker and returns transaction details including:
-    - For **onramp** (Bitcoin → chain): A Bitcoin address to send to, or a PSBT to sign.
-    - For **offramp** (chain → Bitcoin): EVM transaction data to execute.
+    - For **BTC to X** (`onramp`, Bitcoin → chain): A Bitcoin address to send to, or a PSBT to sign.
+    - For **X to BTC** (`offramp`, chain → Bitcoin): EVM transaction data to execute.
     - For **tokenSwap** (EVM → EVM): EVM transaction data to execute.
 
     ```bash
@@ -83,8 +83,8 @@ Gateway transactions follow a 7-step flow to execute Bitcoin↔chain swaps and E
 
   <Step title="Sign and Send Transaction">
     Execute the transaction:
-    - For **onramp**: Create and sign a Bitcoin transaction to the provided address, or use the provided PSBT.
-    - For **offramp** or **tokenSwap**: Sign and broadcast the EVM transaction using the provided transaction data.
+    - For **BTC to X** (`onramp`): Create and sign a Bitcoin transaction to the provided address, or use the provided PSBT.
+    - For **X to BTC** (`offramp`) or **tokenSwap**: Sign and broadcast the EVM transaction using the provided transaction data.
   </Step>
 
   <Step title="Register Transaction">

--- a/docs/gateway/docs.json
+++ b/docs/gateway/docs.json
@@ -22,6 +22,13 @@
             ]
           },
           {
+            "group": "Concepts",
+            "pages": [
+              "gateway/fees",
+              "gateway/refunds"
+            ]
+          },
+          {
             "group": "Integration",
             "pages": [
               "gateway/integration",

--- a/docs/gateway/gateway/faq.mdx
+++ b/docs/gateway/gateway/faq.mdx
@@ -13,7 +13,7 @@ The Relayer estimates gas costs upfront and deducts them from the transaction. U
 </Accordion>
 
 <Accordion icon="triangle-exclamation" title="What happens if my DeFi action fails?">
-Gateway automatically falls back to sending the wrapped BTC directly to the user's EVM address. Always test thoroughly to avoid fallbacks.
+Gateway falls back to sending wrapped BTC directly to the user's EVM address, so the user still receives value. Always test thoroughly to avoid fallbacks. See [Refunds](/gateway/refunds) for details.
 </Accordion>
 
 <Accordion icon="wallet" title="Do I need Bitcoin wallet support?">
@@ -32,7 +32,7 @@ Yes! Custom strategies can interact with multiple protocols in sequence. For exa
 </Accordion>
 
 <Accordion icon="money-bill" title="How does affiliate fee monetization work?">
-You can earn fees on every transaction which is linked to your affiliate ID. The fee is deducted from the user's input amount and sent directly to you.
+You earn a configurable basis-point fee on every swap linked to your affiliate address, paid out in USDT on Ethereum. See [Fees](/gateway/fees) for the model and the [affiliate integration guide](/gateway/integration#monetization-affiliate-fees) for code.
 </Accordion>
 
 <Accordion icon="clock" title="How long do transactions take?">
@@ -45,18 +45,18 @@ The quote response includes an `estimatedTimeInSecs` field with the expected dur
 </Accordion>
 
 <Accordion icon="arrows-rotate" title="What happens if Bitcoin fees spike after I submit?">
-For offramp transactions, you can bump the transaction fee to speed up confirmation if Bitcoin network fees increase.
+For X-to-BTC transactions, the Bitcoin payout can be bumped to speed up confirmation if network fees increase. See [Refunds](/gateway/refunds).
 </Accordion>
 
 <Accordion icon="xmark" title="Can I cancel a transaction?">
-For offramp transactions, you can unlock an order if it gets stuck. This is irreversible - once unlocked, the order cannot be resumed.
+For X-to-BTC orders, you can reclaim locked funds if an order gets stuck. This is irreversible — once unlocked, the order cannot be resumed. See [Refunds](/gateway/refunds).
 </Accordion>
 
 <Accordion icon="code-branch" title="What chains are supported?">
 Gateway supports:
 - **Bitcoin** → BOB (mainnet)
 - **Bitcoin** → Ethereum, Base, Arbitrum, Optimism (via LayerZero)
-- **BOB** → Bitcoin (offramp)
+- **BOB** → Bitcoin (X to BTC)
 
 Check `getRoutes()` for the complete list of available routes.
 </Accordion>
@@ -68,13 +68,7 @@ View audit reports: [docs.gobob.xyz/docs/reference/audits](https://docs.gobob.xy
 </Accordion>
 
 <Accordion icon="money-check-dollar" title="What are the fees?">
-Fees include:
-- **Protocol fees**: Fees applied by the protocol for processing and routing the swaps. Currently fees are set to merely cover routing and gas costs, with 0 markup. In the future, the BOB DAO may vote to activate a fee markup. Then, collected revenues will go to the BOB DAO treasury.
-- **Solver spread**: Solvers compete to offer the best quotes, typically charging a spread of a few basis points (1-20bps on average depending on the route and Solver). BOB Gateway automatically picks the best quote for each swap.
-- **Broker fees**: Most wallets and web apps apply a "convenience" fee for processing swaps. These are deducted from the swapped amount, on-chain by the protocol smart contracts.
-- **Gas costs**: The gas costs of the destination chain are included in the swap processing fees. The gas costs of the source chain (the chain where the swap was initiated) are handled out-of-protocol by the wallet.
-
-All fees are shown transparently in the quote response.
+A Gateway swap has a protocol fee, a solver spread, optional affiliate fees, and destination gas — all shown transparently in the quote response. See [Fees](/gateway/fees) for the full breakdown.
 </Accordion>
 
 <Accordion icon="ban" title="Are any regions blocked from using Gateway?">

--- a/docs/gateway/gateway/fees.mdx
+++ b/docs/gateway/gateway/fees.mdx
@@ -1,0 +1,65 @@
+---
+title: "Fees"
+description: "How Gateway fees work — protocol fees, solver spread, affiliate fees, and gas"
+icon: "money-check-dollar"
+---
+
+## Overview
+
+Every Gateway quote is fully costed before the user signs anything. The `getQuote` response breaks each fee out individually so you can show the user exactly what they're paying — in V2 every fee line also carries an optional `usd` value for display.
+
+A Gateway swap has four kinds of fees.
+
+## Protocol fee
+
+Fees applied by the protocol for processing and routing swaps. Today these are set to merely cover routing and gas costs, with **0 markup**. In the future, the BOB DAO may vote to activate a fee markup; collected revenue would then go to the BOB DAO treasury.
+
+## Solver spread
+
+Solvers compete to fill each order and quote a spread — typically a few basis points (around 1–20 bps depending on the route and the solver). Gateway automatically selects the best quote for every swap, so the user always gets the most competitive price available.
+
+## Affiliate fees
+
+Affiliate fees are your revenue share: a basis-point cut of each swap, routed to one or more EVM addresses you control. This is how integrators monetize Gateway.
+
+<Info>
+**Affiliate fees are paid out in USDT on Ethereum as part of each swap** — regardless of which route the user swapped. One basis point (`1 bps`) is `0.01%`, so `50 bps` is `0.50%`.
+</Info>
+
+You configure affiliate fees **per quote** — there's no upfront registration. Pass one or more `{ address, bps }` pairs when you request a quote, and the fee is deducted as part of the swap and paid to your address(es) on settlement. V2 supports splitting the fee across multiple recipients in a single quote — useful for revenue splits between an aggregator and an underlying integrator, referral programs, or multi-party agreements.
+
+Routes that don't support affiliate fees return the error code `AFFILIATE_FEES_NOT_SUPPORTED_FOR_ROUTE`; handle it by retrying the quote without affiliates or surfacing the error to the user.
+
+For the SDK and raw-API code — single recipient, multi-recipient splits, reading the resolved fee back from the quote, and the format rules — see [Monetization (Affiliate Fees)](/gateway/integration#monetization-affiliate-fees) in the integration guide.
+
+## Gas costs
+
+The gas cost of the **destination** chain is included in the swap processing fees and estimated upfront, so users don't need to hold the destination gas token (for BTC-to-X swaps, users don't need ETH on BOB). The gas cost of the **source** chain — the chain where the swap is initiated — is handled out-of-protocol by the wallet.
+
+## Seeing fees in the quote
+
+All fees are returned on the quote so you can display them before the user commits:
+
+```typescript
+const quote = await gatewaySDK.getQuote({ /* ... */ });
+
+if ('onramp' in quote) {
+  // each feeBreakdown line is a GatewayTokenAmountV2 (optional .usd)
+  console.log('Fees:', quote.onramp.feeBreakdown);
+
+  for (const a of quote.onramp.affiliates ?? []) {
+    console.log(`Affiliate ${a.address}: ${a.fee.amount}` + (a.fee.usd ? ` (~$${a.fee.usd})` : ''));
+  }
+}
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Affiliate fee integration" icon="code" href="/gateway/integration#monetization-affiliate-fees">
+    Code examples for configuring affiliate fees via the SDK and raw API
+  </Card>
+  <Card title="Refunds" icon="arrow-rotate-left" href="/gateway/refunds">
+    What happens when a swap can't be completed
+  </Card>
+</CardGroup>

--- a/docs/gateway/gateway/integration.mdx
+++ b/docs/gateway/gateway/integration.mdx
@@ -6,7 +6,7 @@ icon: "code"
 
 ## Overview
 
-The BOB Gateway SDK makes it easy to bring Bitcoin onramp functionality directly into your app. This guide walks through the complete integration process.
+The BOB Gateway SDK makes it easy to bring native BTC swaps directly into your app. This guide walks through the complete integration process.
 
 We recommend using the API directly, but you may use our SDK for convenience.
 
@@ -24,7 +24,7 @@ V2 adds:
 - **Price impact** — V2 quotes expose `priceImpact` (fraction) and `priceImpactUsd` for display.
 - **Paginated `getOrders`** — `getOrders` now accepts `{ userAddress, cursor?, limit? }` and returns `{ orders, nextCursor }` instead of a bare array. Pass back `nextCursor` to fetch the next page; a null/missing value means you've reached the end ([details](#monitor-orders)).
 - **Order settlement details in status** — `success` and `refunded` are now objects carrying `receivedTokens` / `refundedTokens` (each entry has `chain`, `token`, `amount`, and the settlement `txHash`). In V1 these statuses were bare strings, and the destination `txHash` lived on `dstInfo`; in V2 `dstInfo` no longer carries a `txHash` — read it from the status payload instead.
-- **`pendingBtcPayment` on offramp orders** — while an offramp order is in progress, `status.inProgress.pendingBtcPayment` exposes the gateway's outgoing Bitcoin `{ txid, amount }` so you can show the user the pending payout. This replaces the V1 `bumpFeeTx` field, which is no longer returned.
+- **`pendingBtcPayment` on X-to-BTC orders** — while an X-to-BTC order is in progress, `status.inProgress.pendingBtcPayment` exposes the gateway's outgoing Bitcoin `{ txid, amount }` so you can show the user the pending payout. This replaces the V1 `bumpFeeTx` field, which is no longer returned.
 
 ## Installation
 
@@ -92,7 +92,7 @@ Request a quote for the user's desired transaction:
 
 <CodeGroup>
 
-```typescript Basic Onramp
+```typescript BTC to BOB
 import { parseBtc } from '@gobob/bob-sdk';
 import { parseEther } from 'viem';
 
@@ -154,13 +154,13 @@ The `getQuote` response is a discriminated union — access fields through the a
 const quote = await gatewaySDK.getQuote({ /* ... */ });
 
 if ('onramp' in quote) {
-  // Bitcoin → BOB/EVM onramp
+  // BTC to BOB/EVM
   console.log('Input:', quote.onramp.inputAmount);          // GatewayTokenAmountV2 (has optional .usd)
   console.log('Fees:', quote.onramp.feeBreakdown);          // each line is GatewayTokenAmountV2
   console.log('Price impact:', quote.onramp.priceImpact);   // optional, fraction e.g. "-0.05"
   console.log('ETA:', quote.onramp.estimatedTimeInSecs, 'seconds');
 } else if ('offramp' in quote) {
-  // BOB/EVM → Bitcoin offramp
+  // EVM to BTC
   console.log('Input:', quote.offramp.inputAmount);
   console.log('Fees:', quote.offramp.feeBreakdown);
   console.log('Price impact:', quote.offramp.priceImpact);
@@ -330,15 +330,15 @@ do {
 `order.dstInfo.amount` is the *estimated* output recorded when the order was created. The settled amount and destination `txHash` are reported on `status.success.receivedTokens` (or `status.refunded.refundedTokens`) once the order resolves.
 </Tip>
 
-## Offramp Features
+## X to BTC Order Features
 
-For offramp (BOB → Bitcoin) orders, `getOrders` surfaces V2 status fields you can act on while the order is still in progress:
+For X-to-BTC (BOB → Bitcoin) orders, `getOrders` surfaces V2 status fields you can act on while the order is still in progress:
 
 <AccordionGroup>
 
 <Accordion icon="clock" title="Track the Pending BTC Payout">
 
-While the gateway is settling an offramp, `status.inProgress.pendingBtcPayment` carries the outgoing Bitcoin transaction `{ txid, amount }`. Use it to show the user a "payout in flight" state and link to a block explorer:
+While the gateway is settling an X-to-BTC order, `status.inProgress.pendingBtcPayment` carries the outgoing Bitcoin transaction `{ txid, amount }`. Use it to show the user a "payout in flight" state and link to a block explorer:
 
 ```typescript
 const { orders } = await gatewaySDK.getOrders({ userAddress: userEvmAddress });
@@ -401,9 +401,9 @@ Gateway supports affiliate fees out of the box. You can route a basis-point (bps
 
 ### How it works
 
-Affiliate fees are basis-point cuts of the swap output, deducted at settlement and sent to the recipient addresses you specify. You set them per-quote via the SDK's `affiliates` parameter — an array of `{ address, bps }` pairs (the raw API serialises these as the comma-separated `affiliates` query parameter on `GET /v2/get-quote`).
+Affiliate fees are basis-point cuts of each swap, deducted at settlement and **paid out in USDT on Ethereum** to the recipient addresses you specify, regardless of the route. You set them per-quote via the SDK's `affiliates` parameter — an array of `{ address, bps }` pairs (the raw API serialises these as the comma-separated `affiliates` query parameter on `GET /v2/get-quote`).
 
-`1 bps = 0.01%`, so `50` means `0.50%`.
+`1 bps = 0.01%`, so `50` means `0.50%`. For the full fee model, see [Fees](/gateway/fees).
 
 ### Single recipient
 

--- a/docs/gateway/gateway/overview.mdx
+++ b/docs/gateway/gateway/overview.mdx
@@ -97,7 +97,7 @@ It is currently offers the cheapest rates for BTC↔stablecoin (USDT, USDC), BTC
     Enable native BTC swaps into Tether Gold (XAUT) and PAX Gold (PAXG) on Ethereum.
   </Card>
 
-  <Card title="BTC ↔ wBTC on and off ramping" icon="arrows-split-up-and-left">
+  <Card title="BTC ↔ wBTC" icon="arrows-split-up-and-left">
     Offer wBTC delivery via a single native BTC transaction.
   </Card>
 

--- a/docs/gateway/gateway/refunds.mdx
+++ b/docs/gateway/gateway/refunds.mdx
@@ -1,0 +1,67 @@
+---
+title: "Refunds"
+description: "How Gateway refunds work when a swap can't be completed"
+icon: "arrow-rotate-left"
+---
+
+## Overview
+
+Gateway is non-custodial. Swaps are atomic and secured by an on-chain Bitcoin Light Client, so a solver can never take a user's funds without delivering the other side of the swap. If a swap can't be completed, the user gets their funds back. This page explains when and how that happens.
+
+## When a refund happens
+
+There are two situations where funds are returned instead of the expected output:
+
+- **A DeFi action fails (BTC to X).** When a swap includes a strategy or DeFi action — staking, lending, a multicall — and that on-chain action reverts, Gateway falls back to delivering wrapped BTC directly to the user's EVM address rather than failing the whole swap. The user still receives value; they just receive wrapped BTC instead of the intended position.
+
+- **An order gets stuck or can't be filled.** If no solver completes the order — for example a solver goes offline, or an X-to-BTC payout is never made — the locked funds can be reclaimed. The order status carries a `refundTx` you submit to unlock them.
+
+## BTC to X refunds
+
+For BTC-to-X swaps, refunds take the form of the **fallback** described above: if the destination action fails, the user receives wrapped BTC on their EVM address instead. There's no separate reclaim step — Gateway delivers the fallback asset automatically once the Bitcoin payment is verified.
+
+<Tip>
+Always test strategies thoroughly on testnet. A fallback means the user received wrapped BTC rather than the position they intended to open.
+</Tip>
+
+## X to BTC refunds
+
+For X-to-BTC swaps, the user first locks wrapped BTC in a Gateway contract while a solver fulfils the Bitcoin payout. If the payout doesn't happen, the user has two options:
+
+1. **Bump the fee.** If Bitcoin network fees spiked after the order was created, the payout can be sped up. In V2 the gateway manages BTC fee bumps internally for the payout it broadcasts.
+2. **Reclaim the locked funds.** After a claim-delay period, the user can unlock their wrapped BTC and have it returned.
+
+<Warning>
+Reclaiming is irreversible. Once an order is refunded/unlocked, it cannot be resumed.
+</Warning>
+
+<Note>
+Because users cannot currently submit Bitcoin proofs themselves, an order may be temporarily "stuck" if the relayer is offline. Funds remain safe and become reclaimable — they cannot be taken by the relayer or a solver.
+</Note>
+
+## Refund status in the API
+
+A completed refund shows up as the `refunded` order status, which lists the `refundedTokens` actually returned (each with `chain`, `token`, `amount`, and the settlement `txHash`). While an order is still in progress or has failed, a `refundTx` may be available to trigger the reclaim:
+
+- `status.inProgress.refundTx` — refund available on an in-progress order
+- `status.failed.refundTx` — refund available on a failed order
+- `status.refunded.refundedTokens` — the completed refund
+
+## Issuing a refund
+
+When a `refundTx` is present, submit it as a normal EVM transaction to reclaim the locked assets. See the step-by-step code in the integration guide:
+
+<Card title="Refund stuck orders" icon="unlock" href="/gateway/integration#x-to-btc-order-features" horizontal>
+  Detect a refundable order and submit its refundTx
+</Card>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Fees" icon="money-check-dollar" href="/gateway/fees">
+    The full Gateway fee breakdown
+  </Card>
+  <Card title="Deep Dive" icon="lightbulb" href="/gateway/technical">
+    How verification and settlement work end to end
+  </Card>
+</CardGroup>

--- a/docs/gateway/gateway/technical.mdx
+++ b/docs/gateway/gateway/technical.mdx
@@ -8,7 +8,7 @@ icon: "lightbulb"
 
 BOB Gateway is an intent-based bridge that enables Bitcoin users to access DeFi protocols with a single Bitcoin transaction. The protocol coordinates peer-to-peer swaps between users and Solvers secured by an on-chain Bitcoin Light Client.
 
-## Onramp: Bitcoin → BOB
+## BTC to X (Bitcoin → BOB)
 
 <Steps>
   <Step title="Liquidity">
@@ -46,7 +46,7 @@ BOB Gateway is an intent-based bridge that enables Bitcoin users to access DeFi 
 
 ### Architecture Diagram
 
-The onramp process involves trustless coordination between Bitcoin, the Relayer, and BOB:
+The BTC-to-X process involves trustless coordination between Bitcoin, the Relayer, and BOB:
 
 ```mermaid
 sequenceDiagram
@@ -69,11 +69,11 @@ sequenceDiagram
     Gateway->>User: Execute intent & send tokens
 ```
 
-## Offramp: BOB → Bitcoin
+## X to BTC (BOB → Bitcoin)
 
 <Steps>
   <Step title="Registration">
-    Solvers register their address and fund it with native Bitcoin (BTC) to fulfill offramp orders.
+    Solvers register their address and fund it with native Bitcoin (BTC) to fulfill X-to-BTC orders.
   </Step>
   
   <Step title="User Creates Order">


### PR DESCRIPTION
## Why

An integrator asked for more "how it works" context in the Gateway docs (beyond API/SDK call details) and flagged that search works poorly because key content is hidden inside FAQ accordions. This addresses the concrete asks: a refunds explanation, an expanded fee/affiliate explanation, and the editorial cleanup of "onramp/offramp".

## What

**New searchable Concept pages** (the FAQ-accordion fix)
- **`gateway/fees.mdx`** — full fee model: protocol fee, solver spread, affiliate fees, gas. States plainly that **affiliate fees are paid out in USDT on Ethereum as part of each swap**, regardless of route, and links to the affiliate code in the integration guide.
- **`gateway/refunds.mdx`** — how refunds actually work (previously only a buried code snippet): the BTC-to-X DeFi-action fallback to wrapped BTC; the X-to-BTC locked-funds reclaim with claim delay + irreversibility; the relayer-offline caveat; the `refunded` order status; links to the existing refund code.
- **`docs.json`** — new **Concepts** nav group (Fees, Refunds).

**FAQ trimmed to pointers** — the four big-topic accordions ("What are the fees?", "How does affiliate fee monetization work?", "What happens if my DeFi action fails?", "Can I cancel a transaction?") are now one-liners linking to the new pages, so the substance is indexable by search.

**Terminology** — replaced "onramp"/"offramp" in prose and headings with "BTC to X" / "X to BTC" across `overview`, `technical`, `integration`, `faq`, and the API reference. Literal API/JSON/route identifiers (`'onramp' in quote`, `{ "onramp": ... }`, `OfframpRegistry`, etc.) are kept and glossed on first use.

## Scope notes
- A "calling Gateway from a smart contract" page was requested but **deferred** for now per discussion.
- Affiliate-fee currency is documented as USDT on Ethereum: the backend denominates the fee in the inventory/routing token, but the current Ethereum + USDT-routing deployment makes it always USDT on Ethereum (confirmed with the team).

## Validation
- `mint broken-links` passes — new pages, nav group, and cross-link anchors (`#monetization-affiliate-fees`, `#x-to-btc-order-features`) all resolve.
- `docs.json` is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)