### PR TITLE
fix(docs): serve supported-routes in geoblocked regions + add missing chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Cargo.lock
 # Superpowers / plans
 docs/plans/
 docs/superpowers/
+
+# Vercel
+.vercel

--- a/docs/api/get-routes.ts
+++ b/docs/api/get-routes.ts
@@ -1,6 +1,10 @@
 const UPSTREAM = "https://gateway-api-mainnet.gobob.xyz/v2/get-routes";
 
 export default async function handler(req: any, res: any) {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
   try {
     const upstream = await fetch(UPSTREAM);
     if (!upstream.ok) {
@@ -9,7 +13,8 @@ export default async function handler(req: any, res: any) {
     }
     const data = await upstream.json();
     res.status(200).json(data);
-  } catch {
+  } catch (err) {
+    console.error("get-routes proxy error:", err);
     res.status(502).json({ error: "Failed to fetch routes" });
   }
 }

--- a/docs/api/get-routes.ts
+++ b/docs/api/get-routes.ts
@@ -1,0 +1,15 @@
+const UPSTREAM = "https://gateway-api-mainnet.gobob.xyz/v2/get-routes";
+
+export default async function handler(req: any, res: any) {
+  try {
+    const upstream = await fetch(UPSTREAM);
+    if (!upstream.ok) {
+      res.status(502).json({ error: "Failed to fetch routes" });
+      return;
+    }
+    const data = await upstream.json();
+    res.status(200).json(data);
+  } catch {
+    res.status(502).json({ error: "Failed to fetch routes" });
+  }
+}

--- a/docs/gateway/gateway/supported-routes.mdx
+++ b/docs/gateway/gateway/supported-routes.mdx
@@ -4,7 +4,7 @@ description: "All supported chains and token routes available through the BOB Ga
 icon: "route"
 ---
 
-export const ROUTES_API = "https://gateway-api-mainnet.gobob.xyz/v2/get-routes";
+export const ROUTES_API = "/api/get-routes";
 export const TOKENLIST_URL = "https://raw.githubusercontent.com/bob-collective/tokenlist/main/tokenlist.json";
 export const NON_EVM = { bitcoin: "BTC" };
 export const CHAIN_LABELS = { bsc: "BSC", bob: "BOB" };
@@ -47,7 +47,7 @@ export const SupportedRoutes = () => {
       fetch(ROUTES_API).then((r) => r.json()).catch(() => null),
       fetch(TOKENLIST_URL).then((r) => r.json()).then((d) => d.tokens).catch(() => []),
     ]).then(([routeData, tokens]) => {
-      if (!routeData) {
+      if (!Array.isArray(routeData)) {
         setError(true);
         return;
       }

--- a/docs/gateway/gateway/supported-routes.mdx
+++ b/docs/gateway/gateway/supported-routes.mdx
@@ -9,24 +9,32 @@ export const TOKENLIST_URL = "https://raw.githubusercontent.com/bob-collective/t
 export const NON_EVM = { bitcoin: "BTC" };
 export const CHAIN_LABELS = { bsc: "BSC", bob: "BOB" };
 export const CHAIN_IDS = {
+  arbitrum: 42161,
   avalanche: 43114,
   base: 8453,
   bera: 80094,
   bob: 60808,
   bsc: 56,
   ethereum: 1,
+  hyperliquid: 999,
+  plasma: 9745,
+  polygon: 137,
   sei: 1329,
   soneium: 1868,
   sonic: 146,
   unichain: 130,
 };
 export const EXPLORERS = {
+  arbitrum: "https://arbiscan.io",
   avalanche: "https://snowscan.xyz",
   base: "https://basescan.org",
   bera: "https://berascan.com",
   bob: "https://explorer.gobob.xyz",
   bsc: "https://bscscan.com",
   ethereum: "https://etherscan.io",
+  hyperliquid: "https://hyperevmscan.io",
+  plasma: "https://plasmascan.to",
+  polygon: "https://polygonscan.com",
   sei: "https://seitrace.com",
   soneium: "https://soneium.blockscout.com",
   sonic: "https://sonicscan.org",

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "npx turbo-ignore --fallback=HEAD^1",
+  "regions": ["fra1"],
   "redirects": [
     {
       "source": "/assets/files/bob-dao-charter-v1-0-82d9bf1cc29070c51df8965e9dba786c.pdf",


### PR DESCRIPTION
## Summary

Two fixes to the Gateway **Supported Routes & Assets** docs page (`docs.gobob.xyz/gateway/supported-routes`):

### 1. Make the page work inside geoblocked regions
The page fetched the routes list **client-side** from `gateway-api-mainnet.gobob.xyz`, which geoblocks US/OFAC regions by the *caller's* IP — so visitors in blocked regions saw "Routes could not be loaded."

- Add a Vercel serverless proxy `docs/api/get-routes.ts`, pinned to **Frankfurt (`fra1`)** via `regions` in `vercel.json`, so the gateway API sees the function's IP (allowed) instead of the visitor's. Same origin → no CORS.
- The MDX now fetches the same-origin `/api/get-routes`; tokenlist fetch stays client-side (not geoblocked).
- Proxy rejects non-GET, logs upstream failures, returns `502` on error. Guard added so a non-array response cleanly shows the error state.

### 2. Resolve symbols + explorer links for the four missing chains
`arbitrum`, `hyperliquid`, `plasma`, and `polygon` appear in the live routes feed but were absent from the page's `CHAIN_IDS` / `EXPLORERS` maps, so their tokens rendered as bare truncated addresses. Added the four entries to each map (verified every route token resolves a symbol in the tokenlist under its standard chain ID).

## Notes
- The maps remain hand-maintained: the routes API returns chain *slugs* not chain IDs, and neither viem nor the tokenlist's published JSON supplies the slug→chainId + explorer data. Eliminating the maps would require the gateway API to return `chainId` + `explorerUrl` per chain (not done here).

## Test Plan
- [ ] Preview deploy: `GET /api/get-routes` returns the routes array (from `fra1`).
- [ ] Page renders all route tables in a non-blocked region.
- [ ] Tables now load in a blocked region (VPN) where they previously failed.
- [ ] Arbitrum/Hyperliquid/Plasma/Polygon rows show symbols (USDC/WBTC/USD₮0/USDT0) and working explorer links.
- [ ] Confirm the `docs` Vercel project plan supports region pinning (Pro/Enterprise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)