### PR TITLE
docs(gateway): add arbitrum, hyperliquid, plasma, polygon to supported-routes maps

### DIFF
--- a/docs/gateway/gateway/supported-routes.mdx
+++ b/docs/gateway/gateway/supported-routes.mdx
@@ -9,24 +9,32 @@ export const TOKENLIST_URL = "https://raw.githubusercontent.com/bob-collective/t
 export const NON_EVM = { bitcoin: "BTC" };
 export const CHAIN_LABELS = { bsc: "BSC", bob: "BOB" };
 export const CHAIN_IDS = {
+  arbitrum: 42161,
   avalanche: 43114,
   base: 8453,
   bera: 80094,
   bob: 60808,
   bsc: 56,
   ethereum: 1,
+  hyperliquid: 999,
+  plasma: 9745,
+  polygon: 137,
   sei: 1329,
   soneium: 1868,
   sonic: 146,
   unichain: 130,
 };
 export const EXPLORERS = {
+  arbitrum: "https://arbiscan.io",
   avalanche: "https://snowscan.xyz",
   base: "https://basescan.org",
   bera: "https://berascan.com",
   bob: "https://explorer.gobob.xyz",
   bsc: "https://bscscan.com",
   ethereum: "https://etherscan.io",
+  hyperliquid: "https://hyperevmscan.io",
+  plasma: "https://plasmascan.to",
+  polygon: "https://polygonscan.com",
   sei: "https://seitrace.com",
   soneium: "https://soneium.blockscout.com",
   sonic: "https://sonicscan.org",


### PR DESCRIPTION
## Summary

The **Supported Routes & Assets** page (`docs.gobob.xyz/gateway/supported-routes`) resolves each token's **symbol** via `CHAIN_IDS[chain]` (→ tokenlist key `chainId:address`) and its **explorer link** via `EXPLORERS[chain]`. Four chains present in the live `/v2/get-routes` feed were missing from both maps — `arbitrum`, `hyperliquid`, `plasma`, `polygon` — so their tokens rendered as bare truncated addresses with no symbol and no link.

This adds the four entries to each map (alphabetically). No logic changes — `sym()` / `addressCell()` already handle these chains once the maps are populated.

Verified every route token for the four chains resolves a symbol in the tokenlist under its standard chain ID:
- arbitrum (42161): USDC, WBTC, USD₮0
- hyperliquid (999): USD₮0 → explorer `hyperevmscan.io`
- plasma (9745): USDT0 → explorer `plasmascan.to`
- polygon (137): USDT0 → explorer `polygonscan.com`

## Test Plan
- [ ] On the deployed page, Arbitrum/Hyperliquid/Plasma/Polygon rows show token symbols (USDC/WBTC/USD₮0/USDT0) and working explorer links instead of bare addresses.
- [ ] Other chains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)