### PR TITLE
fix(gateway-cli): don't crash on non-EVM (Tron) token addresses in routes

### DIFF
--- a/gateway-cli/package.json
+++ b/gateway-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/gateway-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "CLI for bridging Bitcoin to/from EVM chains via BOB Gateway",
   "repository": {
     "type": "git",

--- a/gateway-cli/src/chains/evm.ts
+++ b/gateway-cli/src/chains/evm.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, createWalletClient, http, erc20Abi, isAddressEqual, isHex, type WalletClient, type PublicClient, type Hex, type Chain } from 'viem';
+import { createPublicClient, createWalletClient, http, erc20Abi, isAddress, isAddressEqual, isHex, type WalletClient, type PublicClient, type Hex, type Chain } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { supportedChainsMapping, getChainConfig } from '@gobob/bob-sdk';
 import tokenlistJson from '@gobob/tokenlist/tokenlist.json';
@@ -129,7 +129,12 @@ const ZERO_ADDR = "0x0000000000000000000000000000000000000000" as `0x${string}`;
  * Native tokens have no contract address (represented by zero address or undefined).
  */
 function isNativeToken(tokenAddress?: string): boolean {
-  return !tokenAddress || isAddressEqual(tokenAddress as `0x${string}`, ZERO_ADDR);
+  if (!tokenAddress) return true;
+  // Non-EVM addresses (e.g. Tron base58 tokens from Tron routes) are never the
+  // EVM native token. Guard here — isAddressEqual throws on non-EVM input, which
+  // would otherwise abort the whole swap instead of skipping the foreign route.
+  if (!isAddress(tokenAddress, { strict: false })) return false;
+  return isAddressEqual(tokenAddress as `0x${string}`, ZERO_ADDR);
 }
 
 /**

--- a/gateway-cli/tests/chains/evm.test.ts
+++ b/gateway-cli/tests/chains/evm.test.ts
@@ -60,9 +60,30 @@ vi.mock("../../src/util/rpc-resolver.js", () => ({
 
 // ─── Import after mocks ─────────────────────────────────────────────────────
 
-import { getEvmBalances, NATIVE_GAS_BUFFER } from "../../src/chains/evm.js";
+import { getEvmBalances, NATIVE_GAS_BUFFER, getTokenMetadata } from "../../src/chains/evm.js";
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("getTokenMetadata", () => {
+  // Regression: now that Tron routes exist, the gateway returns Tron (base58)
+  // token addresses in the shared routes/quote list. getTokenMetadata must never
+  // hand a non-EVM address to viem — viem throws an InvalidAddressError that
+  // aborts the entire swap, taking down unrelated EVM/BTC legs. It must instead
+  // fail as a clean "Unknown token" so callers (buildTokenIndex) can skip the
+  // Tron route and still resolve the requested pair.
+  const TRON_USDT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+
+  it("treats a non-EVM (Tron) token address as unknown, not a viem error", () => {
+    expect(() => getTokenMetadata(TRON_USDT, "tron")).toThrow(/Unknown token/);
+    expect(() => getTokenMetadata(TRON_USDT, "tron")).not.toThrow(/is invalid/);
+  });
+
+  it("returns best-effort metadata for a non-EVM address when throwOnUnknown is false", () => {
+    expect(() => getTokenMetadata(TRON_USDT, "tron", { throwOnUnknown: false })).not.toThrow();
+    const meta = getTokenMetadata(TRON_USDT, "tron", { throwOnUnknown: false });
+    expect(meta.decimals).toBe(18);
+  });
+});
 
 describe("getEvmBalances", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Problem

Now that Tron routes exist, the gateway returns Tron (base58) token addresses in the shared routes/quote list. The CLI's `isNativeToken` passed raw token addresses straight to viem's `isAddressEqual`, which **throws** `InvalidAddressError` on a non-EVM address.

Because `getTokenMetadata` → `isNativeToken` runs for **every** route in `buildTokenIndex` *before* the requested pair is resolved, a single Tron route aborted **every** swap — observed in the [gateway-bot API-testing run](https://github.com/bob-collective/gateway-bot/actions/runs/27945635619): all 6 legs (USDC/USDT, both directions) failed with:

```
Address "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t" is invalid.
Version: viem@2.48.7
```

(`TR7NH…` is the Tron USDT contract.)

## Fix

Guard `isNativeToken` with `isAddress` first. A non-EVM address is never the EVM native token, so it returns `false`, falls through to the existing `"Unknown token"` path, and `buildTokenIndex` **skips the foreign route** instead of crashing — letting the requested EVM/BTC pair resolve normally.

This is a **crash-resilience** fix: the CLI now skips Tron routes rather than executing them. Full Tron swap support (SDK helper exports + Tron signer + tokenlist entries) is separate, larger work.

## Verification (TDD)

- 2 regression tests in `tests/chains/evm.test.ts`, watched fail with the exact production error then pass.
- Full suite 61 passing (was 59), `tsc` clean.
- Version bumped 0.1.8 → 0.1.9 (publish workflow reads this on tag push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)