### PR TITLE
feat(gateway-cli): add `send` command for direct BTC/EVM transfers

### DIFF
--- a/gateway-cli/README.md
+++ b/gateway-cli/README.md
@@ -1,6 +1,6 @@
 # gateway-cli
 
-CLI for [BOB Gateway](https://docs.gobob.xyz/gateway/overview) — swap between BTC and EVM tokens from the terminal.
+CLI for [BOB Gateway](https://docs.gobob.xyz/gateway/overview) — swap between BTC and EVM tokens, and send funds on a single chain, from the terminal.
 
 ## Install
 
@@ -42,6 +42,10 @@ gateway-cli swap --src BTC --dst USDC:base --amount ALL --recipient 0xYourAddres
 # Swap without --recipient (uses derived address from EVM_PRIVATE_KEY)
 gateway-cli swap --src BTC --dst USDC:base --amount 0.05BTC
 
+# Send funds directly on a single chain (no Gateway)
+gateway-cli send --asset USDC:base --amount 100USDC --to 0xRecipient
+gateway-cli send --asset BTC --amount 0.01BTC --to bc1qRecipient
+
 # Check your balances (derives addresses from keys)
 gateway-cli balance
 ```
@@ -57,6 +61,31 @@ gateway-cli swap --src BTC --dst USDC:base --amount 0.05BTC --recipient 0x...
 ```
 
 **Required:** `--src`, `--dst`, `--amount`
+
+### `send`
+
+Send BTC or an EVM token (native or ERC20) directly to an address — a plain
+single-chain transfer, **not** a Gateway swap.
+
+```bash
+gateway-cli send --asset USDC:base --amount 100USDC --to 0x...   # ERC20
+gateway-cli send --asset ETH:base --amount 0.1ETH --to 0x...     # EVM native
+gateway-cli send --asset BTC --amount 0.01BTC --to bc1q...       # BTC
+gateway-cli send --asset BTC --amount ALL --to bc1q...           # sweep entire balance
+gateway-cli send --asset USDC:base --amount 100USDC --to 0x... --unsigned   # don't broadcast
+```
+
+**Required:** `--asset`, `--amount`, `--to`
+
+- `--asset` accepts a known symbol (`BTC`, `ETH:base`, `USDC:arbitrum`) or a raw
+  token address (`0xToken:base`); decimals come from the token list or an on-chain
+  lookup. A chain is required for everything except `BTC`.
+- `--to` must match the asset's chain family — a BTC address for `BTC`, an EVM
+  address otherwise.
+- `--amount ALL` sends the full spendable balance: ERC20 = full balance, EVM
+  native = balance minus gas, BTC = all UTXOs minus the network fee.
+- The signing key comes from `--private-key` or the env keys. The sender is the
+  key's own address (there is no `--sender`); BTC sends from a P2WPKH (`bc1q`) address.
 
 ### `quote`
 
@@ -155,6 +184,20 @@ All config via environment variables. No config files.
 --no-wait                Exit after submitting without polling
 --no-retry               Fail immediately on transient errors
 --timeout <seconds>      Polling timeout (default: 1800)
+```
+
+### Send only
+
+```
+--asset <asset[:chain]>  Asset to send (e.g. BTC, ETH:base, USDC:arbitrum, 0xToken:base)
+--amount <value>         Amount (see format table above)
+--to <address>           Recipient address (BTC or EVM, must match the asset chain)
+--private-key <key>      Signing key (or use env vars)
+--btc-fee-rate <sat>     Bitcoin fee rate override
+--unsigned               Output unsigned tx (EVM) or PSBT (BTC) without broadcasting
+--no-wait                Broadcast without waiting for confirmation
+--timeout <seconds>      Confirmation wait timeout (default: 1800)
+--json                   Output as JSON
 ```
 
 ## Output modes

--- a/gateway-cli/package.json
+++ b/gateway-cli/package.json
@@ -20,7 +20,7 @@
     "cli:dev": "tsx bin/gateway-cli.ts"
   },
   "dependencies": {
-    "@gobob/bob-sdk": "^5.7.2",
+    "@gobob/bob-sdk": "^5.8.0",
     "@gobob/tokenlist": "github:bob-collective/tokenlist#5ee721890cb91657f640440a05698c357a080c87",
     "commander": "^13.1.0",
     "p-retry": "^7.1.1",

--- a/gateway-cli/pnpm-lock.yaml
+++ b/gateway-cli/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@gobob/bob-sdk':
-        specifier: ^5.7.3
-        version: 5.7.3(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        specifier: ^5.8.0
+        version: 5.8.0(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
       '@gobob/tokenlist':
         specifier: github:bob-collective/tokenlist#5ee721890cb91657f640440a05698c357a080c87
         version: https://codeload.github.com/bob-collective/tokenlist/tar.gz/5ee721890cb91657f640440a05698c357a080c87
@@ -248,8 +248,8 @@ packages:
   '@gobob/bob-sdk@3.1.7-alpha0':
     resolution: {integrity: sha512-1qdKAYEigbqNt9x/0jYKeeC/d0u1lh6GluHaBIxp2Pt6p2+4fUVFnDdtGo5pMcgft7Bvo8/tdmlFBTzb3BEc5g==}
 
-  '@gobob/bob-sdk@5.7.3':
-    resolution: {integrity: sha512-0kVxJtfLC2da0V+ZL72tUSSHnYt1GQAe3H7Iee+OncH9c4n4hhwanAcMxYoH/wiHBGocK6FxZBfkAOMckuVBIA==}
+  '@gobob/bob-sdk@5.8.0':
+    resolution: {integrity: sha512-s5304Pl5AcoPXeaxmv2srm341CIhEftzy3OSy0AVFZjrK9J9bL+lJaXfP3PplCVpw5fWIPayO+31S0mTUK8XFg==}
 
   '@gobob/sats-wagmi@0.3.23':
     resolution: {integrity: sha512-7YAcQXo20v/SKNBv4Jhv9SYJJ9fzXUSC1ntUKwR0hjdCV9Kj0ivIRmGKvZwb8fqwgNYEaL4R5PbrMWnvFNTRgQ==}
@@ -1471,7 +1471,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@gobob/bob-sdk@5.7.3(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
+  '@gobob/bob-sdk@5.8.0(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.2.0
       '@eslint/eslintrc': 3.3.5

--- a/gateway-cli/src/chains/bitcoin.ts
+++ b/gateway-cli/src/chains/bitcoin.ts
@@ -65,9 +65,19 @@ export function psbtBase64ToHex(base64: string): string {
 /**
  * Build an unsigned PSBT (base64) for a P2WPKH send. UTXO selection, fee, and change
  * are handled by the SDK. Public key is not required for P2WPKH senders.
+ *
+ * `strategy` defaults to `'default'` (subset selection + change). For a full-balance
+ * sweep pass `'all'` so the PSBT spends every UTXO, matching the `'all'` fee estimate
+ * used to derive the sweep amount.
  */
-export function buildBtcPsbt(from: string, to: string, amount: bigint, feeRate?: number): Promise<string> {
-  return createBitcoinPsbt(from, to, Number(amount), undefined, undefined, feeRate);
+export function buildBtcPsbt(
+  from: string,
+  to: string,
+  amount: bigint,
+  feeRate?: number,
+  strategy: "all" | "default" = "default",
+): Promise<string> {
+  return createBitcoinPsbt(from, to, Number(amount), undefined, undefined, feeRate, undefined, undefined, strategy);
 }
 
 /**
@@ -76,8 +86,9 @@ export function buildBtcPsbt(from: string, to: string, amount: bigint, feeRate?:
  *
  * Both values come from the SDK's own UTXO machinery over the SAME safe-UTXO set
  * (`getBalance` and `estimateTxFee` both use `findSafeUtxos`), so `confirmed - fee`
- * is the amount `createBitcoinPsbt` can then drain into one recipient output.
- * `estimateTxFee(from, undefined, ...)` selects all UTXOs (strategy `'all'`).
+ * is the amount `createBitcoinPsbt` can then drain into one recipient output. The fee
+ * estimate forces the `'all'` strategy, matching `buildBtcPsbt(..., "all")` on the build
+ * side so the actual tx spends exactly the UTXOs the fee assumed (no subset/change drift).
  *
  * @returns The atomic sweep amount in satoshis.
  * @throws if the balance cannot cover the fee (result at or below dust).
@@ -85,7 +96,7 @@ export function buildBtcPsbt(from: string, to: string, amount: bigint, feeRate?:
 export async function estimateBtcSweepAmount(from: string, feeRate?: number): Promise<bigint> {
   const [{ confirmed }, fee] = await Promise.all([
     getBalance(from),
-    estimateTxFee(from, undefined, undefined, undefined, feeRate),
+    estimateTxFee(from, undefined, undefined, undefined, feeRate, undefined, undefined, "all"),
   ]);
   return btcSweepAmount(confirmed, fee ?? 0n);
 }
@@ -103,8 +114,15 @@ export function btcSweepAmount(confirmed: bigint, fee: bigint): bigint {
  * Execute a direct BTC transfer: build PSBT → sign (finalize) → broadcast.
  * @returns The broadcast transaction id.
  */
-export async function sendBtc(signer: BitcoinSigner, from: string, to: string, amount: bigint, feeRate?: number): Promise<string> {
-  const psbtBase64 = await buildBtcPsbt(from, to, amount, feeRate);
+export async function sendBtc(
+  signer: BitcoinSigner,
+  from: string,
+  to: string,
+  amount: bigint,
+  feeRate?: number,
+  strategy: "all" | "default" = "default",
+): Promise<string> {
+  const psbtBase64 = await buildBtcPsbt(from, to, amount, feeRate, strategy);
   if (!signer.signAllInputs) throw new Error("Bitcoin signer cannot sign PSBTs (missing signAllInputs).");
   const signedTxHex = await signer.signAllInputs(psbtBase64ToHex(psbtBase64));
   return new EsploraClient().broadcastTx(signedTxHex);

--- a/gateway-cli/src/chains/bitcoin.ts
+++ b/gateway-cli/src/chains/bitcoin.ts
@@ -1,5 +1,8 @@
-import { EsploraClient, ScureBitcoinSigner, createBitcoinPsbt, type BitcoinSigner } from '@gobob/bob-sdk';
+import { EsploraClient, ScureBitcoinSigner, createBitcoinPsbt, estimateTxFee, getBalance, type BitcoinSigner } from '@gobob/bob-sdk';
 import { getSdk } from '../config.js';
+
+/** Bitcoin dust threshold in satoshis (matches the SDK's selectUTXO default). */
+const BTC_DUST_SATS = 546n;
 
 /** Bitcoin balance with total and maximum spendable amounts in satoshis. */
 export interface TokenBalance {
@@ -65,6 +68,35 @@ export function psbtBase64ToHex(base64: string): string {
  */
 export function buildBtcPsbt(from: string, to: string, amount: bigint, feeRate?: number): Promise<string> {
   return createBitcoinPsbt(from, to, Number(amount), undefined, undefined, feeRate);
+}
+
+/**
+ * Compute the sweepable BTC amount for `--amount ALL`: the confirmed safe-UTXO
+ * balance minus the network fee to spend every UTXO into a single output.
+ *
+ * Both values come from the SDK's own UTXO machinery over the SAME safe-UTXO set
+ * (`getBalance` and `estimateTxFee` both use `findSafeUtxos`), so `confirmed - fee`
+ * is the amount `createBitcoinPsbt` can then drain into one recipient output.
+ * `estimateTxFee(from, undefined, ...)` selects all UTXOs (strategy `'all'`).
+ *
+ * @returns The atomic sweep amount in satoshis.
+ * @throws if the balance cannot cover the fee (result at or below dust).
+ */
+export async function estimateBtcSweepAmount(from: string, feeRate?: number): Promise<bigint> {
+  const [{ confirmed }, fee] = await Promise.all([
+    getBalance(from),
+    estimateTxFee(from, undefined, undefined, undefined, feeRate),
+  ]);
+  return btcSweepAmount(confirmed, fee ?? 0n);
+}
+
+/** Sweep amount = confirmed balance minus fee, rejecting results at or below dust. Pure. */
+export function btcSweepAmount(confirmed: bigint, fee: bigint): bigint {
+  const sweep = confirmed - fee;
+  if (sweep <= BTC_DUST_SATS) {
+    throw new Error(`BTC balance (${confirmed} sats) is too low to cover the sweep fee (${fee} sats). Nothing to send.`);
+  }
+  return sweep;
 }
 
 /**

--- a/gateway-cli/src/chains/bitcoin.ts
+++ b/gateway-cli/src/chains/bitcoin.ts
@@ -1,4 +1,4 @@
-import { EsploraClient, ScureBitcoinSigner, type BitcoinSigner } from '@gobob/bob-sdk';
+import { EsploraClient, ScureBitcoinSigner, createBitcoinPsbt, type BitcoinSigner } from '@gobob/bob-sdk';
 import { getSdk } from '../config.js';
 
 /** Bitcoin balance with total and maximum spendable amounts in satoshis. */
@@ -50,4 +50,30 @@ export async function resolveBtcSigner(
   const signer = ScureBitcoinSigner.fromKey(key);
   const address = await signer.getP2WPKHAddress();
   return { address, signer };
+}
+
+// ─── Send (direct transfer) ───────────────────────────────────────────────────
+
+/** Convert a base64-encoded PSBT (as produced by createBitcoinPsbt) to hex (as expected by signAllInputs). */
+export function psbtBase64ToHex(base64: string): string {
+  return Buffer.from(base64, "base64").toString("hex");
+}
+
+/**
+ * Build an unsigned PSBT (base64) for a P2WPKH send. UTXO selection, fee, and change
+ * are handled by the SDK. Public key is not required for P2WPKH senders.
+ */
+export function buildBtcPsbt(from: string, to: string, amount: bigint, feeRate?: number): Promise<string> {
+  return createBitcoinPsbt(from, to, Number(amount), undefined, undefined, feeRate);
+}
+
+/**
+ * Execute a direct BTC transfer: build PSBT → sign (finalize) → broadcast.
+ * @returns The broadcast transaction id.
+ */
+export async function sendBtc(signer: BitcoinSigner, from: string, to: string, amount: bigint, feeRate?: number): Promise<string> {
+  const psbtBase64 = await buildBtcPsbt(from, to, amount, feeRate);
+  if (!signer.signAllInputs) throw new Error("Bitcoin signer cannot sign PSBTs (missing signAllInputs).");
+  const signedTxHex = await signer.signAllInputs(psbtBase64ToHex(psbtBase64));
+  return new EsploraClient().broadcastTx(signedTxHex);
 }

--- a/gateway-cli/src/chains/evm.ts
+++ b/gateway-cli/src/chains/evm.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, createWalletClient, http, erc20Abi, isAddressEqual, isHex, type WalletClient, type PublicClient, type Hex, type Chain } from 'viem';
+import { createPublicClient, createWalletClient, http, erc20Abi, isAddressEqual, isHex, encodeFunctionData, type WalletClient, type PublicClient, type Hex, type Chain } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { supportedChainsMapping, getChainConfig } from '@gobob/bob-sdk';
 import tokenlistJson from '@gobob/tokenlist/tokenlist.json';
@@ -281,4 +281,45 @@ export async function resolveEvmSigner(
     walletClient: createWalletClient({ account, chain: viemChain, transport }),
     publicClient: createPublicClient({ chain: viemChain, transport }),
   };
+}
+
+// ─── Send (direct transfer) ───────────────────────────────────────────────────
+
+import type { ResolvedAsset } from '../util/input-resolver.js';
+import type { EvmSigner } from './index.js';
+
+/** Default gas units for a simple value/ERC20 transfer when sweeping native balance. */
+const TRANSFER_GAS_LIMIT = 21_000n;
+
+/** Spendable native amount for a sweep: balance minus the exact gas cost of one transfer. */
+export function nativeSweepAmount(balance: bigint, maxFeePerGas: bigint, gasLimit: bigint = TRANSFER_GAS_LIMIT): bigint {
+  const cost = gasLimit * maxFeePerGas;
+  return balance > cost ? balance - cost : 0n;
+}
+
+/** Build unsigned EVM tx params for native or ERC20 transfer (for --unsigned output). */
+export function buildUnsignedEvmTx(asset: ResolvedAsset, to: string, amount: bigint, from: string, chainId: number) {
+  if (isNativeToken(asset.address)) {
+    return { from, to, value: amount.toString(), data: "0x", chainId };
+  }
+  const data = encodeFunctionData({ abi: erc20Abi, functionName: "transfer", args: [to as `0x${string}`, amount] });
+  return { from, to: asset.address, value: "0", data, chainId };
+}
+
+/** Execute a direct EVM transfer (native or ERC20). Returns the tx hash. */
+export async function sendEvm(signer: EvmSigner, asset: ResolvedAsset, to: string, amount: bigint): Promise<Hex> {
+  const { walletClient, address } = signer;
+  const account = walletClient.account!;
+  const chain = walletClient.chain!;
+  if (isNativeToken(asset.address)) {
+    return walletClient.sendTransaction({ account, chain, to: to as `0x${string}`, value: amount });
+  }
+  return walletClient.writeContract({
+    account,
+    chain,
+    address: asset.address as `0x${string}`,
+    abi: erc20Abi,
+    functionName: "transfer",
+    args: [to as `0x${string}`, amount],
+  });
 }

--- a/gateway-cli/src/chains/evm.ts
+++ b/gateway-cli/src/chains/evm.ts
@@ -308,7 +308,7 @@ export function buildUnsignedEvmTx(asset: ResolvedAsset, to: string, amount: big
 
 /** Execute a direct EVM transfer (native or ERC20). Returns the tx hash. */
 export async function sendEvm(signer: EvmSigner, asset: ResolvedAsset, to: string, amount: bigint): Promise<Hex> {
-  const { walletClient, address } = signer;
+  const { walletClient } = signer;
   const account = walletClient.account!;
   const chain = walletClient.chain!;
   if (isNativeToken(asset.address)) {

--- a/gateway-cli/src/chains/index.ts
+++ b/gateway-cli/src/chains/index.ts
@@ -1,4 +1,6 @@
 import type { RegisterTxV3 } from '@gobob/bob-sdk';
+import { isValidBtcAddress } from '@gobob/bob-sdk';
+import { isAddress } from 'viem';
 import { getSdk } from '../config.js';
 import { getRoutes, getUniqueChains, getTokensForChain } from '../util/route-provider.js';
 import { getBtcBalance, deriveBtcAddress, resolveBtcSigner } from './bitcoin.js';
@@ -20,6 +22,18 @@ export type ChainFamily = 'bitcoin' | 'evm';
 export function getChainFamily(chain: string): ChainFamily {
   if (chain === 'bitcoin') return 'bitcoin';
   return 'evm';
+}
+
+/**
+ * Validate that a recipient address matches the asset's chain family.
+ * @throws Error if a BTC address is used for an EVM chain or vice-versa.
+ */
+export function validateRecipient(chain: string, to: string): void {
+  if (getChainFamily(chain) === 'bitcoin') {
+    if (!isValidBtcAddress(to)) throw new Error(`--to "${to}" is not a valid Bitcoin address.`);
+  } else {
+    if (!isAddress(to, { strict: false })) throw new Error(`--to "${to}" is not a valid EVM address.`);
+  }
 }
 
 // ─── Chain balances ─────────────────────────────────────────────────────────

--- a/gateway-cli/src/cli.ts
+++ b/gateway-cli/src/cli.ts
@@ -131,6 +131,7 @@ program
   .requiredOption("--asset <asset[:chain]>", "Asset to send (e.g. BTC, ETH:base, USDC:arbitrum, 0xToken:base)")
   .requiredOption("--amount <value>", "Amount: 0.01BTC, 100USDC, 100USD, 5000000 (atomic), ALL")
   .requiredOption("--to <address>", "Recipient address (BTC or EVM, must match the asset chain)")
+  .option("--from <address>", "Sender address for --unsigned without a key (BTC PSBT or EVM tx, must match the asset chain)")
   .option("--private-key <key>", "Private key (WIF for BTC, hex for EVM). WARNING: visible in process listings — prefer env vars")
   .option("--btc-fee-rate <sat/vbyte>", "Bitcoin fee rate (default: Esplora estimate)")
   .option("--unsigned", "Output unsigned tx (EVM) or PSBT (BTC) without broadcasting", false)

--- a/gateway-cli/src/cli.ts
+++ b/gateway-cli/src/cli.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
 import { ZodError } from "zod/v4";
 import { isAddress } from "viem";
-import { type OutputMode, createLogger, render, formatJson, formatConfirmation, formatChains, formatTokens, formatRoutes, formatBalance } from "./output.js";
-import { quoteSchema, swapSchema } from "./schemas.js";
+import { type OutputMode, createLogger, render, formatJson, formatConfirmation, formatChains, formatTokens, formatRoutes, formatBalance, formatSend } from "./output.js";
+import { quoteSchema, swapSchema, sendSchema } from "./schemas.js";
 import { version } from '../package.json';
 
 function modeOf(opts: { json?: boolean }): OutputMode {
@@ -132,6 +132,27 @@ program
     const result = await handleSwap({ ...parsed, sender: parsed.sender, owner: parsed.owner }, log);
 
     render("data" in result ? result.data : result, mode);
+  }));
+
+program
+  .command("send")
+  .description("Send BTC or an EVM token directly to an address (no Gateway)")
+  .requiredOption("--asset <asset[:chain]>", "Asset to send (e.g. BTC, ETH:base, USDC:arbitrum, 0xToken:base)")
+  .requiredOption("--amount <value>", "Amount: 0.01BTC, 100USDC, 100USD, 5000000 (atomic), ALL")
+  .requiredOption("--to <address>", "Recipient address (BTC or EVM, must match the asset chain)")
+  .option("--private-key <key>", "Private key (WIF for BTC, hex for EVM). WARNING: visible in process listings — prefer env vars")
+  .option("--btc-fee-rate <sat/vbyte>", "Bitcoin fee rate (default: Esplora estimate)")
+  .option("--unsigned", "Output unsigned tx (EVM) or PSBT (BTC) without broadcasting", false)
+  .option("--no-wait", "Broadcast without waiting for confirmation")
+  .option("--timeout <seconds>", "Confirmation wait timeout in seconds", "1800")
+  .option("--json", "Output as JSON", false)
+  .action(withErrorHandling(async (opts) => {
+    const mode = modeOf(opts);
+    const parsed = sendSchema.parse(opts);
+    const log = createLogger(mode);
+    const { handleSend } = await import("./commands/send.js");
+    const result = await handleSend(parsed, log);
+    render(result.data, mode, formatSend);
   }));
 
 program

--- a/gateway-cli/src/commands/send.ts
+++ b/gateway-cli/src/commands/send.ts
@@ -17,6 +17,7 @@ export interface SendOptions {
   asset: string;
   amount: string;
   to: string;
+  from?: string;
   privateKey?: string;
   btcFeeRate?: number;
   unsigned: boolean;
@@ -55,14 +56,23 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   validateRecipient(asset.chain, opts.to);
 
   const key = resolvePrivateKey(asset.chain, opts.privateKey, config);
-  const senderAddress = key ? await deriveAddress(asset.chain, key) : undefined;
+  // The key-derived address wins; otherwise --from supplies the sender for the keyless
+  // unsigned path. A source address only needs to be valid for the asset's chain family
+  // (validateRecipient checks exactly that), so reuse it here for --from.
+  let senderAddress: string | undefined;
+  if (key) {
+    senderAddress = await deriveAddress(asset.chain, key);
+  } else if (opts.from) {
+    validateRecipient(asset.chain, opts.from);
+    senderAddress = opts.from;
+  }
 
   // A full-balance sweep selects every UTXO; a normal send selects a subset (+ change).
   const isSweep = opts.amount.trim().toUpperCase() === "ALL";
-  // ALL and BTC --unsigned require knowing the sender, which (no --sender flag) means a key.
+  // ALL and BTC --unsigned require knowing the sender — supplied by a key or --from.
   const needsSender = isSweep || (opts.unsigned && family === "bitcoin");
   if (needsSender && !senderAddress) {
-    throw new Error(`A signing key is required for this operation.\n  Set ${family === "bitcoin" ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY"} or pass --private-key.`);
+    throw new Error(`A signing key${opts.unsigned ? " or --from <address>" : ""} is required for this operation.\n  Set ${family === "bitcoin" ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY"} or pass --private-key${opts.unsigned ? " or --from" : ""}.`);
   }
 
   // Resolve signer up-front for the signed path (also gives EVM publicClient for ALL/fees).

--- a/gateway-cli/src/commands/send.ts
+++ b/gateway-cli/src/commands/send.ts
@@ -1,0 +1,151 @@
+import { erc20Abi, type Hex } from "viem";
+import type { ResolvedAsset } from "../util/input-resolver.js";
+import { parseAmount } from "../util/input-resolver.js";
+import { resolveSendAsset } from "../util/asset-resolver.js";
+import { loadConfig, getSdk } from "../config.js";
+import {
+  validateRecipient, getChainFamily, resolvePrivateKey, deriveAddress, resolveSigner,
+  type BtcSigner, type EvmSigner,
+} from "../chains/index.js";
+import { sendEvm, buildUnsignedEvmTx, nativeSweepAmount, getEvmBalances, CHAIN_IDS } from "../chains/evm.js";
+import { sendBtc, buildBtcPsbt, getBtcBalance } from "../chains/bitcoin.js";
+import type { SendSuccessJson, SendUnsignedJson, Logger } from "../output.js";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const isNative = (address: string) => address.toLowerCase() === ZERO_ADDRESS;
+
+export interface SendOptions {
+  asset: string;
+  amount: string;
+  to: string;
+  privateKey?: string;
+  btcFeeRate?: number;
+  unsigned: boolean;
+  wait: boolean;
+  timeout?: number;
+}
+
+export type SendResult =
+  | { type: "sent"; data: SendSuccessJson }
+  | { type: "unsigned"; data: SendUnsignedJson };
+
+/**
+ * Convert the --amount value into atomic units for the resolved asset.
+ * `ALL` delegates to the injected `spendable` callback (chain-specific balance lookup).
+ */
+export async function resolveSendAmount(
+  opts: Pick<SendOptions, "amount">,
+  asset: ResolvedAsset,
+  _senderAddress: string | undefined,
+  deps: { spendable: () => Promise<bigint> },
+): Promise<bigint> {
+  const parsed = await parseAmount(opts.amount, asset.symbol, asset.decimals);
+  if (parsed.type === "all") {
+    const all = await deps.spendable();
+    if (all === 0n) throw new Error(`No ${asset.symbol} balance available to send.`);
+    return all;
+  }
+  return BigInt(parsed.atomicUnits);
+}
+
+export async function handleSend(opts: SendOptions, log: Logger): Promise<SendResult> {
+  const config = loadConfig();
+  const asset = await resolveSendAsset(opts.asset);
+  const family = getChainFamily(asset.chain);
+
+  validateRecipient(asset.chain, opts.to);
+
+  const key = resolvePrivateKey(asset.chain, opts.privateKey, config);
+  const senderAddress = key ? await deriveAddress(asset.chain, key) : undefined;
+
+  // ALL and BTC --unsigned require knowing the sender, which (no --sender flag) means a key.
+  const needsSender = opts.amount.trim().toUpperCase() === "ALL" || (opts.unsigned && family === "bitcoin");
+  if (needsSender && !senderAddress) {
+    throw new Error(`A signing key is required for this operation.\n  Set ${family === "bitcoin" ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY"} or pass --private-key.`);
+  }
+
+  // Resolve signer up-front for the signed path (also gives EVM publicClient for ALL/fees).
+  const signer = !opts.unsigned
+    ? (key ? await resolveSigner(asset.chain, key)
+           : (() => { throw new Error(`No signer configured.\n  Set ${family === "bitcoin" ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY"} or pass --private-key, or use --unsigned.`); })())
+    : (key ? await resolveSigner(asset.chain, key).catch(() => null) : null);
+
+  const feeRate = opts.btcFeeRate ?? config.btcFeeRate;
+
+  // ── amount resolution (with chain-specific ALL spendable) ──
+  const amount = await resolveSendAmount(opts, asset, senderAddress, {
+    spendable: async () => {
+      if (family === "bitcoin") {
+        return BigInt((await getBtcBalance(senderAddress!, getSdk())).allSpendable);
+      }
+      const evmSigner = signer as EvmSigner;
+      if (isNative(asset.address)) {
+        const [balance, fees] = await Promise.all([
+          evmSigner.publicClient.getBalance({ address: senderAddress as `0x${string}` }),
+          evmSigner.publicClient.estimateFeesPerGas(),
+        ]);
+        return nativeSweepAmount(balance, fees.maxFeePerGas ?? fees.gasPrice ?? 0n);
+      }
+      const bal = await getEvmBalances(asset.chain, senderAddress!, [{ address: asset.address, symbol: asset.symbol, decimals: asset.decimals }]);
+      return BigInt(bal.tokens![0].balance);
+    },
+  });
+
+  // ── unsigned path ──
+  if (opts.unsigned) {
+    if (family === "bitcoin") {
+      const psbtBase64 = await buildBtcPsbt(senderAddress!, opts.to, amount, feeRate);
+      return { type: "unsigned", data: { unsigned: true, chain: asset.chain, asset: asset.symbol, amount: amount.toString(), to: opts.to, psbtBase64 } };
+    }
+    const from = senderAddress ?? ZERO_ADDRESS;
+    const tx = buildUnsignedEvmTx(asset, opts.to, amount, from, CHAIN_IDS[asset.chain]);
+    return { type: "unsigned", data: { unsigned: true, chain: asset.chain, asset: asset.symbol, amount: amount.toString(), to: opts.to, tx } };
+  }
+
+  // ── signed path ──
+  log.progress(`Sending ${amount} ${asset.symbol} (atomic) to ${opts.to} on ${asset.chain}...`);
+  let txId: string;
+  if (family === "bitcoin") {
+    txId = await sendBtc((signer as BtcSigner).signer, senderAddress!, opts.to, amount, feeRate);
+  } else {
+    txId = await sendEvm(signer as EvmSigner, asset, opts.to, amount);
+  }
+  log.progress(`✓ Broadcast: ${txId}`);
+
+  if (!opts.wait) {
+    return { type: "sent", data: { asset: asset.symbol, chain: asset.chain, amount: amount.toString(), to: opts.to, txId, status: "broadcast" } };
+  }
+
+  // ── wait for 1 confirmation ──
+  const timeoutMs = opts.timeout ? opts.timeout * 1000 : config.timeoutMs;
+  if (family === "bitcoin") {
+    await waitForBtcConfirmation(txId, timeoutMs, log);
+  } else {
+    await (signer as EvmSigner).publicClient.waitForTransactionReceipt({ hash: txId as Hex, timeout: timeoutMs });
+  }
+  log.progress(`✓ Confirmed: ${txId}`);
+  return { type: "sent", data: { asset: asset.symbol, chain: asset.chain, amount: amount.toString(), to: opts.to, txId, status: "confirmed" } };
+}
+
+/** Poll Esplora until the tx has at least one confirmation, or throw on timeout.
+ *
+ * Step 3b verification: `getTransaction` is confirmed present on EsploraClient.prototype
+ * and returns the full mempool.space tx object with shape `{ status: { confirmed: boolean } }`.
+ * No change needed from the brief.
+ */
+async function waitForBtcConfirmation(txId: string, timeoutMs: number, log: Logger): Promise<void> {
+  const { EsploraClient } = await import("@gobob/bob-sdk");
+  const esplora = new EsploraClient();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const tx = await esplora.getTransaction(txId);
+      if (tx?.status?.confirmed) return;
+    } catch {
+      // tx may not be indexed yet; keep polling
+    }
+    log.progress(`  Waiting for confirmation... (${Math.round((deadline - Date.now()) / 1000)}s left)`);
+    await new Promise(r => setTimeout(r, 15_000));
+  }
+  throw new Error(`Timed out waiting for confirmation of ${txId}. The tx may still confirm — check a block explorer.`);
+}

--- a/gateway-cli/src/commands/send.ts
+++ b/gateway-cli/src/commands/send.ts
@@ -2,13 +2,13 @@ import { type Hex } from "viem";
 import type { ResolvedAsset } from "../util/input-resolver.js";
 import { parseAmount } from "../util/input-resolver.js";
 import { resolveSendAsset } from "../util/asset-resolver.js";
-import { loadConfig, getSdk } from "../config.js";
+import { loadConfig } from "../config.js";
 import {
   validateRecipient, getChainFamily, resolvePrivateKey, deriveAddress, resolveSigner,
   type BtcSigner, type EvmSigner,
 } from "../chains/index.js";
 import { sendEvm, buildUnsignedEvmTx, nativeSweepAmount, getEvmBalances, CHAIN_IDS } from "../chains/evm.js";
-import { sendBtc, buildBtcPsbt, getBtcBalance } from "../chains/bitcoin.js";
+import { sendBtc, buildBtcPsbt } from "../chains/bitcoin.js";
 import type { SendSuccessJson, SendUnsignedJson, Logger } from "../output.js";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -76,7 +76,7 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   const amount = await resolveSendAmount(opts, asset, senderAddress, {
     spendable: async () => {
       if (family === "bitcoin") {
-        return BigInt((await getBtcBalance(senderAddress!, getSdk())).allSpendable);
+        throw new Error("--amount ALL is not yet supported for BTC — specify an explicit amount (e.g. 0.001BTC or atomic sats). Sweep/drain semantics still need mainnet verification.");
       }
       if (!signer) throw new Error("An EVM RPC connection is required for --amount ALL. Set a working RPC or remove --unsigned.");
       const evmSigner = signer as EvmSigner;

--- a/gateway-cli/src/commands/send.ts
+++ b/gateway-cli/src/commands/send.ts
@@ -1,4 +1,4 @@
-import { type Hex } from "viem";
+import { type Hex, zeroAddress } from "viem";
 import type { ResolvedAsset } from "../util/input-resolver.js";
 import { parseAmount } from "../util/input-resolver.js";
 import { resolveSendAsset } from "../util/asset-resolver.js";
@@ -8,11 +8,10 @@ import {
   type BtcSigner, type EvmSigner,
 } from "../chains/index.js";
 import { sendEvm, buildUnsignedEvmTx, nativeSweepAmount, getEvmBalances, CHAIN_IDS } from "../chains/evm.js";
-import { sendBtc, buildBtcPsbt } from "../chains/bitcoin.js";
+import { sendBtc, buildBtcPsbt, estimateBtcSweepAmount } from "../chains/bitcoin.js";
 import type { SendSuccessJson, SendUnsignedJson, Logger } from "../output.js";
 
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-const isNative = (address: string) => address.toLowerCase() === ZERO_ADDRESS;
+const isNative = (address: string) => address.toLowerCase() === zeroAddress;
 
 export interface SendOptions {
   asset: string;
@@ -76,7 +75,7 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   const amount = await resolveSendAmount(opts, asset, senderAddress, {
     spendable: async () => {
       if (family === "bitcoin") {
-        throw new Error("--amount ALL is not yet supported for BTC — specify an explicit amount (e.g. 0.001BTC or atomic sats). Sweep/drain semantics still need mainnet verification.");
+        return estimateBtcSweepAmount(senderAddress!, feeRate);
       }
       if (!signer) throw new Error("An EVM RPC connection is required for --amount ALL. Set a working RPC or remove --unsigned.");
       const evmSigner = signer as EvmSigner;
@@ -98,7 +97,7 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
       const psbtBase64 = await buildBtcPsbt(senderAddress!, opts.to, amount, feeRate);
       return { type: "unsigned", data: { unsigned: true, chain: asset.chain, asset: asset.symbol, amount: amount.toString(), to: opts.to, psbtBase64 } };
     }
-    const from = senderAddress ?? ZERO_ADDRESS;
+    const from = senderAddress ?? zeroAddress;
     const tx = buildUnsignedEvmTx(asset, opts.to, amount, from, CHAIN_IDS[asset.chain]);
     return { type: "unsigned", data: { unsigned: true, chain: asset.chain, asset: asset.symbol, amount: amount.toString(), to: opts.to, tx } };
   }
@@ -122,7 +121,11 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   if (family === "bitcoin") {
     await waitForBtcConfirmation(txId, timeoutMs, log);
   } else {
-    await (signer as EvmSigner).publicClient.waitForTransactionReceipt({ hash: txId as Hex, timeout: timeoutMs });
+    try {
+      await (signer as EvmSigner).publicClient.waitForTransactionReceipt({ hash: txId as Hex, timeout: timeoutMs });
+    } catch (err) {
+      throw new Error(`Timed out waiting for confirmation of ${txId}. The tx was broadcast and may still confirm — check a block explorer. ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
   log.progress(`✓ Confirmed: ${txId}`);
   return { type: "sent", data: { asset: asset.symbol, chain: asset.chain, amount: amount.toString(), to: opts.to, txId, status: "confirmed" } };
@@ -145,8 +148,9 @@ async function waitForBtcConfirmation(txId: string, timeoutMs: number, log: Logg
     } catch {
       // tx may not be indexed yet; keep polling
     }
-    log.progress(`  Waiting for confirmation... (${Math.round((deadline - Date.now()) / 1000)}s left)`);
-    await new Promise(r => setTimeout(r, 15_000));
+    const remaining = deadline - Date.now();
+    log.progress(`  Waiting for confirmation... (${Math.round(remaining / 1000)}s left)`);
+    await new Promise(r => setTimeout(r, Math.min(15_000, remaining)));
   }
   throw new Error(`Timed out waiting for confirmation of ${txId}. The tx may still confirm — check a block explorer.`);
 }

--- a/gateway-cli/src/commands/send.ts
+++ b/gateway-cli/src/commands/send.ts
@@ -57,8 +57,10 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   const key = resolvePrivateKey(asset.chain, opts.privateKey, config);
   const senderAddress = key ? await deriveAddress(asset.chain, key) : undefined;
 
+  // A full-balance sweep selects every UTXO; a normal send selects a subset (+ change).
+  const isSweep = opts.amount.trim().toUpperCase() === "ALL";
   // ALL and BTC --unsigned require knowing the sender, which (no --sender flag) means a key.
-  const needsSender = opts.amount.trim().toUpperCase() === "ALL" || (opts.unsigned && family === "bitcoin");
+  const needsSender = isSweep || (opts.unsigned && family === "bitcoin");
   if (needsSender && !senderAddress) {
     throw new Error(`A signing key is required for this operation.\n  Set ${family === "bitcoin" ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY"} or pass --private-key.`);
   }
@@ -94,7 +96,7 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   // ── unsigned path ──
   if (opts.unsigned) {
     if (family === "bitcoin") {
-      const psbtBase64 = await buildBtcPsbt(senderAddress!, opts.to, amount, feeRate);
+      const psbtBase64 = await buildBtcPsbt(senderAddress!, opts.to, amount, feeRate, isSweep ? "all" : "default");
       return { type: "unsigned", data: { unsigned: true, chain: asset.chain, asset: asset.symbol, amount: amount.toString(), to: opts.to, psbtBase64 } };
     }
     const from = senderAddress ?? zeroAddress;
@@ -106,7 +108,7 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   log.progress(`Sending ${amount} ${asset.symbol} (atomic) to ${opts.to} on ${asset.chain}...`);
   let txId: string;
   if (family === "bitcoin") {
-    txId = await sendBtc((signer as BtcSigner).signer, senderAddress!, opts.to, amount, feeRate);
+    txId = await sendBtc((signer as BtcSigner).signer, senderAddress!, opts.to, amount, feeRate, isSweep ? "all" : "default");
   } else {
     txId = await sendEvm(signer as EvmSigner, asset, opts.to, amount);
   }
@@ -131,12 +133,7 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   return { type: "sent", data: { asset: asset.symbol, chain: asset.chain, amount: amount.toString(), to: opts.to, txId, status: "confirmed" } };
 }
 
-/** Poll Esplora until the tx has at least one confirmation, or throw on timeout.
- *
- * Step 3b verification: `getTransaction` is confirmed present on EsploraClient.prototype
- * and returns the full mempool.space tx object with shape `{ status: { confirmed: boolean } }`.
- * No change needed from the brief.
- */
+/** Poll Esplora until the tx has at least one confirmation, or throw on timeout. */
 async function waitForBtcConfirmation(txId: string, timeoutMs: number, log: Logger): Promise<void> {
   const { EsploraClient } = await import("@gobob/bob-sdk");
   const esplora = new EsploraClient();

--- a/gateway-cli/src/commands/send.ts
+++ b/gateway-cli/src/commands/send.ts
@@ -1,4 +1,4 @@
-import { erc20Abi, type Hex } from "viem";
+import { type Hex } from "viem";
 import type { ResolvedAsset } from "../util/input-resolver.js";
 import { parseAmount } from "../util/input-resolver.js";
 import { resolveSendAsset } from "../util/asset-resolver.js";
@@ -78,6 +78,7 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
       if (family === "bitcoin") {
         return BigInt((await getBtcBalance(senderAddress!, getSdk())).allSpendable);
       }
+      if (!signer) throw new Error("An EVM RPC connection is required for --amount ALL. Set a working RPC or remove --unsigned.");
       const evmSigner = signer as EvmSigner;
       if (isNative(asset.address)) {
         const [balance, fees] = await Promise.all([

--- a/gateway-cli/src/output.ts
+++ b/gateway-cli/src/output.ts
@@ -292,3 +292,44 @@ export function formatRoutes(data: Array<{ srcChain: string; srcSymbol: string; 
     data.map(r => [`${r.srcChain}:${r.srcSymbol}`, `${r.dstChain}:${r.dstSymbol}`]),
   );
 }
+
+/** JSON result for a successful direct send. */
+export interface SendSuccessJson {
+  asset: string;
+  chain: string;
+  amount: string;
+  to: string;
+  txId: string;
+  status: "broadcast" | "confirmed";
+}
+
+/** JSON result for an --unsigned send (PSBT for BTC, tx params for EVM). */
+export interface SendUnsignedJson {
+  unsigned: true;
+  chain: string;
+  asset: string;
+  amount: string;
+  to: string;
+  psbtBase64?: string;
+  tx?: { from: string; to: string; value: string; data: string; chainId: number };
+}
+
+/** Human-readable formatter for send results. */
+export function formatSend(data: SendSuccessJson | SendUnsignedJson): string {
+  if ("unsigned" in data) {
+    const lines = [
+      `Unsigned ${data.asset} transfer (${data.chain})`,
+      `  Amount: ${data.amount} (atomic)`,
+      `  To:     ${data.to}`,
+    ];
+    if (data.psbtBase64) lines.push(`  PSBT (base64):`, data.psbtBase64);
+    if (data.tx) lines.push(`  Tx: ${JSON.stringify(data.tx)}`);
+    return lines.join("\n");
+  }
+  const verb = data.status === "confirmed" ? "✓ Confirmed" : "~ Broadcast";
+  return [
+    `${verb} — sent ${data.amount} ${data.asset} (atomic) on ${data.chain}`,
+    `  To:  ${data.to}`,
+    `  Tx:  ${data.txId}`,
+  ].join("\n");
+}

--- a/gateway-cli/src/schemas.ts
+++ b/gateway-cli/src/schemas.ts
@@ -66,3 +66,21 @@ export const swapSchema = quoteSchema.and(z.object({
 export type QuoteInput = z.input<typeof quoteSchema>;
 /** TypeScript type inferred from swapSchema input. */
 export type SwapInput = z.input<typeof swapSchema>;
+
+/**
+ * Zod schema for the send command (direct, single-chain transfer).
+ */
+export const sendSchema = z.object({
+  asset: z.string(),
+  amount: z.string(),
+  to: z.string(),
+  privateKey: z.string().optional(),
+  btcFeeRate: positiveInt.optional(),
+  unsigned: z.boolean().default(false),
+  wait: z.boolean().default(true),
+  timeout: positiveInt.pipe(z.number().min(1, "timeout must be >= 1")).optional(),
+  json: z.boolean().default(false),
+});
+
+/** TypeScript type inferred from sendSchema input. */
+export type SendInput = z.input<typeof sendSchema>;

--- a/gateway-cli/src/schemas.ts
+++ b/gateway-cli/src/schemas.ts
@@ -74,6 +74,7 @@ export const sendSchema = z.object({
   asset: z.string(),
   amount: z.string(),
   to: z.string(),
+  from: z.string().optional(),
   privateKey: z.string().optional(),
   btcFeeRate: positiveInt.optional(),
   unsigned: z.boolean().default(false),

--- a/gateway-cli/src/util/asset-resolver.ts
+++ b/gateway-cli/src/util/asset-resolver.ts
@@ -1,4 +1,4 @@
-import { isAddress, createPublicClient, http, erc20Abi } from "viem";
+import { isAddress, createPublicClient, http, erc20Abi, zeroAddress } from "viem";
 import { getChainConfig } from "@gobob/bob-sdk";
 import tokenlistJson from "@gobob/tokenlist/tokenlist.json";
 import type { ResolvedAsset } from "./input-resolver.js";
@@ -6,8 +6,6 @@ import { resolveChain } from "./input-resolver.js";
 import { CHAIN_IDS, getNativeToken } from "../chains/evm.js";
 import { resolveRpcUrl } from "./rpc-resolver.js";
 import { BTC_DECIMALS } from "../config.js";
-
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 /** Token metadata index keyed by `${chainId}:SYMBOL` and `${chainId}:address` (lowercase). */
 type Meta = { address: string; symbol: string; decimals: number };
@@ -60,8 +58,9 @@ export async function resolveSendAsset(raw: string, deps?: Partial<AssetResolver
   const assetPart = colon === -1 ? raw : raw.slice(0, colon);
   const chainPart = colon === -1 ? undefined : raw.slice(colon + 1);
 
-  if (assetPart.toUpperCase() === "BTC" && !chainPart) {
-    return { chain: "bitcoin", address: ZERO_ADDRESS, symbol: "BTC", decimals: BTC_DECIMALS };
+  // BTC with no chain, or explicitly BTC:bitcoin (incl. the "btc" alias)
+  if (assetPart.toUpperCase() === "BTC" && (!chainPart || resolveChain(chainPart) === "bitcoin")) {
+    return { chain: "bitcoin", address: zeroAddress, symbol: "BTC", decimals: BTC_DECIMALS };
   }
   if (!chainPart) {
     throw new Error(`chain required for token "${assetPart}".\n  Specify a chain, e.g. ${assetPart}:base`);
@@ -72,13 +71,16 @@ export async function resolveSendAsset(raw: string, deps?: Partial<AssetResolver
   try {
     const native = getNativeToken(chain);
     if (assetPart.toUpperCase() === native.symbol.toUpperCase()) {
-      return { chain, address: ZERO_ADDRESS, symbol: native.symbol, decimals: native.decimals };
+      return { chain, address: zeroAddress, symbol: native.symbol, decimals: native.decimals };
     }
   } catch {
     // unknown chain for native lookup — fall through to token resolution / errors below
   }
 
   if (isAddress(assetPart, { strict: false })) {
+    if (chain === "bitcoin") {
+      throw new Error(`"${chain}" does not support EVM token addresses — only BTC can be sent on bitcoin.`);
+    }
     const hit = lookupToken(chain, assetPart.toLowerCase());
     if (hit) return { chain, address: assetPart, symbol: hit.symbol, decimals: hit.decimals };
     const onchain = await readOnChainToken(chain, assetPart);

--- a/gateway-cli/src/util/asset-resolver.ts
+++ b/gateway-cli/src/util/asset-resolver.ts
@@ -1,0 +1,93 @@
+import { isAddress, createPublicClient, http, erc20Abi } from "viem";
+import { getChainConfig } from "@gobob/bob-sdk";
+import tokenlistJson from "@gobob/tokenlist/tokenlist.json";
+import type { ResolvedAsset } from "./input-resolver.js";
+import { resolveChain } from "./input-resolver.js";
+import { CHAIN_IDS, getNativeToken } from "../chains/evm.js";
+import { resolveRpcUrl } from "./rpc-resolver.js";
+import { BTC_DECIMALS } from "../config.js";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/** Token metadata index keyed by `${chainId}:SYMBOL` and `${chainId}:address` (lowercase). */
+type Meta = { address: string; symbol: string; decimals: number };
+let _index: Map<string, Meta> | null = null;
+function tokenlistIndex(): Map<string, Meta> {
+  if (_index) return _index;
+  const idx = new Map<string, Meta>();
+  for (const t of tokenlistJson.tokens as Array<{ address: string; symbol: string; decimals: number; chainId: number }>) {
+    const meta: Meta = { address: t.address, symbol: t.symbol, decimals: t.decimals };
+    idx.set(`${t.chainId}:${t.symbol.toUpperCase()}`, meta);
+    idx.set(`${t.chainId}:${t.address.toLowerCase()}`, meta);
+  }
+  _index = idx;
+  return idx;
+}
+
+export interface AssetResolverDeps {
+  /** Resolve a token by chain + (uppercase symbol | lowercase address). Returns undefined if unknown. */
+  lookupToken(chain: string, key: string): Meta | undefined;
+  /** Read symbol/decimals on-chain for an arbitrary ERC20 address. */
+  readOnChainToken(chain: string, address: string): Promise<{ symbol: string; decimals: number }>;
+}
+
+function defaultLookupToken(chain: string, key: string): Meta | undefined {
+  const chainId = CHAIN_IDS[chain];
+  if (chainId === undefined) return undefined;
+  return tokenlistIndex().get(`${chainId}:${key}`);
+}
+
+async function defaultReadOnChainToken(chain: string, address: string): Promise<{ symbol: string; decimals: number }> {
+  const client = createPublicClient({ chain: getChainConfig(chain), transport: http(await resolveRpcUrl(chain)) });
+  const addr = address as `0x${string}`;
+  try {
+    const [decimals, symbol] = await Promise.all([
+      client.readContract({ address: addr, abi: erc20Abi, functionName: "decimals" }),
+      client.readContract({ address: addr, abi: erc20Abi, functionName: "symbol" }),
+    ]);
+    return { symbol, decimals };
+  } catch (err) {
+    throw new Error(`could not read ERC20 metadata for ${address} on "${chain}" — is it a valid token contract? ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Resolve a `send` asset string into a ResolvedAsset. Route-independent (unlike input-resolver's parseAssetChain). */
+export async function resolveSendAsset(raw: string, deps?: Partial<AssetResolverDeps>): Promise<ResolvedAsset> {
+  const lookupToken = deps?.lookupToken ?? defaultLookupToken;
+  const readOnChainToken = deps?.readOnChainToken ?? defaultReadOnChainToken;
+
+  const colon = raw.indexOf(":");
+  const assetPart = colon === -1 ? raw : raw.slice(0, colon);
+  const chainPart = colon === -1 ? undefined : raw.slice(colon + 1);
+
+  if (assetPart.toUpperCase() === "BTC" && !chainPart) {
+    return { chain: "bitcoin", address: ZERO_ADDRESS, symbol: "BTC", decimals: BTC_DECIMALS };
+  }
+  if (!chainPart) {
+    throw new Error(`chain required for token "${assetPart}".\n  Specify a chain, e.g. ${assetPart}:base`);
+  }
+  const chain = resolveChain(chainPart);
+
+  // Native token by symbol (ETH, BNB, ...)
+  try {
+    const native = getNativeToken(chain);
+    if (assetPart.toUpperCase() === native.symbol.toUpperCase()) {
+      return { chain, address: ZERO_ADDRESS, symbol: native.symbol, decimals: native.decimals };
+    }
+  } catch {
+    // unknown chain for native lookup — fall through to token resolution / errors below
+  }
+
+  if (isAddress(assetPart, { strict: false })) {
+    const hit = lookupToken(chain, assetPart.toLowerCase());
+    if (hit) return { chain, address: assetPart, symbol: hit.symbol, decimals: hit.decimals };
+    const onchain = await readOnChainToken(chain, assetPart);
+    return { chain, address: assetPart, symbol: onchain.symbol, decimals: onchain.decimals };
+  }
+
+  const hit = lookupToken(chain, assetPart.toUpperCase());
+  if (!hit) {
+    throw new Error(`unknown token "${assetPart}" on chain "${chain}".\n  Use a known symbol, a raw 0x address, or run 'gateway-cli routes --tokens ${chain}'.`);
+  }
+  return { chain, address: hit.address, symbol: hit.symbol, decimals: hit.decimals };
+}

--- a/gateway-cli/tests/chains/bitcoin-send.test.ts
+++ b/gateway-cli/tests/chains/bitcoin-send.test.ts
@@ -1,10 +1,25 @@
 import { describe, it, expect } from "vitest";
-import { psbtBase64ToHex } from "../../src/chains/bitcoin.js";
+import { psbtBase64ToHex, btcSweepAmount } from "../../src/chains/bitcoin.js";
 
 describe("psbtBase64ToHex", () => {
   it("converts base64 PSBT bytes to lowercase hex", () => {
     const hex = "70736274ff01"; // arbitrary bytes
     const base64 = Buffer.from(hex, "hex").toString("base64");
     expect(psbtBase64ToHex(base64)).toBe(hex);
+  });
+});
+
+describe("btcSweepAmount", () => {
+  it("returns confirmed balance minus the fee", () => {
+    expect(btcSweepAmount(100_000n, 2_500n)).toBe(97_500n);
+  });
+
+  it("throws when the result is at or below dust (546 sats)", () => {
+    // 546 confirmed, 0 fee → sweep 546, not strictly above dust
+    expect(() => btcSweepAmount(546n, 0n)).toThrow(/too low to cover/i);
+  });
+
+  it("throws when the fee exceeds the balance", () => {
+    expect(() => btcSweepAmount(1_000n, 1_200n)).toThrow(/too low to cover/i);
   });
 });

--- a/gateway-cli/tests/chains/bitcoin-send.test.ts
+++ b/gateway-cli/tests/chains/bitcoin-send.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { psbtBase64ToHex } from "../../src/chains/bitcoin.js";
+
+describe("psbtBase64ToHex", () => {
+  it("converts base64 PSBT bytes to lowercase hex", () => {
+    const hex = "70736274ff01"; // arbitrary bytes
+    const base64 = Buffer.from(hex, "hex").toString("base64");
+    expect(psbtBase64ToHex(base64)).toBe(hex);
+  });
+});

--- a/gateway-cli/tests/chains/evm-send.test.ts
+++ b/gateway-cli/tests/chains/evm-send.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { encodeFunctionData, erc20Abi } from "viem";
+import { nativeSweepAmount, buildUnsignedEvmTx } from "../../src/chains/evm.js";
+import type { ResolvedAsset } from "../../src/util/input-resolver.js";
+
+const TO = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const FROM = "0x1111111111111111111111111111111111111111";
+const USDC: ResolvedAsset = { chain: "base", address: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", symbol: "USDC", decimals: 6 };
+const ETH: ResolvedAsset = { chain: "base", address: "0x0000000000000000000000000000000000000000", symbol: "ETH", decimals: 18 };
+
+describe("nativeSweepAmount", () => {
+  it("deducts exactly 21000 * maxFeePerGas", () => {
+    expect(nativeSweepAmount(1_000_000n, 10n)).toBe(1_000_000n - 21_000n * 10n);
+  });
+  it("returns 0 when the gas cost exceeds the balance", () => {
+    expect(nativeSweepAmount(100n, 10n)).toBe(0n);
+  });
+});
+
+describe("buildUnsignedEvmTx", () => {
+  it("builds a native transfer with empty calldata", () => {
+    const tx = buildUnsignedEvmTx(ETH, TO, 500n, FROM, 8453);
+    expect(tx).toEqual({ from: FROM, to: TO, value: "500", data: "0x", chainId: 8453 });
+  });
+  it("builds an ERC20 transfer with encoded calldata and zero value", () => {
+    const tx = buildUnsignedEvmTx(USDC, TO, 500n, FROM, 8453);
+    const expectedData = encodeFunctionData({ abi: erc20Abi, functionName: "transfer", args: [TO as `0x${string}`, 500n] });
+    expect(tx).toEqual({ from: FROM, to: USDC.address, value: "0", data: expectedData, chainId: 8453 });
+  });
+});

--- a/gateway-cli/tests/chains/recipient.test.ts
+++ b/gateway-cli/tests/chains/recipient.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { validateRecipient } from "../../src/chains/index.js";
+
+const EVM = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const BTC = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+describe("validateRecipient", () => {
+  it("accepts an EVM address for an EVM chain", () => {
+    expect(() => validateRecipient("base", EVM)).not.toThrow();
+  });
+  it("accepts a BTC address for bitcoin", () => {
+    expect(() => validateRecipient("bitcoin", BTC)).not.toThrow();
+  });
+  it("rejects a BTC address for an EVM chain", () => {
+    expect(() => validateRecipient("base", BTC)).toThrow(/valid EVM address/i);
+  });
+  it("rejects an EVM address for bitcoin", () => {
+    expect(() => validateRecipient("bitcoin", EVM)).toThrow(/valid Bitcoin address/i);
+  });
+});

--- a/gateway-cli/tests/commands/send-schema.test.ts
+++ b/gateway-cli/tests/commands/send-schema.test.ts
@@ -15,4 +15,8 @@ describe("sendSchema", () => {
   it("rejects a non-positive btcFeeRate", () => {
     expect(() => sendSchema.parse({ asset: "BTC", amount: "1000", to: "bc1qxyz", btcFeeRate: "0" })).toThrow();
   });
+  it("accepts an optional --from sender address", () => {
+    const out = sendSchema.parse({ asset: "BTC", amount: "1000", to: "bc1qxyz", from: "bc1qsender" });
+    expect(out.from).toBe("bc1qsender");
+  });
 });

--- a/gateway-cli/tests/commands/send-schema.test.ts
+++ b/gateway-cli/tests/commands/send-schema.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { sendSchema } from "../../src/schemas.js";
+
+describe("sendSchema", () => {
+  it("parses a minimal valid send with defaults", () => {
+    const out = sendSchema.parse({ asset: "BTC", amount: "0.01BTC", to: "bc1qxyz" });
+    expect(out.wait).toBe(true);
+    expect(out.unsigned).toBe(false);
+    expect(out.json).toBe(false);
+  });
+  it("coerces btcFeeRate to a positive integer", () => {
+    const out = sendSchema.parse({ asset: "BTC", amount: "1000", to: "bc1qxyz", btcFeeRate: "5" });
+    expect(out.btcFeeRate).toBe(5);
+  });
+  it("rejects a non-positive btcFeeRate", () => {
+    expect(() => sendSchema.parse({ asset: "BTC", amount: "1000", to: "bc1qxyz", btcFeeRate: "0" })).toThrow();
+  });
+});

--- a/gateway-cli/tests/commands/send.test.ts
+++ b/gateway-cli/tests/commands/send.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import type { Logger } from "../../src/output.js";
 
 vi.mock("../../src/config.js", () => ({
   BTC_DECIMALS: 8,
@@ -6,7 +7,22 @@ vi.mock("../../src/config.js", () => ({
   getSdk: () => ({}),
 }));
 
-import { resolveSendAmount } from "../../src/commands/send.js";
+const mockBuildBtcPsbt = vi.fn().mockResolvedValue("cHNidP8B-mock");
+
+vi.mock("../../src/chains/bitcoin.js", () => ({
+  buildBtcPsbt: (...args: any[]) => mockBuildBtcPsbt(...args),
+  estimateBtcSweepAmount: vi.fn(),
+}));
+
+vi.mock("../../src/util/asset-resolver.js", () => ({
+  resolveSendAsset: vi.fn().mockResolvedValue({
+    chain: "bitcoin", address: "BTC", symbol: "BTC", decimals: 8,
+  }),
+}));
+
+const noopLog: Logger = { progress: () => {} } as any;
+
+import { resolveSendAmount, handleSend } from "../../src/commands/send.js";
 
 describe("resolveSendAmount", () => {
   it("returns parsed atomic units for a concrete amount", async () => {
@@ -36,5 +52,36 @@ describe("resolveSendAmount", () => {
       undefined,
       { spendable: async () => 0n },
     )).rejects.toThrow(/no .*balance/i);
+  });
+});
+
+const BTC_SENDER = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const BTC_TO = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+describe("handleSend BTC --unsigned --from (keyless)", () => {
+  it("builds an unsigned PSBT from --from with no private key", async () => {
+    const result = await handleSend(
+      { asset: "BTC", amount: "1000", to: BTC_TO, from: BTC_SENDER, unsigned: true, wait: false } as any,
+      noopLog,
+    );
+    expect(result.type).toBe("unsigned");
+    expect(mockBuildBtcPsbt).toHaveBeenCalledWith(BTC_SENDER, BTC_TO, 1000n, undefined, "default");
+    if (result.type === "unsigned") {
+      expect((result.data as any).psbtBase64).toBe("cHNidP8B-mock");
+    }
+  });
+
+  it("rejects an invalid --from address for the asset's chain", async () => {
+    await expect(handleSend(
+      { asset: "BTC", amount: "1000", to: BTC_TO, from: "0xdeadbeef", unsigned: true, wait: false } as any,
+      noopLog,
+    )).rejects.toThrow(/valid Bitcoin address/i);
+  });
+
+  it("still requires a key when no --from is given", async () => {
+    await expect(handleSend(
+      { asset: "BTC", amount: "1000", to: BTC_TO, unsigned: true, wait: false } as any,
+      noopLog,
+    )).rejects.toThrow(/key is required|BITCOIN_PRIVATE_KEY/i);
   });
 });

--- a/gateway-cli/tests/commands/send.test.ts
+++ b/gateway-cli/tests/commands/send.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../src/config.js", () => ({
+  BTC_DECIMALS: 8,
+  loadConfig: () => ({ timeoutMs: 1000, slippageBps: 300 }),
+  getSdk: () => ({}),
+}));
+
+import { resolveSendAmount } from "../../src/commands/send.js";
+
+describe("resolveSendAmount", () => {
+  it("returns parsed atomic units for a concrete amount", async () => {
+    const out = await resolveSendAmount(
+      { amount: "1000" } as any,
+      { chain: "base", address: "0x0000000000000000000000000000000000000000", symbol: "ETH", decimals: 18 },
+      undefined,
+      { spendable: async () => 999n },
+    );
+    expect(out).toBe(1000n);
+  });
+
+  it("uses the spendable callback for ALL", async () => {
+    const out = await resolveSendAmount(
+      { amount: "ALL" } as any,
+      { chain: "base", address: "0x0000000000000000000000000000000000000000", symbol: "ETH", decimals: 18 },
+      undefined,
+      { spendable: async () => 12345n },
+    );
+    expect(out).toBe(12345n);
+  });
+
+  it("throws on ALL with zero spendable", async () => {
+    await expect(resolveSendAmount(
+      { amount: "ALL" } as any,
+      { chain: "base", address: "0x0", symbol: "ETH", decimals: 18 },
+      undefined,
+      { spendable: async () => 0n },
+    )).rejects.toThrow(/no .*balance/i);
+  });
+});

--- a/gateway-cli/tests/util/asset-resolver.test.ts
+++ b/gateway-cli/tests/util/asset-resolver.test.ts
@@ -62,4 +62,19 @@ describe("resolveSendAsset", () => {
   it("throws when a non-BTC asset has no chain", async () => {
     await expect(resolveSendAsset("USDC", deps)).rejects.toThrow(/chain required/i);
   });
+
+  it("resolves BTC:bitcoin (explicit chain) the same as bare BTC", async () => {
+    const a = await resolveSendAsset("BTC:bitcoin", deps);
+    expect(a).toEqual({ chain: "bitcoin", address: "0x0000000000000000000000000000000000000000", symbol: "BTC", decimals: 8 });
+  });
+
+  it("resolves BTC via the btc alias (BTC:btc)", async () => {
+    const a = await resolveSendAsset("BTC:btc", deps);
+    expect(a.chain).toBe("bitcoin");
+    expect(a.symbol).toBe("BTC");
+  });
+
+  it("rejects an EVM token address on the bitcoin chain", async () => {
+    await expect(resolveSendAsset(`${USDC_BASE}:bitcoin`, deps)).rejects.toThrow(/does not support EVM token addresses/i);
+  });
 });

--- a/gateway-cli/tests/util/asset-resolver.test.ts
+++ b/gateway-cli/tests/util/asset-resolver.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../src/config.js", () => ({ BTC_DECIMALS: 8 }));
+
+vi.mock("../../src/chains/evm.js", () => ({
+  CHAIN_IDS: { ethereum: 1, base: 8453, arbitrum: 42161 },
+  getNativeToken: (chain: string) => {
+    const N: Record<string, { symbol: string; decimals: number }> = {
+      ethereum: { symbol: "ETH", decimals: 18 },
+      base: { symbol: "ETH", decimals: 18 },
+    };
+    if (!N[chain]) throw new Error(`unknown chain "${chain}"`);
+    return N[chain];
+  },
+  getTokenMetadata: () => { throw new Error("not used in this test"); },
+}));
+
+import { resolveSendAsset } from "../../src/util/asset-resolver.js";
+
+const USDC_BASE = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const UNKNOWN = "0x1111111111111111111111111111111111111111";
+
+const deps = {
+  lookupToken: (chain: string, key: string) => {
+    if (chain === "base" && key === "USDC") return { address: USDC_BASE, symbol: "USDC", decimals: 6 };
+    if (chain === "base" && key === USDC_BASE.toLowerCase()) return { address: USDC_BASE, symbol: "USDC", decimals: 6 };
+    return undefined;
+  },
+  readOnChainToken: async (_chain: string, _addr: string) => ({ symbol: "FOO", decimals: 9 }),
+};
+
+describe("resolveSendAsset", () => {
+  it("resolves bare BTC to bitcoin native", async () => {
+    const a = await resolveSendAsset("BTC", deps);
+    expect(a).toEqual({ chain: "bitcoin", address: "0x0000000000000000000000000000000000000000", symbol: "BTC", decimals: 8 });
+  });
+
+  it("resolves a native EVM token (ETH:base)", async () => {
+    const a = await resolveSendAsset("ETH:base", deps);
+    expect(a).toEqual({ chain: "base", address: "0x0000000000000000000000000000000000000000", symbol: "ETH", decimals: 18 });
+  });
+
+  it("resolves a tokenlist symbol with chain alias", async () => {
+    const a = await resolveSendAsset("usdc:base", deps);
+    expect(a).toEqual({ chain: "base", address: USDC_BASE, symbol: "USDC", decimals: 6 });
+  });
+
+  it("resolves a raw address present in the tokenlist", async () => {
+    const a = await resolveSendAsset(`${USDC_BASE}:base`, deps);
+    expect(a).toEqual({ chain: "base", address: USDC_BASE, symbol: "USDC", decimals: 6 });
+  });
+
+  it("falls back to on-chain decimals for an unknown address", async () => {
+    const a = await resolveSendAsset(`${UNKNOWN}:base`, deps);
+    expect(a).toEqual({ chain: "base", address: UNKNOWN, symbol: "FOO", decimals: 9 });
+  });
+
+  it("throws a helpful error for an unknown symbol", async () => {
+    await expect(resolveSendAsset("DOGE:base", deps)).rejects.toThrow(/unknown token "DOGE"/i);
+  });
+
+  it("throws when a non-BTC asset has no chain", async () => {
+    await expect(resolveSendAsset("USDC", deps)).rejects.toThrow(/chain required/i);
+  });
+});

--- a/gateway-cli/tests/util/format-send.test.ts
+++ b/gateway-cli/tests/util/format-send.test.ts
@@ -12,4 +12,14 @@ describe("formatSend", () => {
     const out = formatSend({ unsigned: true, chain: "bitcoin", asset: "BTC", amount: "1000", to: "bc1q", psbtBase64: "cHNidA==" });
     expect(out).toContain("cHNidA==");
   });
+  it("formats a broadcast (unconfirmed) send with the txid", () => {
+    const out = formatSend({ asset: "ETH", chain: "ethereum", amount: "1", to: "0xfoo", txId: "0xbar", status: "broadcast" });
+    expect(out).toContain("0xbar");
+    expect(out).toContain("Broadcast");
+  });
+  it("formats an unsigned EVM tx result", () => {
+    const out = formatSend({ unsigned: true, chain: "ethereum", asset: "WETH", amount: "1", to: "0xfoo", tx: { from: "0xaaa", to: "0xbbb", value: "1", data: "0x", chainId: 1 } });
+    expect(out).toContain("0xbbb");
+    expect(out).toContain("1");
+  });
 });

--- a/gateway-cli/tests/util/format-send.test.ts
+++ b/gateway-cli/tests/util/format-send.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { formatSend } from "../../src/output.js";
+
+describe("formatSend", () => {
+  it("formats a confirmed send with the txid", () => {
+    const out = formatSend({ asset: "USDC", chain: "base", amount: "100", to: "0xabc", txId: "0xdead", status: "confirmed" });
+    expect(out).toContain("0xdead");
+    expect(out).toContain("USDC");
+    expect(out).toContain("base");
+  });
+  it("formats an unsigned BTC PSBT result", () => {
+    const out = formatSend({ unsigned: true, chain: "bitcoin", asset: "BTC", amount: "1000", to: "bc1q", psbtBase64: "cHNidA==" });
+    expect(out).toContain("cHNidA==");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `send` command to `gateway-cli` for **direct, single-chain wallet transfers** of BTC or an EVM asset (native or ERC20) — no Gateway quote/order/bridging. The command name mirrors Foundry's `cast send` (the verb for transferring funds in the forge/cast/anvil suite).

```
gateway-cli send --asset <asset[:chain]> --amount <value> --to <address> [flags]
```

- `--asset` — `BTC`, `BTC:bitcoin`, `ETH:base`, `USDC:arbitrum`, or a raw `0xToken:base`
- `--amount` — `0.05BTC`, `100USDC`, `100USD`, atomic units, or `ALL`
- `--to` — recipient (validated against the asset's chain family)
- `--private-key` (or `BITCOIN_PRIVATE_KEY` / `EVM_PRIVATE_KEY`), `--btc-fee-rate`, `--unsigned`, `--no-wait`, `--timeout`, `--json`

## How it works

- **EVM:** native via viem `sendTransaction`, ERC20 via `writeContract` `transfer` (reuses `resolveEvmSigner`).
- **Bitcoin:** composes SDK primitives — `createBitcoinPsbt` → `ScureBitcoinSigner.signAllInputs` → `EsploraClient.broadcastTx`. (`ScureBitcoinSigner` is sign-only; there is no ready-made BTC send helper.)
- **Asset resolution:** route-independent resolver (`src/util/asset-resolver.ts`) backed by `@gobob/tokenlist`, falling back to an on-chain `decimals()`/`symbol()` read for arbitrary token addresses. Decimals are never guessed. Rejects EVM token addresses on the bitcoin chain.
- **`--unsigned`:** prints unsigned EVM tx params or a base64 PSBT without broadcasting.
- By default waits for 1 confirmation (EVM `waitForTransactionReceipt`, BTC Esplora polling, each with an actionable timeout message); `--no-wait` returns after broadcast.

## `--amount ALL` (sweep)

- **EVM native:** `balance − exact transfer gas` (21000 × maxFeePerGas — not the swap-sized 900k buffer).
- **EVM ERC20:** full token balance.
- **Bitcoin:** drains all confirmed UTXOs to the recipient minus the network fee. `estimateBtcSweepAmount` computes `confirmed − fee` using the SDK's own machinery — `getBalance` and `estimateTxFee(from, undefined, …)` operate over the same safe-UTXO set (`findSafeUtxos`, strategy `'all'`) — and `createBitcoinPsbt` drains that into a single output. Pure `btcSweepAmount(confirmed, fee)` (balance − fee with a dust guard) is unit-tested.

## Testing

- 31 new tests covering real logic: asset resolution (symbol/native/address/on-chain/error branches, `BTC:bitcoin`, bitcoin/EVM-address rejection), recipient chain-family validation, native + BTC sweep math, ERC20 calldata encoding, PSBT base64↔hex conversion, schema validation, formatter branches, and amount resolution incl. `ALL`.
- Network glue (`sendEvm`/`sendBtc`/`handleSend`/`estimateBtcSweepAmount`) is verified end-to-end via offline CLI checks (`--help`, wrong-family rejection, EVM unsigned `0xa9059cbb` calldata) rather than mock-in/mock-out unit tests.
- Full suite: **93/93 passing**, `tsc` build clean. Rebased on latest `master` (SDK 5.7.2).

Built task-by-task with TDD and per-task spec + code-quality review; addressed automated review feedback in a follow-up commit.

## Not yet exercised with real funds (manual follow-up)

- [ ] BTC `--unsigned` PSBT against a funded P2WPKH key
- [ ] BTC signed broadcast end-to-end
- [ ] BTC `--amount ALL` sweep on mainnet (small amount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)