### PR TITLE
fix(sdk): pass account object (not address) to EVM signing calls

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "5.7.1",
+    "version": "5.7.2",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "repository": {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -46,6 +46,23 @@ import { formatBtc, isValidTronAddress, tronAddressToHex } from './utils';
 
 const RETRY_COUNT = 8; // Number of times to retry fetching transaction receipt after sending a transaction
 
+/**
+ * Resolve the `account` to pass to viem write/simulate/send calls.
+ *
+ * Local accounts (e.g. gateway-cli / bots holding a private key) must be passed
+ * as the account OBJECT so viem signs locally (`eth_sendRawTransaction`).
+ * Passing their `.address` downgrades them to a json-rpc account, forcing
+ * `eth_sendTransaction`, which key-signing callers and non-EIP-1193 RPCs
+ * (e.g. Tenderly) reject with "not supported".
+ *
+ * json-rpc accounts keep using the address string — unchanged behaviour for
+ * browser wallets (the connected wallet signs) and the UI's custom Tron client,
+ * which stores a base58 address and handles base58<->hex conversion itself.
+ */
+function signerAccount(walletClient: WalletClient<Transport, ViemChain, Account>): Account | Address {
+    return walletClient.account.type === 'local' ? walletClient.account : walletClient.account.address;
+}
+
 export const ETHEREUM_USDT_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
 
 /**
@@ -364,7 +381,7 @@ export class GatewayApiClient {
                 // https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
                 if (needsReset) {
                     const { request: resetRequest } = await publicClient.simulateContract({
-                        account: walletClient.account,
+                        account: signerAccount(walletClient),
                         address: tokenAddress,
                         abi: USDTApproveAbi,
                         functionName: 'approve',
@@ -376,7 +393,7 @@ export class GatewayApiClient {
                 }
 
                 const { request } = await publicClient.simulateContract({
-                    account: walletClient.account,
+                    account: signerAccount(walletClient),
                     address: tokenAddress as Address,
                     abi:
                         isAddress(tokenAddress as Address) &&
@@ -394,7 +411,7 @@ export class GatewayApiClient {
 
             callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
             const transactionHash = await walletClient.sendTransaction({
-                account: walletClient.account,
+                account: signerAccount(walletClient),
                 data: order.offramp.tx.data as Hex,
                 to: spenderAddress,
                 value: BigInt(order.offramp.tx.value || 0),
@@ -486,7 +503,7 @@ export class GatewayApiClient {
                     // https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
                     if (needsReset) {
                         const { request: resetRequest } = await publicClient.simulateContract({
-                            account: walletClient.account,
+                            account: signerAccount(walletClient),
                             address: tokenAddress as Address,
                             abi: USDTApproveAbi,
                             functionName: 'approve',
@@ -498,7 +515,7 @@ export class GatewayApiClient {
                     }
 
                     const { request } = await publicClient.simulateContract({
-                        account: walletClient.account,
+                        account: signerAccount(walletClient),
                         address: tokenAddress as Address,
                         abi:
                             isAddress(tokenAddress) && isAddressEqual(tokenAddress, ETHEREUM_USDT_ADDRESS)
@@ -528,7 +545,7 @@ export class GatewayApiClient {
 
             callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
             const transactionHash = await walletClient.sendTransaction({
-                account: walletClient.account,
+                account: signerAccount(walletClient),
                 data: order.tokenSwap.tx.data as Hex,
                 to: order.tokenSwap.tx.to as Address,
                 value: BigInt(order.tokenSwap.tx.value || 0),
@@ -577,7 +594,7 @@ export class GatewayApiClient {
 
         if (BigInt(params.amount) > allowance) {
             const { request } = await publicClient.simulateContract({
-                account: walletClient.account,
+                account: signerAccount(walletClient),
                 address: params.token,
                 abi: erc20Abi,
                 functionName: 'approve',
@@ -594,7 +611,7 @@ export class GatewayApiClient {
             abi: strategyCaller,
             functionName: 'handleGatewayMessageWithSlippageArgs', // TODO: encode args
             args: [params.token, params.amount, params.receiver, { amountOutMin: params.amountOutMin }],
-            account: walletClient.account,
+            account: signerAccount(walletClient),
         });
 
         const transactionHash = await walletClient.writeContract(request);

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -364,7 +364,7 @@ export class GatewayApiClient {
                 // https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
                 if (needsReset) {
                     const { request: resetRequest } = await publicClient.simulateContract({
-                        account: walletClient.account.address,
+                        account: walletClient.account,
                         address: tokenAddress,
                         abi: USDTApproveAbi,
                         functionName: 'approve',
@@ -376,7 +376,7 @@ export class GatewayApiClient {
                 }
 
                 const { request } = await publicClient.simulateContract({
-                    account: walletClient.account.address,
+                    account: walletClient.account,
                     address: tokenAddress as Address,
                     abi:
                         isAddress(tokenAddress as Address) &&
@@ -394,7 +394,7 @@ export class GatewayApiClient {
 
             callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
             const transactionHash = await walletClient.sendTransaction({
-                account: walletClient.account.address,
+                account: walletClient.account,
                 data: order.offramp.tx.data as Hex,
                 to: spenderAddress,
                 value: BigInt(order.offramp.tx.value || 0),
@@ -486,7 +486,7 @@ export class GatewayApiClient {
                     // https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
                     if (needsReset) {
                         const { request: resetRequest } = await publicClient.simulateContract({
-                            account: walletClient.account.address,
+                            account: walletClient.account,
                             address: tokenAddress as Address,
                             abi: USDTApproveAbi,
                             functionName: 'approve',
@@ -498,7 +498,7 @@ export class GatewayApiClient {
                     }
 
                     const { request } = await publicClient.simulateContract({
-                        account: walletClient.account.address,
+                        account: walletClient.account,
                         address: tokenAddress as Address,
                         abi:
                             isAddress(tokenAddress) && isAddressEqual(tokenAddress, ETHEREUM_USDT_ADDRESS)
@@ -528,7 +528,7 @@ export class GatewayApiClient {
 
             callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
             const transactionHash = await walletClient.sendTransaction({
-                account: walletClient.account.address,
+                account: walletClient.account,
                 data: order.tokenSwap.tx.data as Hex,
                 to: order.tokenSwap.tx.to as Address,
                 value: BigInt(order.tokenSwap.tx.value || 0),
@@ -577,7 +577,7 @@ export class GatewayApiClient {
 
         if (BigInt(params.amount) > allowance) {
             const { request } = await publicClient.simulateContract({
-                account: walletClient.account.address,
+                account: walletClient.account,
                 address: params.token,
                 abi: erc20Abi,
                 functionName: 'approve',
@@ -594,7 +594,7 @@ export class GatewayApiClient {
             abi: strategyCaller,
             functionName: 'handleGatewayMessageWithSlippageArgs', // TODO: encode args
             args: [params.token, params.amount, params.receiver, { amountOutMin: params.amountOutMin }],
-            account: walletClient.account.address,
+            account: walletClient.account,
         });
 
         const transactionHash = await walletClient.writeContract(request);

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -819,9 +819,7 @@ describe('Gateway Tests', () => {
         // because their account stays type 'json-rpc' either way.
         const gatewaySDK = new GatewaySDK();
         // Throwaway placeholder key (= 1); only used to build a local viem account.
-        const account = privateKeyToAccount(
-            '0x0000000000000000000000000000000000000000000000000000000000000001'
-        );
+        const account = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001');
 
         const mockQuote: GatewayQuoteV3OneOf = {
             offramp: {

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -9,6 +9,7 @@ import {
     WalletClient,
     zeroAddress,
 } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 import {
     BitcoinSigner,
@@ -805,6 +806,81 @@ describe('Gateway Tests', () => {
         expect(simulateContractMock).toHaveBeenCalledTimes(1);
         expect(simulateContractMock.mock.calls[0][0].args).toEqual([spenderAddress, 1000n]);
         expect(mockWalletClient.writeContract).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the local account object (not its address) to sendTransaction on offramp', async () => {
+        // Regression (bob #1075): the offramp send was changed from
+        //   account: walletClient.account  ->  account: walletClient.account.address
+        // A bare address string is a json-rpc account in viem, forcing
+        // eth_sendTransaction (node/wallet signs). Local-key callers (CLI/bots)
+        // then fail on RPCs that don't support it. The account OBJECT (type
+        // 'local') must reach sendTransaction so viem signs locally and uses
+        // eth_sendRawTransaction. Browser (json-rpc) callers are unaffected
+        // because their account stays type 'json-rpc' either way.
+        const gatewaySDK = new GatewaySDK();
+        // Throwaway placeholder key (= 1); only used to build a local viem account.
+        const account = privateKeyToAccount(
+            '0x0000000000000000000000000000000000000000000000000000000000000001'
+        );
+
+        const mockQuote: GatewayQuoteV3OneOf = {
+            offramp: {
+                srcChain: 'bob',
+                feeBreakdown: {
+                    protocolFee: { address: zeroAddress, amount: '5', chain: 'bob' },
+                    affiliateFee: { address: zeroAddress, amount: '2', chain: 'bob' },
+                    solverFee: { address: zeroAddress, amount: '1', chain: 'bob' },
+                    inclusionFee: { address: zeroAddress, amount: '1', chain: 'bob' },
+                    fastestFeeRate: '6',
+                },
+                inputAmount: { address: zeroAddress, amount: '1000', chain: 'bob' },
+                outputAmount: { address: zeroAddress, amount: '990', chain: 'bob' },
+                tokenAddress: WBTC_OFT_ADDRESS,
+                ownerAddress: account.address,
+                recipient: '0x1F5fF4a5B9C15d5C78Fd492e6FCF25905eB3eCFF',
+                slippage: 0,
+                totalFeeUsd: '3',
+                txTo: zeroAddress,
+            },
+        };
+
+        const spenderAddress = '0x1234567890123456789012345678901234567890';
+
+        nock(`${MAINNET_GATEWAY_BASE_URL}`)
+            .post('/v3/create-order')
+            .reply(200, {
+                offramp: {
+                    order_id: 'offramp-order-local',
+                    tx: { type: 'evm', chain: 'bob', to: spenderAddress, data: '0xabcdef', value: '0' },
+                },
+            });
+        nock(`${MAINNET_GATEWAY_BASE_URL}`).patch('/v3/register-tx').reply(200, JSON.stringify('ok'));
+
+        const sendTransactionMock = vi.fn().mockResolvedValue('0xtxhash' as `0x${string}`);
+        const mockWalletClient = {
+            account,
+            writeContract: vi.fn().mockResolvedValue('0xapprovehash' as `0x${string}`),
+            sendTransaction: sendTransactionMock,
+        } as unknown as WalletClient<Transport, ViemChain, Account>;
+
+        const mockPublicClient = {
+            // approvalRequired: false -> no approve step, straight to sendTransaction
+            readContract: mockOftReadContract({ approvalRequired: false }),
+            simulateContract: vi.fn().mockResolvedValue({ request: {} }),
+            waitForTransactionReceipt: vi.fn().mockResolvedValue({}),
+        } as unknown as PublicClient<Transport>;
+
+        await gatewaySDK.executeQuote({
+            quote: mockQuote,
+            walletClient: mockWalletClient,
+            publicClient: mockPublicClient,
+        });
+
+        expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+        const passedAccount = sendTransactionMock.mock.calls[0][0].account;
+        // Must be the local account object, not the downgraded address string.
+        expect(passedAccount).toBe(account);
+        expect((passedAccount as Account).type).toBe('local');
     });
 
     it('should reset USDT allowance before approving', async () => {

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -881,6 +881,72 @@ describe('Gateway Tests', () => {
         expect((passedAccount as Account).type).toBe('local');
     });
 
+    it('passes the address string for json-rpc accounts on offramp (browser/Tron unchanged)', async () => {
+        // Guarantee: the local-account fix must NOT change behaviour for json-rpc
+        // accounts. Browser wallets (wagmi) and the UI's custom Tron client both
+        // use type 'json-rpc' and store the address as a string (base58 for Tron).
+        // They must keep receiving `account.address`, so the wallet signs and any
+        // base58<->hex conversion is handled by the injected client as before.
+        const gatewaySDK = new GatewaySDK();
+        const jsonRpcAddress = '0xabcd1234abcd1234abcd1234abcd1234abcd1234' as Address;
+
+        const mockQuote: GatewayQuoteV3OneOf = {
+            offramp: {
+                srcChain: 'bob',
+                feeBreakdown: {
+                    protocolFee: { address: zeroAddress, amount: '5', chain: 'bob' },
+                    affiliateFee: { address: zeroAddress, amount: '2', chain: 'bob' },
+                    solverFee: { address: zeroAddress, amount: '1', chain: 'bob' },
+                    inclusionFee: { address: zeroAddress, amount: '1', chain: 'bob' },
+                    fastestFeeRate: '6',
+                },
+                inputAmount: { address: zeroAddress, amount: '1000', chain: 'bob' },
+                outputAmount: { address: zeroAddress, amount: '990', chain: 'bob' },
+                tokenAddress: WBTC_OFT_ADDRESS,
+                ownerAddress: jsonRpcAddress,
+                recipient: '0x1F5fF4a5B9C15d5C78Fd492e6FCF25905eB3eCFF',
+                slippage: 0,
+                totalFeeUsd: '3',
+                txTo: zeroAddress,
+            },
+        };
+
+        const spenderAddress = '0x1234567890123456789012345678901234567890';
+
+        nock(`${MAINNET_GATEWAY_BASE_URL}`)
+            .post('/v3/create-order')
+            .reply(200, {
+                offramp: {
+                    order_id: 'offramp-order-jsonrpc',
+                    tx: { type: 'evm', chain: 'bob', to: spenderAddress, data: '0xabcdef', value: '0' },
+                },
+            });
+        nock(`${MAINNET_GATEWAY_BASE_URL}`).patch('/v3/register-tx').reply(200, JSON.stringify('ok'));
+
+        const sendTransactionMock = vi.fn().mockResolvedValue('0xtxhash' as `0x${string}`);
+        const mockWalletClient = {
+            account: { address: jsonRpcAddress, type: 'json-rpc' },
+            writeContract: vi.fn().mockResolvedValue('0xapprovehash' as `0x${string}`),
+            sendTransaction: sendTransactionMock,
+        } as unknown as WalletClient<Transport, ViemChain, Account>;
+
+        const mockPublicClient = {
+            readContract: mockOftReadContract({ approvalRequired: false }),
+            simulateContract: vi.fn().mockResolvedValue({ request: {} }),
+            waitForTransactionReceipt: vi.fn().mockResolvedValue({}),
+        } as unknown as PublicClient<Transport>;
+
+        await gatewaySDK.executeQuote({
+            quote: mockQuote,
+            walletClient: mockWalletClient,
+            publicClient: mockPublicClient,
+        });
+
+        expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+        // json-rpc account -> address string is passed (unchanged from pre-fix behaviour).
+        expect(sendTransactionMock.mock.calls[0][0].account).toBe(jsonRpcAddress);
+    });
+
     it('should reset USDT allowance before approving', async () => {
         const gatewaySDK = new GatewaySDK();
 


### PR DESCRIPTION
## Problem

`executeQuote` (offramp / tokenSwap) and `executeStrategy` dispatch their EVM transactions with:

```js
walletClient.sendTransaction({ account: walletClient.account.address, ... })
```

In viem, a bare **address string** is a `json-rpc` account → `eth_sendTransaction` (the node/wallet signs). The **account object** from `privateKeyToAccount` is `type: 'local'` → viem signs locally → `eth_sendRawTransaction`.

Passing `.address` coerces **every** caller to json-rpc signing. That's invisible to browser wallets (they're json-rpc anyway, so the wallet signs), but it breaks **local-key callers (gateway-cli / bots)**: the local account is downgraded, viem calls `eth_sendTransaction`, and RPCs that don't support it (Tenderly) reject with `not supported`. This took down **every offramp/tokenSwap leg** of the gateway-bot once the earlier Tron crash ([#1084](https://github.com/bob-collective/bob/pull/1084)) stopped masking it — onramps (BTC→EVM, which sign a PSBT) were unaffected, matching the observed failure pattern.

## Why now

[#1075](https://github.com/bob-collective/bob/pull/1075) (v3 API) changed all these sites from `account: walletClient.account` → `account: walletClient.account.address`. The UI never noticed; the gateway-cli is the new local-account consumer.

## Fix

A bare revert to the object would be too broad: the UI's custom Tron `walletClient` ([`use-tron-wallet-client.ts`](https://github.com/bob-collective/ui/blob/44bb02aaf972f6aa858695d01615b9dd1ba34664/apps/evm/src/app/%5Blang%5D/swap/hooks/use-tron-wallet-client.ts#L153)) stores its address as **base58** with `type: 'json-rpc'`, and deliberately receives the address string (its `sendTransaction`/`writeContract` ignore the `account` field; base58↔hex is handled around `triggersmartcontract` with `visible: true`).

So the fix gates on **`account.type`** via a `signerAccount()` helper:

| Account type | Caller | Passed to viem | Result |
|---|---|---|---|
| `local` | gateway-cli / bots (private key) | account **object** | local sign → `eth_sendRawTransaction` ✅ fixed |
| `json-rpc` | browser wallets **and** the Tron client | address **string** | unchanged — wallet signs, base58↔hex handled by the client |

Applied at all 8 call sites (offramp + tokenSwap + executeStrategy). The Tron/browser path is byte-for-byte unchanged.

## Verification

- **New test**: a `type: 'local'` account object reaches `sendTransaction` on offramp (failed before the fix, passes after).
- **Companion test**: a `type: 'json-rpc'` account still receives the address string — locks in that browser/Tron behaviour is unaffected.
- Full SDK suite: **69 passing** (was 67), prettier + `tsc` clean.
- Version bumped 5.7.1 → 5.7.2.

> Not published / not rippled to gateway-cli + bot yet — opening for review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)