### PR TITLE
fix(sdk): buffer gas limit on offramp/tokenSwap sends for local-key signers (#1088)

### DIFF
--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -66,12 +66,10 @@ function signerAccount(walletClient: WalletClient<Transport, ViemChain, Account>
 /**
  * Gas-limit buffer for offramp / tokenSwap sends (bob#1088).
  *
- * Combines the two buffers bob-gateway already uses: velora multiplies its
- * estimate by 1.2 (crates/velora/src/api/client.rs) and the intents path adds a
- * fixed 300k cushion (crates/intents/src/constant.rs). We take the max so small
- * txs get the fixed floor and large (velora) txs get the multiplier. A gas
- * *limit* is not a gas *cost* — unused gas is refunded — so erring generous is
- * nearly free, while erring tight causes silent out-of-gas order failures.
+ * Takes the max of a 1.2x multiplier and a fixed 300k cushion, so small txs get
+ * the fixed floor and large (aggregator) txs get the multiplier. Unused gas is
+ * refunded, so a generous limit is nearly free while a tight one causes
+ * out-of-gas failures on gas-heavy routes.
  */
 const GAS_BUFFER_NUM = 12n;
 const GAS_BUFFER_DEN = 10n;

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -42,7 +42,7 @@ import {
     type GetQuoteParams,
     type StrategyParams,
 } from './types';
-import { formatBtc, isValidTronAddress, tronAddressToHex } from './utils';
+import { estimateGasWithBuffer, formatBtc, isValidTronAddress, tronAddressToHex } from './utils';
 
 const RETRY_COUNT = 8; // Number of times to retry fetching transaction receipt after sending a transaction
 
@@ -61,47 +61,6 @@ const RETRY_COUNT = 8; // Number of times to retry fetching transaction receipt 
  */
 function signerAccount(walletClient: WalletClient<Transport, ViemChain, Account>): Account | Address {
     return walletClient.account.type === 'local' ? walletClient.account : walletClient.account.address;
-}
-
-/**
- * Gas-limit buffer for offramp / tokenSwap sends (bob#1088).
- *
- * Takes the max of a 1.2x multiplier and a fixed 300k cushion, so small txs get
- * the fixed floor and large (aggregator) txs get the multiplier. Unused gas is
- * refunded, so a generous limit is nearly free while a tight one causes
- * out-of-gas failures on gas-heavy routes.
- */
-const GAS_BUFFER_NUM = 12n;
-const GAS_BUFFER_DEN = 10n;
-const GAS_BUFFER_FIXED = 300_000n;
-
-function applyGasBuffer(estimate: bigint): bigint {
-    const multiplied = (estimate * GAS_BUFFER_NUM) / GAS_BUFFER_DEN;
-    const fixed = estimate + GAS_BUFFER_FIXED;
-    return multiplied > fixed ? multiplied : fixed;
-}
-
-/**
- * Buffered gas limit for local-key sends, or `undefined` to fall back to viem's
- * default estimation. If `eth_estimateGas` reverts we return `undefined` so the
- * send behaves exactly as it does today — never introducing a new failure mode.
- */
-async function estimateGasWithBuffer(
-    publicClient: PublicClient<Transport>,
-    account: Account,
-    tx: { to: Address; data: Hex; value: bigint }
-): Promise<bigint | undefined> {
-    try {
-        const estimate = await publicClient.estimateGas({
-            account,
-            to: tx.to,
-            data: tx.data,
-            value: tx.value,
-        });
-        return applyGasBuffer(estimate);
-    } catch {
-        return undefined;
-    }
 }
 
 export const ETHEREUM_USDT_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7';

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -63,6 +63,49 @@ function signerAccount(walletClient: WalletClient<Transport, ViemChain, Account>
     return walletClient.account.type === 'local' ? walletClient.account : walletClient.account.address;
 }
 
+/**
+ * Gas-limit buffer for offramp / tokenSwap sends (bob#1088).
+ *
+ * Combines the two buffers bob-gateway already uses: velora multiplies its
+ * estimate by 1.2 (crates/velora/src/api/client.rs) and the intents path adds a
+ * fixed 300k cushion (crates/intents/src/constant.rs). We take the max so small
+ * txs get the fixed floor and large (velora) txs get the multiplier. A gas
+ * *limit* is not a gas *cost* — unused gas is refunded — so erring generous is
+ * nearly free, while erring tight causes silent out-of-gas order failures.
+ */
+const GAS_BUFFER_NUM = 12n;
+const GAS_BUFFER_DEN = 10n;
+const GAS_BUFFER_FIXED = 300_000n;
+
+function applyGasBuffer(estimate: bigint): bigint {
+    const multiplied = (estimate * GAS_BUFFER_NUM) / GAS_BUFFER_DEN;
+    const fixed = estimate + GAS_BUFFER_FIXED;
+    return multiplied > fixed ? multiplied : fixed;
+}
+
+/**
+ * Buffered gas limit for local-key sends, or `undefined` to fall back to viem's
+ * default estimation. If `eth_estimateGas` reverts we return `undefined` so the
+ * send behaves exactly as it does today — never introducing a new failure mode.
+ */
+async function estimateGasWithBuffer(
+    publicClient: PublicClient<Transport>,
+    account: Account,
+    tx: { to: Address; data: Hex; value: bigint }
+): Promise<bigint | undefined> {
+    try {
+        const estimate = await publicClient.estimateGas({
+            account,
+            to: tx.to,
+            data: tx.data,
+            value: tx.value,
+        });
+        return applyGasBuffer(estimate);
+    } catch {
+        return undefined;
+    }
+}
+
 export const ETHEREUM_USDT_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
 
 /**
@@ -410,11 +453,23 @@ export class GatewayApiClient {
             }
 
             callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
+            const offrampData = order.offramp.tx.data as Hex;
+            const offrampValue = BigInt(order.offramp.tx.value || 0);
+            const offrampGas =
+                walletClient.account.type === 'local'
+                    ? await estimateGasWithBuffer(publicClient, walletClient.account, {
+                          to: spenderAddress,
+                          data: offrampData,
+                          value: offrampValue,
+                      })
+                    : undefined;
+
             const transactionHash = await walletClient.sendTransaction({
                 account: signerAccount(walletClient),
-                data: order.offramp.tx.data as Hex,
+                data: offrampData,
                 to: spenderAddress,
-                value: BigInt(order.offramp.tx.value || 0),
+                value: offrampValue,
+                ...(offrampGas !== undefined && { gas: offrampGas }),
             });
 
             await publicClient?.waitForTransactionReceipt({ hash: transactionHash, retryCount: RETRY_COUNT });
@@ -544,11 +599,24 @@ export class GatewayApiClient {
             }
 
             callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
+            const tokenSwapTo = order.tokenSwap.tx.to as Address;
+            const tokenSwapData = order.tokenSwap.tx.data as Hex;
+            const tokenSwapValue = BigInt(order.tokenSwap.tx.value || 0);
+            const tokenSwapGas =
+                walletClient.account.type === 'local'
+                    ? await estimateGasWithBuffer(publicClient, walletClient.account, {
+                          to: tokenSwapTo,
+                          data: tokenSwapData,
+                          value: tokenSwapValue,
+                      })
+                    : undefined;
+
             const transactionHash = await walletClient.sendTransaction({
                 account: signerAccount(walletClient),
-                data: order.tokenSwap.tx.data as Hex,
-                to: order.tokenSwap.tx.to as Address,
-                value: BigInt(order.tokenSwap.tx.value || 0),
+                data: tokenSwapData,
+                to: tokenSwapTo,
+                value: tokenSwapValue,
+                ...(tokenSwapGas !== undefined && { gas: tokenSwapGas }),
             });
 
             await publicClient.waitForTransactionReceipt({ hash: transactionHash, retryCount: RETRY_COUNT });

--- a/sdk/src/gateway/utils/gas.ts
+++ b/sdk/src/gateway/utils/gas.ts
@@ -1,0 +1,42 @@
+import { type Account, type Address, type Hex, type PublicClient, type Transport } from 'viem';
+
+const GAS_BUFFER_NUM = 12n;
+const GAS_BUFFER_DEN = 10n;
+const GAS_BUFFER_FIXED = 300_000n;
+
+/**
+ * Gas-limit buffer for offramp / tokenSwap sends (bob#1088).
+ *
+ * Takes the max of a 1.2x multiplier and a fixed 300k cushion, so small txs get
+ * the fixed floor and large (aggregator) txs get the multiplier. Unused gas is
+ * refunded, so a generous limit is nearly free while a tight one causes
+ * out-of-gas failures on gas-heavy routes.
+ */
+export function applyGasBuffer(estimate: bigint): bigint {
+    const multiplied = (estimate * GAS_BUFFER_NUM) / GAS_BUFFER_DEN;
+    const fixed = estimate + GAS_BUFFER_FIXED;
+    return multiplied > fixed ? multiplied : fixed;
+}
+
+/**
+ * Buffered gas limit for local-key sends, or `undefined` to fall back to viem's
+ * default estimation. If `eth_estimateGas` reverts we return `undefined` so the
+ * send behaves exactly as it does today — never introducing a new failure mode.
+ */
+export async function estimateGasWithBuffer(
+    publicClient: PublicClient<Transport>,
+    account: Account,
+    tx: { to: Address; data: Hex; value: bigint }
+): Promise<bigint | undefined> {
+    try {
+        const estimate = await publicClient.estimateGas({
+            account,
+            to: tx.to,
+            data: tx.data,
+            value: tx.value,
+        });
+        return applyGasBuffer(estimate);
+    } catch {
+        return undefined;
+    }
+}

--- a/sdk/src/gateway/utils/index.ts
+++ b/sdk/src/gateway/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './common';
 export * from './bitcoin-signer';
+export * from './gas';
 export * from './quote';
 export * from './tron';

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -2403,5 +2403,64 @@ describe('Gateway Tests', () => {
             expect(estimateGasMock).not.toHaveBeenCalled();
             expect(sendTransactionMock.mock.calls[0][0]).not.toHaveProperty('gas');
         });
+
+        it('applies max(1.2x, +300k) buffer as gas for a local-key tokenSwap send', async () => {
+            const gatewaySDK = new GatewaySDK();
+
+            const tokenSwapTo = '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c';
+            // zeroAddress input token => requiresApprove is false; straight to sendTransaction.
+            const tokenSwapQuote: GatewayQuoteV2OneOf2 = {
+                tokenSwap: {
+                    dstChain: 'bob',
+                    estimatedTimeInSecs: 60,
+                    fees: { amount: '0', address: zeroAddress, chain: 'bob' },
+                    inputAmount: { amount: '100000', address: zeroAddress, chain: 'ethereum' },
+                    outputAmount: { amount: '100000', address: zeroAddress, chain: 'bob' },
+                    recipient: '0x1F5fF4a5B9C15d5C78Fd492e6FCF25905eB3eCFF',
+                    slippage: 100,
+                    srcChain: 'ethereum',
+                    txTo: tokenSwapTo,
+                },
+            };
+
+            nock(`${MAINNET_GATEWAY_BASE_URL}`)
+                .post('/v3/create-order')
+                .reply(200, {
+                    tokenSwap: {
+                        order_id: 'tokenswap-gas-1',
+                        tx: { type: 'evm', chain: 'ethereum', to: tokenSwapTo, data: '0xabcdef', value: '0' },
+                    },
+                });
+            nock(`${MAINNET_GATEWAY_BASE_URL}`).patch('/v3/register-tx').reply(200, JSON.stringify('ok'));
+
+            const estimate = 1_074_362n; // the failing-case estimate from #1088
+            const sendTransactionMock = vi.fn().mockResolvedValue('0xtxhash' as `0x${string}`);
+            const estimateGasMock = vi.fn().mockResolvedValue(estimate);
+
+            const mockWalletClient = {
+                account: localAccount,
+                writeContract: vi.fn(),
+                sendTransaction: sendTransactionMock,
+            } as unknown as WalletClient<Transport, ViemChain, Account>;
+
+            const mockPublicClient = {
+                readContract: mockOftReadContract({ approvalRequired: false }),
+                multicall: vi.fn().mockResolvedValue([0n]),
+                estimateGas: estimateGasMock,
+                waitForTransactionReceipt: vi.fn().mockResolvedValue({}),
+            } as unknown as PublicClient<Transport>;
+
+            await gatewaySDK.executeQuote({
+                quote: tokenSwapQuote,
+                walletClient: mockWalletClient,
+                publicClient: mockPublicClient,
+            });
+
+            // max(1_074_362*12/10, 1_074_362+300_000) = max(1_289_234, 1_374_362) = 1_374_362
+            expect(estimateGasMock).toHaveBeenCalledWith(
+                expect.objectContaining({ to: tokenSwapTo, data: '0xabcdef', value: 0n })
+            );
+            expect(sendTransactionMock).toHaveBeenCalledWith(expect.objectContaining({ gas: 1_374_362n }));
+        });
     });
 });

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -2270,4 +2270,138 @@ describe('Gateway Tests', () => {
         expect(result).toBeDefined();
         assert(instanceOfGatewayQuoteOneOf(result));
     });
+
+    describe('gas-limit buffer (#1088)', () => {
+        // Throwaway placeholder key (= 1); only used to build a local viem account.
+        const localAccount = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001');
+
+        const offrampQuote = (): GatewayQuoteV3OneOf => ({
+            offramp: {
+                srcChain: 'ethereum',
+                feeBreakdown: {
+                    protocolFee: { address: zeroAddress, amount: '5', chain: 'ethereum' },
+                    affiliateFee: { address: zeroAddress, amount: '2', chain: 'ethereum' },
+                    solverFee: { address: zeroAddress, amount: '1', chain: 'ethereum' },
+                    inclusionFee: { address: zeroAddress, amount: '1', chain: 'ethereum' },
+                    fastestFeeRate: '6',
+                },
+                inputAmount: { address: zeroAddress, amount: '1000', chain: 'ethereum' },
+                outputAmount: { address: zeroAddress, amount: '990', chain: 'ethereum' },
+                // zeroAddress token => no approval path; goes straight to sendTransaction
+                tokenAddress: zeroAddress,
+                ownerAddress: localAccount.address,
+                recipient: '0x1F5fF4a5B9C15d5C78Fd492e6FCF25905eB3eCFF',
+                slippage: 0,
+                totalFeeUsd: '3',
+                txTo: zeroAddress,
+            },
+        });
+
+        const spenderAddress = '0x2e77b55553e7e0fe57f74055757b974e0a6e2a2e';
+
+        function mockCreateOrder() {
+            nock(`${MAINNET_GATEWAY_BASE_URL}`)
+                .post('/v3/create-order')
+                .reply(200, {
+                    offramp: {
+                        order_id: 'offramp-gas-1',
+                        tx: { type: 'evm', chain: 'ethereum', to: spenderAddress, data: '0xabcdef', value: '0' },
+                    },
+                });
+            nock(`${MAINNET_GATEWAY_BASE_URL}`).patch('/v3/register-tx').reply(200, JSON.stringify('ok'));
+        }
+
+        it('applies max(1.2x, +300k) buffer as gas for a local-key offramp send', async () => {
+            const gatewaySDK = new GatewaySDK();
+            mockCreateOrder();
+
+            const estimate = 1_074_362n; // the failing-case estimate from #1088
+            const sendTransactionMock = vi.fn().mockResolvedValue('0xtxhash' as `0x${string}`);
+            const estimateGasMock = vi.fn().mockResolvedValue(estimate);
+
+            const mockWalletClient = {
+                account: localAccount,
+                writeContract: vi.fn(),
+                sendTransaction: sendTransactionMock,
+            } as unknown as WalletClient<Transport, ViemChain, Account>;
+
+            const mockPublicClient = {
+                readContract: mockOftReadContract({ approvalRequired: false }),
+                multicall: vi.fn().mockResolvedValue([0n]),
+                estimateGas: estimateGasMock,
+                waitForTransactionReceipt: vi.fn().mockResolvedValue({}),
+            } as unknown as PublicClient<Transport>;
+
+            await gatewaySDK.executeQuote({
+                quote: offrampQuote(),
+                walletClient: mockWalletClient,
+                publicClient: mockPublicClient,
+            });
+
+            // max(1_074_362*12/10, 1_074_362+300_000) = max(1_289_234, 1_374_362) = 1_374_362
+            expect(estimateGasMock).toHaveBeenCalledWith(
+                expect.objectContaining({ to: spenderAddress, data: '0xabcdef', value: 0n })
+            );
+            expect(sendTransactionMock).toHaveBeenCalledWith(expect.objectContaining({ gas: 1_374_362n }));
+        });
+
+        it('falls back to no gas field when estimateGas throws (no new failure mode)', async () => {
+            const gatewaySDK = new GatewaySDK();
+            mockCreateOrder();
+
+            const sendTransactionMock = vi.fn().mockResolvedValue('0xtxhash' as `0x${string}`);
+            const mockWalletClient = {
+                account: localAccount,
+                writeContract: vi.fn(),
+                sendTransaction: sendTransactionMock,
+            } as unknown as WalletClient<Transport, ViemChain, Account>;
+
+            const mockPublicClient = {
+                readContract: mockOftReadContract({ approvalRequired: false }),
+                multicall: vi.fn().mockResolvedValue([0n]),
+                estimateGas: vi.fn().mockRejectedValue(new Error('execution reverted')),
+                waitForTransactionReceipt: vi.fn().mockResolvedValue({}),
+            } as unknown as PublicClient<Transport>;
+
+            await gatewaySDK.executeQuote({
+                quote: offrampQuote(),
+                walletClient: mockWalletClient,
+                publicClient: mockPublicClient,
+            });
+
+            expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+            expect(sendTransactionMock.mock.calls[0][0]).not.toHaveProperty('gas');
+        });
+
+        it('does NOT estimate or set gas for a json-rpc (browser-wallet) offramp send', async () => {
+            const gatewaySDK = new GatewaySDK();
+            mockCreateOrder();
+
+            const sendTransactionMock = vi.fn().mockResolvedValue('0xtxhash' as `0x${string}`);
+            const estimateGasMock = vi.fn();
+
+            // address-only account => viem json-rpc account (type !== 'local')
+            const mockWalletClient = {
+                account: { address: localAccount.address },
+                writeContract: vi.fn(),
+                sendTransaction: sendTransactionMock,
+            } as unknown as WalletClient<Transport, ViemChain, Account>;
+
+            const mockPublicClient = {
+                readContract: mockOftReadContract({ approvalRequired: false }),
+                multicall: vi.fn().mockResolvedValue([0n]),
+                estimateGas: estimateGasMock,
+                waitForTransactionReceipt: vi.fn().mockResolvedValue({}),
+            } as unknown as PublicClient<Transport>;
+
+            await gatewaySDK.executeQuote({
+                quote: offrampQuote(),
+                walletClient: mockWalletClient,
+                publicClient: mockPublicClient,
+            });
+
+            expect(estimateGasMock).not.toHaveBeenCalled();
+            expect(sendTransactionMock.mock.calls[0][0]).not.toHaveProperty('gas');
+        });
+    });
 });


### PR DESCRIPTION
Closes #1088.

## Problem
`GatewayApiClient.executeQuote` sends the offramp / tokenSwap EVM transactions **without an explicit `gas` limit**, so viem uses a bare `eth_estimateGas` with no safety buffer. On gas-heavy / variable routes (notably **velora** aggregator swaps) the real execution exceeds the estimate and the tx reverts out of gas — surfacing as a silent `{"failed":{}}` order.

The backend `tx` object carries no gas field, so the SDK must estimate and buffer itself. The observed failure (mainnet tx `0x5ab74cf6…0772f`) used 99.8% of a 1,074,362 limit and OOG'd in a **nested call** — the classic 63/64-rule signature where a buffered top-level limit also enlarges the gas forwarded to the sub-call.

## Fix
Add a gas buffer to the two swap `sendTransaction` sites, **for local-key signers only** (`account.type === 'local'` — gateway-bot, gateway-cli, server flows):

```
gas = max(estimate * 12n / 10n, estimate + 300_000n)
```

This `max(1.2x, +300k)` combines the two conventions already in bob-gateway: velora's `estimated_gas * 120/100` (`crates/velora/src/api/client.rs`) and the intents fixed `+300_000` cushion (`crates/intents/src/constant.rs`). Small txs get the fixed floor; large velora txs get the multiplier.

If `eth_estimateGas` reverts, the helper returns `undefined` and the send proceeds exactly as today — **no new failure mode**.

## Impact
- **gateway-bot / gateway-cli** (local key): get the buffer → OOG fixed. Picks up via an `@gobob/bob-sdk` version bump.
- **UI** (injected/json-rpc wallet): branch is skipped → behavior is **byte-for-byte unchanged** (the wallet does its own padding, as before).
- **ERC20 approvals**: out of scope — fixed/predictable gas, never the OOG culprit.

A gas *limit* is not a gas *cost* (unused gas is refunded), so erring generous is nearly free for a bot while erring tight causes the silent failures.

## Tests
`sdk/test/gateway.test.ts` — 4 new tests (offramp happy-path buffer math, estimate-throws fallback, json-rpc path unchanged, tokenSwap happy-path). Full suite: 73 passed / 11 skipped.

## Reviewed
Self-run ducklings methodology (`/bob-review`): no P0–P2 findings; the one coverage gap (tokenSwap test) was added before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)