### PR TITLE
feat(sdk): add utxoSelectionStrategy to BTC tx builders, un-deprecate estimateTxFee

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "5.7.3",
+    "version": "5.8.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "repository": {

--- a/sdk/src/wallet/utxo.ts
+++ b/sdk/src/wallet/utxo.ts
@@ -160,6 +160,8 @@ export interface Input {
  * @param feeRate Optional fee rate in satoshis per byte.
  * @param confirmationTarget The number of blocks to include this tx (for fee estimation).
  * @param isSignet True if using Bitcoin Signet.
+ * @param utxoSelectionStrategy UTXO selection strategy. `'default'` selects a subset (may leave change);
+ *   `'all'` spends every safe UTXO (used for full-balance sweeps so the tx matches an `'all'` fee estimate).
  * @returns {Promise<string>} The Base64 encoded PSBT.
  *
  * @example
@@ -185,12 +187,10 @@ export async function createBitcoinPsbt(
     opReturnData?: string,
     feeRate?: number,
     confirmationTarget: number = 3,
-    isSignet: boolean = false
+    isSignet: boolean = false,
+    utxoSelectionStrategy: 'all' | 'default' = 'default'
 ): Promise<string> {
     const addressInfo = getAddressInfo(fromAddress, isSignet);
-
-    // TODO: possibly, allow other strategies to be passed to this function
-    const utxoSelectionStrategy: 'all' | 'default' = 'default';
 
     if (addressInfo.network === 'regtest') {
         throw new Error('Bitcoin regtest not supported');
@@ -322,9 +322,23 @@ export function getInputFromUtxoAndTx(
 }
 
 /**
- * @deprecated This method is deprecated and will be removed in a future release.
+ * Estimate the Bitcoin network fee (in satoshis) to spend from `fromAddress`.
  *
- * For full balance sweeping, first call `getBalance(address)` to get the confirmed balance, then pass that as the `amount` to `getQuote`.
+ * Used for direct (non-Gateway) sends. With `amount` omitted, all safe UTXOs are
+ * selected (a full-balance sweep estimate); otherwise the fee is estimated for the
+ * given `amount`. Pass `utxoSelectionStrategy` to force a strategy regardless of `amount`
+ * (e.g. `'all'` to match a sweep built with `createBitcoinPsbt(..., 'all')`).
+ *
+ * @param fromAddress The Bitcoin address spending the funds.
+ * @param amount The amount (in satoshis) to send; omit to estimate a full-balance sweep.
+ * @param publicKey Optional public key needed if using P2SH-P2WPKH.
+ * @param opReturnData Optional OP_RETURN data to include in an output.
+ * @param feeRate Optional fee rate in satoshis per byte.
+ * @param confirmationTarget The number of blocks to include this tx (for fee estimation).
+ * @param isSignet True if using Bitcoin Signet.
+ * @param utxoSelectionStrategy Optional UTXO selection strategy override. Defaults to `'all'`
+ *   when `amount` is omitted, otherwise `'default'`.
+ * @returns {Promise<bigint | undefined>} The estimated fee in satoshis.
  */
 export async function estimateTxFee(
     fromAddress: string,
@@ -333,7 +347,8 @@ export async function estimateTxFee(
     opReturnData?: string,
     feeRate?: number,
     confirmationTarget: number = 3,
-    isSignet: boolean = false
+    isSignet: boolean = false,
+    utxoSelectionStrategy?: 'all' | 'default'
 ): Promise<bigint | undefined> {
     const addressInfo = getAddressInfo(fromAddress, isSignet);
 
@@ -384,17 +399,14 @@ export async function estimateTxFee(
         });
     }
 
-    // Select all UTXOs if no amount is specified
-    let utxoSelectionStrategy: 'all' | 'default' = 'default';
-    if (amount === undefined) {
-        utxoSelectionStrategy = 'all';
-    }
+    // An explicit strategy wins; otherwise select all UTXOs when no amount is specified.
+    const strategy: 'all' | 'default' = utxoSelectionStrategy ?? (amount === undefined ? 'all' : 'default');
 
     // Outsource UTXO selection to btc-signer
     // https://github.com/paulmillr/scure-btc-signer?tab=readme-ov-file#utxo-selection
     // default = exactBiggest/accumBiggest creates tx with smallest fees, but it breaks
     // big outputs to small ones, which in the end will create a lot of outputs close to dust.
-    const transaction = selectUTXO(possibleInputs, outputs, utxoSelectionStrategy, {
+    const transaction = selectUTXO(possibleInputs, outputs, strategy, {
         changeAddress: fromAddress, // Refund surplus to the payment address
         feePerByte: BigInt(Math.ceil(feeRate)), // round up to the nearest integer
         bip69: true, // Sort inputs and outputs according to BIP69

--- a/sdk/test/utxo.test.ts
+++ b/sdk/test/utxo.test.ts
@@ -697,4 +697,54 @@ describe('UTXO Tests', () => {
         expect(allowedUtxos).toEqual([utxos[0], utxos[1]]);
         expect((global.fetch as Mock).mock.calls.length).toEqual(16);
     });
+
+    describe('utxoSelectionStrategy', () => {
+        // A confirmed, immutable mainnet tx funding a single P2WPKH output (vout 0) for `fundedAddress`.
+        // The raw tx never changes, so this fixture is stable without hitting the network.
+        const fundedAddress = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+        const toAddress = 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d';
+        const utxo: UTXO = {
+            txid: '69bd1bd1fb0ec441d8fe8d18284895d8eaa23a49c10560d71e29652c4184f0e6',
+            vout: 0,
+            value: 116937,
+            confirmed: true,
+        };
+        const txHex =
+            '0200000000010155baf31aba2997e696c86a2745aba743927738d491707c0ffbd1be72eef6dbc30100000000fdffffff02c9c8010000000000160014e8df018c7e326cc253faac7e46cdc51e68542c421704000000000000160014577cec4ef756989d4fd911eddab37128111913230248304502210085eb93a41834d1266610d16ed37eb44c8f3f8b350780c369a791a3ac16e7c05c02205872c733cc8cb58d6b5b64f78710f361245d65dd7cdd31051ca8e3119fc9f8bc012103ef4329d763463fd98232a6ce5724868a84b8b6dda7002bcb54a87ea24ee44b9300000000';
+        const feeRate = 5;
+
+        beforeEach(() => {
+            // Mock only the network boundary: one confirmed, cardinal UTXO + its funding tx.
+            vi.spyOn(EsploraClient.prototype, 'getAddressUtxos').mockResolvedValue([utxo]);
+            vi.spyOn(EsploraClient.prototype, 'getTransactionHex').mockResolvedValue(txHex);
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error partial mock: only `outpoint` is read by getSafeUtxos
+            vi.spyOn(OrdinalsClient.prototype, 'getOutputsFromAddress').mockResolvedValue([
+                { outpoint: OutPoint.toString(utxo) },
+            ]);
+            // Canned selection result so the assertion does not depend on real coin selection succeeding.
+            (selectUTXO as Mock).mockReturnValue({ tx: { toPSBT: () => Uint8Array.from([0]) }, fee: 1000n });
+        });
+
+        it('createBitcoinPsbt forwards the requested strategy to selectUTXO', async () => {
+            await createBitcoinPsbt(fundedAddress, toAddress, 1000, undefined, undefined, feeRate, 3, false, 'all');
+
+            const [, , strategy] = (selectUTXO as Mock).mock.lastCall!;
+            expect(strategy).toBe('all');
+        });
+
+        it('createBitcoinPsbt defaults to the "default" strategy', async () => {
+            await createBitcoinPsbt(fundedAddress, toAddress, 1000, undefined, undefined, feeRate);
+
+            const [, , strategy] = (selectUTXO as Mock).mock.lastCall!;
+            expect(strategy).toBe('default');
+        });
+
+        it('estimateTxFee forwards the requested strategy to selectUTXO, overriding the amount-based default', async () => {
+            await estimateTxFee(fundedAddress, 1000, undefined, undefined, feeRate, 3, false, 'all');
+
+            const [, , strategy] = (selectUTXO as Mock).mock.lastCall!;
+            expect(strategy).toBe('all');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Enables consistent full-balance BTC sweeps and removes a deprecation that left direct (non-Gateway) sends without a supported fee primitive. Prep for the gateway-cli `send` review fixes (#1085).

- **`createBitcoinPsbt`** / **`estimateTxFee`** now accept an optional trailing `utxoSelectionStrategy: 'all' | 'default'`, forwarded to scure-btc-signer's `selectUTXO` (resolves the long-standing in-code TODO). Callers can force `'all'` so a sweep's **fee estimate and PSBT build select the same UTXO set** — removing the subset/change drift between the two calls.
- **`estimateTxFee` un-deprecated.** Its suggested replacement (`getBalance` + `getQuote`) is Gateway-only, leaving no non-deprecated primitive for direct fee estimation — which both the gateway-cli `send` command and the UI's `use-btc-fee-estimate` hook rely on. cc @slavastartsev (you added the deprecation in b81e34dd) in case there was a removal reason we're missing.

Both changes are **additive and backward-compatible**: the new param is optional and trailing, defaulting to the prior behavior (`'default'`, or `'all'` when `estimateTxFee` is called without an amount). The only current direct consumer is gateway-cli; the UI calls `estimateTxFee` with a fixed arity that is unaffected.

## Tests

3 new tests in `sdk/test/utxo.test.ts` assert the strategy is forwarded to `selectUTXO` and defaults correctly, using an immutable mainnet tx fixture + client spies (network-free). `pnpm build` and lint clean.

## Versioning

Minor bump: `5.7.3` → `5.8.0`. gateway-cli's dependency bump to `^5.8.0` lands in the #1085 follow-up once this publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)