### PR TITLE
docs: add install step to gateway-cli walkthroughs

### DIFF
--- a/docs/gateway/gateway/agents.mdx
+++ b/docs/gateway/gateway/agents.mdx
@@ -93,6 +93,15 @@ Agents call tools and read structured output. The Gateway CLI is built around th
 An agentic swap follows a consistent pattern: discover what is possible, get a quote, decide, then settle.
 
 <Steps>
+  <Step title="Install the CLI">
+    Install globally with npm so `gateway-cli` is on the PATH wherever the agent runs.
+
+    ```bash
+    npm install -g @gobob/gateway-cli
+    gateway-cli --help
+    ```
+  </Step>
+
   <Step title="Discover available routes">
     The agent queries available routes so it isn't guessing at assets or chains.
 
@@ -240,12 +249,7 @@ Gateway has already powered experiments like a Bitcoin yield bot built on Coinba
 
 ---
 
-## Install and try it
-
-```bash
-npm install -g @gobob/gateway-cli
-gateway-cli --help
-```
+## Try it
 
 Set your keys and run a quote to verify the setup:
 

--- a/gateway-cli/README.md
+++ b/gateway-cli/README.md
@@ -2,30 +2,12 @@
 
 CLI for [BOB Gateway](https://docs.gobob.xyz/gateway/overview) — swap between BTC and EVM tokens, and send funds on a single chain, from the terminal.
 
-## Install
-
-```bash
-npm install -g @gobob/gateway-cli
-gateway-cli --help
-```
-
-### From source
-
-```bash
-pnpm install && pnpm build
-npm link                      # makes gateway-cli available globally
-gateway-cli --help
-```
-
-For development without linking:
-
-```bash
-pnpm cli:dev --help
-```
-
 ## Quick start
 
 ```bash
+# Install
+npm install -g @gobob/gateway-cli
+
 # Set your keys
 export BITCOIN_PRIVATE_KEY="<wif-or-hex>"
 export EVM_PRIVATE_KEY="<hex>"
@@ -48,6 +30,20 @@ gateway-cli send --asset BTC --amount 0.01BTC --to bc1qRecipient
 
 # Check your balances (derives addresses from keys)
 gateway-cli balance
+```
+
+## Install from source
+
+```bash
+pnpm install && pnpm build
+npm link                      # makes gateway-cli available globally
+gateway-cli --help
+```
+
+For development without linking:
+
+```bash
+pnpm cli:dev --help
 ```
 
 ## Commands


### PR DESCRIPTION
## What

Make installing the CLI an explicit first step *inside* both Gateway CLI walkthroughs, and consolidate the standalone install sections so the basic `npm install -g @gobob/gateway-cli` command appears exactly once per file (no duplication).

## Changes

**`gateway-cli/README.md`**
- Quick start now opens with `# Install` → `npm install -g @gobob/gateway-cli`, making it a complete copy-paste sequence.
- The old `## Install` section is removed; the from-source / `pnpm cli:dev` instructions are preserved as a dedicated `## Install from source` section placed after Quick start.

**`docs/gateway/gateway/agents.mdx`**
- Adds `<Step title="Install the CLI">` as the first step in the "agent loop" `<Steps>` block, so the walkthrough is self-contained from zero.
- Removes the duplicate `npm install` block from the closing section; renames `## Install and try it` → `## Try it`, keeping the verify-with-keys quote and the link cards.

## Verification

- `npm install -g` appears exactly once per file.
- `<Steps>`/`<Step>` tags balanced (5/5) in `agents.mdx`.
- No content lost — from-source build steps and the verify/link-card content are retained.
- Local ducklings-style review: both files are pure docs (inert), no code findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)