### PR TITLE
docs(gateway): document V3 API and regenerate client

### DIFF
--- a/docs/gateway/api-reference/openapi.json
+++ b/docs/gateway/api-reference/openapi.json
@@ -305,7 +305,7 @@
           {
             "name": "gasRefill",
             "in": "query",
-            "description": "Optional gas refill amount (in smallest unit, e.g., wei)",
+            "description": "Deprecated: gas refill is no longer supported. Supplying this field is\nrejected with an error. Removed in V3.",
             "required": false,
             "schema": {
               "type": "string"
@@ -758,7 +758,7 @@
           {
             "name": "gasRefill",
             "in": "query",
-            "description": "Optional gas refill amount (in smallest unit, e.g., wei)",
+            "description": "Deprecated: gas refill is no longer supported. Supplying this field is\nrejected with an error. Removed in V3.",
             "required": false,
             "schema": {
               "type": "string"
@@ -1198,16 +1198,6 @@
             },
             "style": "form",
             "example": "100000"
-          },
-          {
-            "name": "gasRefill",
-            "in": "query",
-            "description": "Optional gas refill amount (in smallest unit, e.g., wei)",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "style": "form"
           },
           {
             "name": "slippage",
@@ -1795,7 +1785,8 @@
         "enum": [
           "BUNGEE_NO_ROUTE",
           "MISSING_OWNER_ADDRESS",
-          "NON_COMPLIANT_ADDRESSES"
+          "NON_COMPLIANT_ADDRESSES",
+          "TOO_MANY_AFFILIATES"
         ]
       },
       "GatewayErrorDetails": {
@@ -2242,6 +2233,21 @@
                 "type": "string"
               },
               "src_token": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "max",
+              "actual"
+            ],
+            "properties": {
+              "actual": {
+                "type": "string"
+              },
+              "max": {
                 "type": "string"
               }
             }
@@ -3479,7 +3485,7 @@
             ],
             "properties": {
               "tokenSwap": {
-                "$ref": "#/components/schemas/GatewayTokenSwapQuoteV2"
+                "$ref": "#/components/schemas/GatewayTokenSwapQuoteV3"
               }
             }
           }
@@ -3564,6 +3570,86 @@
           "txTo"
         ],
         "properties": {
+          "dstChain": {
+            "type": "string"
+          },
+          "estimatedTimeInSecs": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Estimated time in secs to complete the Order",
+            "minimum": 0
+          },
+          "fees": {
+            "$ref": "#/components/schemas/GatewayTokenAmountV2"
+          },
+          "inputAmount": {
+            "$ref": "#/components/schemas/GatewayTokenAmountV2"
+          },
+          "outputAmount": {
+            "$ref": "#/components/schemas/GatewayTokenAmountV2"
+          },
+          "priceImpact": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Price impact as a fraction, e.g. `\"-0.05\"` means 5% loss. Absent if no price feed is\navailable."
+          },
+          "priceImpactUsd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Price impact in USD, excluding execution fee. E.g. `\"-1.00\"` means $1 loss. Absent if no\nprice feed is available."
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "sender": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "slippage": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "srcChain": {
+            "type": "string"
+          },
+          "txTo": {
+            "type": "string"
+          }
+        }
+      },
+      "GatewayTokenSwapQuoteV3": {
+        "type": "object",
+        "description": "V3 token-swap quote: the V2 shape plus a resolved `affiliate`. The quote *is*\nthe create-order body, so carrying the affiliate here is what stops it being\ndropped on the round-trip — the aggregator (Bungee/Velora) charges it on the\nsource chain. Mirrors how onramp/offramp embed affiliates in their quotes.",
+        "required": [
+          "srcChain",
+          "dstChain",
+          "inputAmount",
+          "outputAmount",
+          "estimatedTimeInSecs",
+          "recipient",
+          "slippage",
+          "fees",
+          "txTo"
+        ],
+        "properties": {
+          "affiliate": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TokenSwapAffiliateV3",
+                "description": "Affiliate fee applied to this swap, if any. Absent for fee-free swaps."
+              }
+            ]
+          },
           "dstChain": {
             "type": "string"
           },
@@ -4221,6 +4307,26 @@
           },
           "srcToken": {
             "type": "string"
+          }
+        }
+      },
+      "TokenSwapAffiliateV3": {
+        "type": "object",
+        "description": "A single affiliate fee on a token swap: `bps` of the swap input paid to\n`address` by the aggregator on the source chain. Aggregators charge one\npartner fee, so a swap carries at most one.",
+        "required": [
+          "address",
+          "bps"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Affiliate fee recipient, encoded for the source chain (`0x…` on EVM)."
+          },
+          "bps": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Affiliate fee size in basis points of the swap input.",
+            "minimum": 0
           }
         }
       },

--- a/docs/gateway/api-reference/overview.mdx
+++ b/docs/gateway/api-reference/overview.mdx
@@ -16,27 +16,26 @@ The BOB Gateway API enables seamless cross-chain interactions for Bitcoin-powere
 </Card>
 
 
-## What's new in V2
+## What's new in V3
 
 <Info>
-This reference targets the V2 API. V1 endpoints remain reachable but are deprecated.
+This reference targets the V3 API. V1 and V2 endpoints remain reachable but are superseded — new integrations should use `/v3`.
 </Info>
 
-V2 adds:
+V3 builds on V2 with multi-chain support and richer settlement data:
 
-- **`tokenSwap` route** — EVM-to-EVM token swaps, alongside `onramp` (Bitcoin → chain) and `offramp` (chain → Bitcoin).
-- **Multi-affiliate fees** — the `affiliates` query parameter on `GET /v2/get-quote` accepts a comma-separated list of `<address>:<bps>` pairs. See the [Monetization section in the integration guide](/gateway/integration#monetization-affiliate-fees).
-- **USD values** — token amounts and fee-breakdown lines carry an optional `usd` field.
-- **`priceImpact` / `priceImpactUsd`** — exposed on all V2 quote variants.
-- **Paginated `GET /v2/get-orders`** — accepts `cursor` and `limit` query parameters and returns `{ orders: GatewayOrderInfoV2[], nextCursor: string | null }` instead of a bare array. Pass back `nextCursor` to fetch the next page; a null/missing value means there are no more orders.
-- **Settlement details in order status** — `success` and `refunded` statuses are now objects (`{ success: { received_tokens: [...] } }`, `{ refunded: { refunded_tokens: [...] } }`) where each token entry carries `chain`, `token`, `amount`, and the settlement `txHash`. In V1 these statuses were bare string enums and the destination `txHash` lived on `dstInfo`; V2 `dstInfo` no longer carries a `txHash`.
-- **`pending_btc_payment` on in-progress X-to-BTC orders** — `status.inProgress.pending_btc_payment` exposes the gateway's outgoing Bitcoin `{ txid, amount }` while it's still pending. The V1 `bump_fee_tx` field is no longer returned (the gateway manages BTC fee bumps internally).
+- **Non-EVM chains (Tron & Solana)** — `srcChain`/`dstChain` and the address/token parameters now accept `0x…` on EVM chains and Base58 on Tron/Solana. `POST /v3/create-order` returns a tagged `GatewayTxData` union — `{ "type": "evm" | "tron" | "solana", ... }` — so a client dispatches on `type`. The Solana entry returns a base64-encoded, unsigned `VersionedTransaction`: decode, sign, re-serialize, and broadcast it (don't sign the base64 string directly). The Tron entry adds `feeLimit` (max TRX, in sun, the wallet may burn).
+- **Chain-aware `PATCH /v3/register-tx`** — for `offramp` and `tokenSwap`, the body now carries `src_tx_hash` + `src_chain` (EVM `0x…` hash or Base58 Solana signature) instead of V2's `evm_txhash`. `onramp` is unchanged (`bitcoin_tx_hex` / `bitcoin_txid`).
+- **USD on order info** — `srcInfo`, `dstInfo`, settled token transfers (`received_tokens` / `refunded_tokens`), and `pending_btc_payment` now each carry an optional `usd` field, valued at order time. In V2, `usd` was only on quote amounts and fee-breakdown lines.
+- **Affiliate fees on `tokenSwap`** — `tokenSwap` quotes now embed a single resolved `affiliate` (`{ address, bps }`), charged by the aggregator (Bungee/Velora) on the **source chain**. Because the quote *is* the create-order body, embedding the affiliate is what stops it being dropped on the round-trip. Aggregators allow only one partner fee per swap, so passing more than one affiliate returns the new `TOO_MANY_AFFILIATES` error code. (`onramp`/`offramp` keep V2's multi-recipient `affiliates` list — see the [Monetization section in the integration guide](/gateway/integration#monetization-affiliate-fees).)
+- **`ownerAddress` & `refundAddress`** — `GET /v3/get-quote` accepts an optional `ownerAddress` (EVM owner / refund-claimant, also used for order lookup) that is resolved onto each quote variant, and an optional `refundAddress` (Bitcoin refund address for onramps). Routes that need an owner but don't get one return the new `MISSING_OWNER_ADDRESS` error code.
+- **Removed parameters** — `gasRefill`, `strategyTarget`, and `strategyMessage` are no longer supported; supplying any of them is rejected with an error.
 
 ## Authentication
 
-API keys are **optional**. All V2 endpoints are reachable without authentication; a key unlocks higher rate limits and access to partner features. To request one, contact the BOB team.
+API keys are **optional**. All V3 endpoints are reachable without authentication; a key unlocks higher rate limits and access to partner features. To request one, contact the BOB team.
 
-When you have a key, send it as a Bearer token on every V2 request:
+When you have a key, send it as a Bearer token on every V3 request:
 
 ```http
 Authorization: Bearer <api-key>
@@ -46,75 +45,77 @@ Keys are exactly 32 characters long. The SDK takes the same key via `new Gateway
 
 ## How It Works
 
-Gateway transactions follow a 7-step flow to execute Bitcoin↔chain swaps and EVM token swaps:
+Gateway transactions follow a 7-step flow to execute Bitcoin↔chain swaps and cross-chain token swaps:
 
 <Steps>
   <Step title="Get Available Routes">
-    Call `GET /v2/get-routes` to fetch all supported routes, chains, and tokens. This helps you understand what swaps are available and present options to your users.
+    Call `GET /v3/get-routes` to fetch all supported routes, chains, and tokens. This helps you understand what swaps are available and present options to your users.
 
     ```bash
-    GET /v2/get-routes
+    GET /v3/get-routes
     ```
 
     Returns information about supported chains, tokens, bridges, and fee structures.
   </Step>
 
   <Step title="Get a Quote">
-    Call `GET /v2/get-quote` with your swap parameters (amount, source/destination chains, tokens, etc.). The API returns a discriminated quote (`onramp`, `offramp`, or `tokenSwap`) with routing information, fees, and expected outputs.
+    Call `GET /v3/get-quote` with your swap parameters (amount, source/destination chains, tokens, etc.). The API returns a discriminated quote (`onramp`, `offramp`, or `tokenSwap`) with routing information, fees, and expected outputs.
 
     ```bash
-    GET /v2/get-quote?srcChain=bitcoin&dstChain=bob&amount=10000000...
+    GET /v3/get-quote?srcChain=bitcoin&dstChain=bob&amount=10000000...
     ```
 
-    Pass `affiliates=0xAddr1:50,0xAddr2:25` to route a basis-point cut to one or more recipients on settlement.
+    Addresses and token identifiers are `0x…` on EVM chains and Base58 on Tron/Solana. Pass `affiliates=0xAddr1:50,0xAddr2:25` to route a basis-point cut to one or more recipients on settlement, and `ownerAddress`/`refundAddress` where the route requires them.
   </Step>
 
   <Step title="Create an Order">
-    Pass the quote to `POST /v2/create-order` to lock in the quote and create an order. This reserves liquidity with the market maker and returns transaction details including:
+    Pass the quote to `POST /v3/create-order` to lock in the quote and create an order. This reserves liquidity with the market maker and returns transaction details including:
     - For **BTC to X** (`onramp`, Bitcoin → chain): A Bitcoin address to send to, or a PSBT to sign.
-    - For **X to BTC** (`offramp`, chain → Bitcoin): EVM transaction data to execute.
-    - For **tokenSwap** (EVM → EVM): EVM transaction data to execute.
+    - For **X to BTC** (`offramp`, chain → Bitcoin): chain transaction data to execute.
+    - For **tokenSwap** (chain → chain): chain transaction data to execute.
 
     ```bash
-    POST /v2/create-order
+    POST /v3/create-order
     { "onramp": { ...quote data } }
     ```
+
+    For `offramp` and `tokenSwap`, the returned transaction data is a tagged `GatewayTxData` union — dispatch on `type` (`"evm"`, `"tron"`, or `"solana"`).
   </Step>
 
   <Step title="Sign and Send Transaction">
     Execute the transaction:
     - For **BTC to X** (`onramp`): Create and sign a Bitcoin transaction to the provided address, or use the provided PSBT.
-    - For **X to BTC** (`offramp`) or **tokenSwap**: Sign and broadcast the EVM transaction using the provided transaction data.
+    - For **X to BTC** (`offramp`) or **tokenSwap**: Sign and broadcast the chain transaction using the provided transaction data. On EVM/Tron use the call fields (`to`, `data`, `value`); on Solana, decode the base64 unsigned `VersionedTransaction`, sign it, re-serialize, and broadcast.
   </Step>
 
   <Step title="Register Transaction">
-    Call `PATCH /v2/register-tx` with the signed transaction hash/hex. This allows Gateway to track your order and provide status updates.
+    Call `PATCH /v3/register-tx` with the signed transaction hash/hex. This allows Gateway to track your order and provide status updates.
 
     ```bash
-    PATCH /v2/register-tx
+    PATCH /v3/register-tx
     { "onramp":    { "order_id": "...", "bitcoin_tx_hex": "..." } }
-    { "offramp":   { "order_id": "...", "evm_txhash": "0x..." } }
-    { "tokenSwap": { "order_id": "...", "evm_txhash": "0x..." } }
+    { "offramp":   { "order_id": "...", "src_tx_hash": "0x...", "src_chain": "ethereum" } }
+    { "tokenSwap": { "order_id": "...", "src_tx_hash": "0x...", "src_chain": "ethereum" } }
     ```
 
-    The body shape varies by route: `onramp` carries `bitcoin_tx_hex` (and/or `bitcoin_txid`); `offramp` and `tokenSwap` both carry `evm_txhash`.
+    The body shape varies by route: `onramp` carries `bitcoin_tx_hex` (and/or `bitcoin_txid`); `offramp` and `tokenSwap` carry `src_tx_hash` + `src_chain` (a `0x…` hash on EVM, a Base58 signature on Solana).
   </Step>
 
   <Step title="Monitor Single Order">
-    Track the status of a specific order using `GET /v2/get-order/{id}`. Returns the status and details for a single order by its order ID.
+    Track the status of a specific order using `GET /v3/get-order/{id}`. Returns the status and details for a single order by its order ID.
 
     ```bash
-    GET /v2/get-order/0x1234abcd...
+    GET /v3/get-order/0x1234abcd...
     ```
 
     Use this endpoint to monitor the progress of an individual order, including its current state and any updates.
   </Step>
 
   <Step title="Monitor All User Orders">
-    Track the progress of all orders for a user using `GET /v2/get-orders/{user_address}`. Returns every order (pending and completed) associated with the specified user address.
+    Track the progress of all orders for a user using `GET /v3/get-orders/{user_address}`. Returns every order (pending and completed) associated with the specified user address.
 
     ```bash
-    GET /v2/get-orders/0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb
+    GET /v3/get-orders/0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb
     ```
 
     Poll this endpoint to update your UI as orders progress through states: pending → confirmed → completed.

--- a/docs/gateway/gateway/integration.mdx
+++ b/docs/gateway/gateway/integration.mdx
@@ -10,21 +10,21 @@ The BOB Gateway SDK makes it easy to bring native BTC swaps directly into your a
 
 We recommend using the API directly, but you may use our SDK for convenience.
 
-## What's new in V2
+## What's new in V3
 
 <Info>
-This guide targets the V2 API. V1 endpoints remain reachable but are deprecated.
+This guide targets the V3 API. V1 and V2 endpoints remain reachable but are superseded — the SDK calls `/v3` under the hood.
 </Info>
 
-V2 adds:
+V3 builds on V2 with multi-chain support and richer settlement data:
 
-- **Multi-affiliate fees** — split fees across multiple recipients per quote ([details](#monetization-affiliate-fees)).
-- **`tokenSwap` route** — EVM-to-EVM token swaps, replacing the V1 `layerZero` variant.
-- **USD values** — `GatewayTokenAmountV2` carries an optional `usd` field on every token amount and on each line of the V2 fee breakdowns.
-- **Price impact** — V2 quotes expose `priceImpact` (fraction) and `priceImpactUsd` for display.
-- **Paginated `getOrders`** — `getOrders` now accepts `{ userAddress, cursor?, limit? }` and returns `{ orders, nextCursor }` instead of a bare array. Pass back `nextCursor` to fetch the next page; a null/missing value means you've reached the end ([details](#monitor-orders)).
-- **Order settlement details in status** — `success` and `refunded` are now objects carrying `receivedTokens` / `refundedTokens` (each entry has `chain`, `token`, `amount`, and the settlement `txHash`). In V1 these statuses were bare strings, and the destination `txHash` lived on `dstInfo`; in V2 `dstInfo` no longer carries a `txHash` — read it from the status payload instead.
-- **`pendingBtcPayment` on X-to-BTC orders** — while an X-to-BTC order is in progress, `status.inProgress.pendingBtcPayment` exposes the gateway's outgoing Bitcoin `{ txid, amount }` so you can show the user the pending payout. This replaces the V1 `bumpFeeTx` field, which is no longer returned.
+- **Non-EVM chains (Tron & Solana)** — quotes and orders now span EVM, Tron, and Solana as well as Bitcoin. Addresses and token identifiers are `0x…` on EVM chains and Base58 on Tron/Solana. `executeQuote` signs and broadcasts the right transaction shape for each chain; if you build transactions yourself, `createOrder` returns a tagged union you dispatch on (`type: 'evm' | 'tron' | 'solana'`).
+- **`ownerAddress` (required) and `refundAddress`** — `getQuote` now takes an `ownerAddress` (the EVM owner / refund-claimant, also used for order lookup) and an optional Bitcoin `refundAddress` for onramps. Routes that need an owner but don't get one fail with `MISSING_OWNER_ADDRESS`.
+- **USD on order info** — `srcInfo`, `dstInfo`, settled transfers (`receivedTokens` / `refundedTokens`), and `pendingBtcPayment` now each carry an optional `usd` value (valued at order time). In V2, `usd` was only on quote amounts and fee-breakdown lines.
+- **Affiliate fees on `tokenSwap`** — `tokenSwap` quotes now expose a resolved single `affiliate` (`{ address, bps }`), charged by the aggregator on the source chain. Aggregators allow only one partner fee per swap, so passing more than one affiliate returns `TOO_MANY_AFFILIATES`. `onramp`/`offramp` keep the V2 multi-recipient `affiliates` list ([details](#monetization-affiliate-fees)).
+- **Removed parameters** — `gasRefill`, `strategyAddress`/`strategyTarget`, and `strategyMessage` are no longer supported and are rejected by the gateway.
+- **Paginated `getOrders`** — `getOrders` accepts `{ userAddress, cursor?, limit? }` and returns `{ orders, nextCursor }` (carried over from V2). Pass back `nextCursor` to fetch the next page; a null/missing value means you've reached the end ([details](#monitor-orders)).
+- **Discriminated order status** — `success` / `refunded` are objects carrying `receivedTokens` / `refundedTokens` (each entry has `chain`, `token`, `amount`, the settlement `txHash`, and now `usd`); `status.inProgress.pendingBtcPayment` exposes the gateway's outgoing Bitcoin `{ txid, amount, usd }` on in-progress X-to-BTC orders. Read the destination `txHash` from the status payload — `dstInfo` doesn't carry one.
 
 ## Installation
 
@@ -60,7 +60,7 @@ const gatewaySDKStaging = new GatewaySDK({ basePath: STAGING_GATEWAY_BASE_URL })
 
 ### Authentication
 
-Gateway API keys are **optional**. All V2 endpoints are reachable without authentication; an API key unlocks higher rate limits and access to partner features.
+Gateway API keys are **optional**. All V3 endpoints are reachable without authentication; an API key unlocks higher rate limits and access to partner features.
 
 To request a key, contact the BOB team. Once you have one, pass it in the options object:
 
@@ -70,7 +70,7 @@ import { GatewaySDK } from '@gobob/bob-sdk';
 const gatewaySDK = new GatewaySDK({ apiKey: 'your-api-key' });
 ```
 
-The API key must be exactly 32 characters long. When provided, the SDK will include it in the `Authorization` header as a Bearer token (`Authorization: Bearer <api-key>`). If you're calling the API directly, set the same header on every V2 request.
+The API key must be exactly 32 characters long. When provided, the SDK will include it in the `Authorization` header as a Bearer token (`Authorization: Bearer <api-key>`). If you're calling the API directly, set the same header on every V3 request.
 
 ## Get Available Routes
 
@@ -94,7 +94,6 @@ Request a quote for the user's desired transaction:
 
 ```typescript BTC to BOB
 import { parseBtc } from '@gobob/bob-sdk';
-import { parseEther } from 'viem';
 
 const quote = await gatewaySDK.getQuote({
   fromChain: 'bitcoin',
@@ -103,8 +102,8 @@ const quote = await gatewaySDK.getQuote({
   toChain: 'bob',
   toToken: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
   toUserAddress: '0x2D2E86236a5bC1c8a5e5499C517E17Fb88Dbc18c',
+  ownerAddress: '0x2D2E86236a5bC1c8a5e5499C517E17Fb88Dbc18c', // EVM owner / refund-claimant
   amount: parseBtc("0.1"), // 0.1 BTC
-  gasRefill: parseEther("0.00001"), // Optional ETH gas refill
 });
 ```
 
@@ -116,15 +115,15 @@ const quote = await gatewaySDK.getQuote({
   toChain: 'bob',
   toToken: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
   toUserAddress: '0x2D2E86236a5bC1c8a5e5499C517E17Fb88Dbc18c',
+  ownerAddress: '0x2D2E86236a5bC1c8a5e5499C517E17Fb88Dbc18c',
   amount: parseBtc("0.1"),
-  gasRefill: parseEther("0.00001"),
-  // V2 affiliate fees: array of { address, bps } pairs
+  // onramp/offramp accept multiple recipients; tokenSwap accepts exactly one
   affiliates: [{ address: '0xYourAddress', bps: 50 }], // 0.50% to one recipient
 });
 ```
 
-```typescript EVM Token Swap
-// V2 supports EVM-to-EVM token swaps via the tokenSwap route.
+```typescript Token Swap
+// V3 supports cross-chain token swaps via the tokenSwap route.
 const quote = await gatewaySDK.getQuote({
   fromChain: 'bob',
   fromToken: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c', // source token on BOB
@@ -132,14 +131,29 @@ const quote = await gatewaySDK.getQuote({
   toToken: '0x...', // destination token
   fromUserAddress: '0x...',
   toUserAddress: '0x...',
+  ownerAddress: '0x...',
   amount: '1000000', // amount in smallest unit
+});
+```
+
+```typescript To Solana / Tron
+// Destination addresses and tokens on Tron/Solana are Base58, not 0x-hex.
+const quote = await gatewaySDK.getQuote({
+  fromChain: 'bitcoin',
+  fromToken: '0x0000000000000000000000000000000000000000',
+  fromUserAddress: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
+  toChain: 'solana',
+  toToken: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC mint (Base58)
+  toUserAddress: '7xKX...9aBc', // Base58 wallet address
+  ownerAddress: '0x2D2E86236a5bC1c8a5e5499C517E17Fb88Dbc18c', // EVM owner for lookup
+  amount: parseBtc("0.1"),
 });
 ```
 
 </CodeGroup>
 
 <Warning>
-Token parameters (`fromToken`, `toToken`) must be `0x`-prefixed hex addresses, not symbols. Use `getRoutes()` to find supported token addresses. For BTC, use the zero address `0x0000000000000000000000000000000000000000`.
+On EVM chains, token parameters (`fromToken`, `toToken`) must be `0x`-prefixed hex addresses, not symbols; on Tron/Solana they are Base58 identifiers. Use `getRoutes()` to find supported token addresses. For BTC, use the zero address `0x0000000000000000000000000000000000000000`.
 </Warning>
 
 <Tip>
@@ -166,16 +180,21 @@ if ('onramp' in quote) {
   console.log('Price impact:', quote.offramp.priceImpact);
   console.log('ETA:', quote.offramp.estimatedTimeInSecs, 'seconds');
 } else if ('tokenSwap' in quote) {
-  // EVM token swap (V2)
+  // Cross-chain token swap (V3)
   console.log('Input:', quote.tokenSwap.inputAmount);
   console.log('Fees:', quote.tokenSwap.fees);
   console.log('Price impact:', quote.tokenSwap.priceImpact);
   console.log('ETA:', quote.tokenSwap.estimatedTimeInSecs, 'seconds');
+  // V3: the resolved single affiliate (null for fee-free swaps)
+  if (quote.tokenSwap.affiliate) {
+    const { address, bps } = quote.tokenSwap.affiliate;
+    console.log(`Affiliate: ${bps} bps to ${address}`);
+  }
 }
 ```
 
 <Tip>
-You don't need to handle all quote types — the response type matches your `fromChain`/`toChain` parameters. `fromChain: 'bitcoin'` with `toChain: 'bob'` always returns an `onramp` quote; an EVM-to-EVM pair returns a `tokenSwap` quote.
+You don't need to handle all quote types — the response type matches your `fromChain`/`toChain` parameters. `fromChain: 'bitcoin'` with `toChain: 'bob'` always returns an `onramp` quote; a token-to-token pair (including to Tron/Solana) returns a `tokenSwap` quote.
 </Tip>
 
 ## Execute the Quote
@@ -276,10 +295,11 @@ const { orders, nextCursor } = await gatewaySDK.getOrders({
 });
 
 orders.forEach(order => {
-  console.log(`Source: ${order.srcInfo.amount} ${order.srcInfo.token} (${order.srcInfo.chain})`);
+  // V3: srcInfo/dstInfo now carry an optional `usd` value alongside the amount
+  console.log(`Source: ${order.srcInfo.amount} ${order.srcInfo.token} (${order.srcInfo.chain})`, order.srcInfo.usd && `~$${order.srcInfo.usd}`);
   console.log(`Destination (estimated): ${order.dstInfo.amount} ${order.dstInfo.token} (${order.dstInfo.chain})`);
 
-  // V2 status is always a discriminated object — no bare strings
+  // Order status is always a discriminated object — no bare strings
   if ('inProgress' in order.status) {
     console.log('Status: in progress');
     if (order.status.inProgress.pendingBtcPayment) {
@@ -296,9 +316,9 @@ orders.forEach(order => {
     }
   } else if ('success' in order.status) {
     console.log('Status: success');
-    // V2: settled token transfers (with on-chain txHash) are on the status payload
+    // Settled token transfers (with on-chain txHash, and V3 `usd`) are on the status payload
     for (const t of order.status.success.receivedTokens) {
-      console.log(`Received ${t.amount} ${t.token} on ${t.chain} (tx ${t.txHash})`);
+      console.log(`Received ${t.amount} ${t.token} on ${t.chain} (tx ${t.txHash})`, t.usd && `~$${t.usd}`);
     }
   } else if ('refunded' in order.status) {
     console.log('Status: refunded');
@@ -332,7 +352,7 @@ do {
 
 ## X to BTC Order Features
 
-For X-to-BTC (BOB → Bitcoin) orders, `getOrders` surfaces V2 status fields you can act on while the order is still in progress:
+For X-to-BTC (BOB → Bitcoin) orders, `getOrders` surfaces status fields you can act on while the order is still in progress:
 
 <AccordionGroup>
 
@@ -354,7 +374,7 @@ if (inFlight && 'inProgress' in inFlight.status) {
 ```
 
 <Note>
-V2 no longer exposes a `bumpFeeTx` EVM transaction — the gateway manages fee bumps internally for the BTC payout it broadcasts.
+Gateway no longer exposes a `bumpFeeTx` EVM transaction — it manages fee bumps internally for the BTC payout it broadcasts.
 </Note>
 
 </Accordion>
@@ -397,11 +417,10 @@ This action is irreversible. Once refunded, the order cannot be resumed.
 
 ## Monetization (Affiliate Fees)
 
-Gateway supports affiliate fees out of the box. You can route a basis-point (bps) cut of each swap to one or more EVM recipient addresses, configured per-quote. V2 supports splitting fees across multiple recipients in a single quote.
+Gateway supports affiliate fees out of the box. You set them per-quote via the SDK's `affiliates` parameter — an array of `{ address, bps }` pairs. How they're charged depends on the route:
 
-### How it works
-
-Affiliate fees are basis-point cuts of each swap, deducted at settlement and **paid out in USDT on Ethereum** to the recipient addresses you specify, regardless of the route. You set them per-quote via the SDK's `affiliates` parameter — an array of `{ address, bps }` pairs (the raw API serialises these as the comma-separated `affiliates` query parameter on `GET /v2/get-quote`).
+- **`onramp` / `offramp`** — fees are deducted at settlement and **paid out in USDT on Ethereum** to the recipient addresses you specify, regardless of the route. These routes accept **multiple** recipients per quote.
+- **`tokenSwap`** — the fee is charged by the aggregator (Bungee/Velora) on the **source chain**. Aggregators allow only **one** partner fee per swap, so a `tokenSwap` quote accepts exactly one affiliate. Passing more than one returns `TOO_MANY_AFFILIATES`.
 
 `1 bps = 0.01%`, so `50` means `0.50%`. For the full fee model, see [Fees](/gateway/fees).
 
@@ -416,7 +435,7 @@ const quote = await gatewaySDK.getQuote({
 
 ### Split fees across multiple recipients
 
-V2 lets you split affiliate fees across multiple recipients in a single quote — useful for revenue splits between an aggregator and an underlying integrator, referral programs, or multi-party agreements.
+`onramp` and `offramp` quotes let you split affiliate fees across multiple recipients in a single quote — useful for revenue splits between an aggregator and an underlying integrator, referral programs, or multi-party agreements. (`tokenSwap` accepts only one affiliate.)
 
 ```typescript
 const quote = await gatewaySDK.getQuote({
@@ -434,11 +453,12 @@ const quote = await gatewaySDK.getQuote({
 - Each address must be a valid EVM address.
 - Each `bps` MUST be greater than `0`.
 - Omit `affiliates` or pass an empty array for no affiliate fees.
+- `tokenSwap` accepts at most one affiliate; more than one returns `TOO_MANY_AFFILIATES`.
 - The gateway enforces caps on recipient count and total bps. Routes that don't support affiliate fees return error code `AFFILIATE_FEES_NOT_SUPPORTED_FOR_ROUTE` — handle this by retrying the quote with `affiliates` omitted, or surfacing the error to the user.
 
 ### Reading resolved fees from the quote
 
-The V2 quote response includes a resolved `affiliates` array — each entry has the recipient address and the computed fee amount (with optional USD value). Use it to surface the affiliate split to the user:
+`onramp` and `offramp` quotes include a resolved `affiliates` array — each entry has the recipient address and the computed fee amount (with optional USD value). Use it to surface the affiliate split to the user:
 
 ```typescript
 const quote = await gatewaySDK.getQuote({ /* ... */ });
@@ -454,14 +474,22 @@ if (onramp?.affiliates?.length) {
 }
 ```
 
-The `affiliates` field is present on `onramp` and `offramp` V2 quotes. `tokenSwap` quotes don't currently expose a resolved affiliates list.
+`tokenSwap` quotes instead expose a single resolved `affiliate` (`{ address, bps }`, or `null` for a fee-free swap):
+
+```typescript
+const tokenSwap = 'tokenSwap' in quote ? quote.tokenSwap : null;
+if (tokenSwap?.affiliate) {
+  const { address, bps } = tokenSwap.affiliate;
+  console.log(`${address} earns ${bps} bps on the source chain`);
+}
+```
 
 ### Raw API equivalent
 
-For integrators not using the SDK, pass the same pairs to the V2 quote endpoint as the `affiliates` query parameter:
+For integrators not using the SDK, pass the same pairs to the V3 quote endpoint as the `affiliates` query parameter:
 
 ```bash
-GET /v2/get-quote?...&affiliates=0xPartnerA:50,0xPartnerB:25
+GET /v3/get-quote?...&affiliates=0xPartnerA:50,0xPartnerB:25
 ```
 
 URL-encode the comma if your client doesn't allow raw commas in query strings.

--- a/docs/gateway/gateway/integration.mdx
+++ b/docs/gateway/gateway/integration.mdx
@@ -296,7 +296,7 @@ const { orders, nextCursor } = await gatewaySDK.getOrders({
 
 orders.forEach(order => {
   // V3: srcInfo/dstInfo now carry an optional `usd` value alongside the amount
-  console.log(`Source: ${order.srcInfo.amount} ${order.srcInfo.token} (${order.srcInfo.chain})`, order.srcInfo.usd && `~$${order.srcInfo.usd}`);
+  console.log(`Source: ${order.srcInfo.amount} ${order.srcInfo.token} (${order.srcInfo.chain})${order.srcInfo.usd ? ` ~$${order.srcInfo.usd}` : ''}`);
   console.log(`Destination (estimated): ${order.dstInfo.amount} ${order.dstInfo.token} (${order.dstInfo.chain})`);
 
   // Order status is always a discriminated object — no bare strings
@@ -318,7 +318,7 @@ orders.forEach(order => {
     console.log('Status: success');
     // Settled token transfers (with on-chain txHash, and V3 `usd`) are on the status payload
     for (const t of order.status.success.receivedTokens) {
-      console.log(`Received ${t.amount} ${t.token} on ${t.chain} (tx ${t.txHash})`, t.usd && `~$${t.usd}`);
+      console.log(`Received ${t.amount} ${t.token} on ${t.chain} (tx ${t.txHash})${t.usd ? ` ~$${t.usd}` : ''}`);
     }
   } else if ('refunded' in order.status) {
     console.log('Status: refunded');

--- a/sdk/src/gateway/generated-client/apis/index.ts
+++ b/sdk/src/gateway/generated-client/apis/index.ts
@@ -1,13 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-export * from "./V1Api";
-export * from "./V2Api";
-export {
-	type CreateOrderV3Request,
-	type GetMaxSpendableV2Request as GetMaxSpendableV3Request,
-	type GetOrderV3Request,
-	type GetOrdersV3Request,
-	type GetQuoteV3Request,
-	type RegisterTxV3Request,
-	V3Api,
-} from "./V3Api";
+export * from './V1Api';
+export * from './V2Api';
+export * from './V3Api';


### PR DESCRIPTION
## Summary

Retargets the Gateway **API reference** (`overview.mdx`) and **SDK integration guide** (`integration.mdx`) to the V3 API, and rewrites the "What's new" sections to cover the delta since V2. Also includes the `make openapi` regeneration of the OpenAPI spec and generated SDK client that this documents.

## What's new in V3 (documented)

- **Non-EVM chains (Tron & Solana)** — Base58 addresses/tokens; `create-order` returns a tagged `GatewayTxData` union (`evm`/`tron`/`solana`); Solana returns a base64 unsigned `VersionedTransaction`; `register-tx` uses chain-aware `src_tx_hash` + `src_chain`.
- **USD on order info** — `usd` now on `srcInfo`, `dstInfo`, settled transfers, and `pendingBtcPayment`.
- **`tokenSwap` affiliate fees** — single resolved `affiliate` charged by the aggregator on the source chain; new `TOO_MANY_AFFILIATES` error. (`onramp`/`offramp` keep multi-recipient fees paid in USDT on Ethereum.)
- **`ownerAddress` / `refundAddress`** quote params; new `MISSING_OWNER_ADDRESS` error.
- **Removed** `gasRefill`, `strategyTarget`, `strategyMessage`.

## Files

- `docs/gateway/api-reference/overview.mdx` — "What's new" rewrite + `/v2/`→`/v3/` across auth and the 7-step flow.
- `docs/gateway/gateway/integration.mdx` — "What's new" rewrite, updated SDK examples (drop `gasRefill`, add `ownerAddress`, Solana/Tron example), `tokenSwap.affiliate`, USD in order monitoring, reworked Monetization section.
- `docs/gateway/api-reference/openapi.json`, `sdk/src/gateway/generated-client/apis/index.ts` — `make openapi` regen (source of truth for the above).

## Notes

- Docs build not run locally (Mintlify subsite); MDX structure verified (balanced fences / components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)