### PR TITLE
docs(gateway): partner-questions updates — refunds, fees, onboarding, explorer links, editorial

### DIFF
--- a/docs/gateway/api-reference/overview.mdx
+++ b/docs/gateway/api-reference/overview.mdx
@@ -37,7 +37,14 @@ V3 builds on V2 with multi-chain support and richer settlement data:
 
 ## Authentication
 
-API keys are **optional**. All V3 endpoints are reachable without authentication; a key unlocks higher rate limits and access to partner features. To request one, contact the BOB team.
+API keys are **optional** — the API is reachable without authentication. A key unlocks:
+
+- **Analytics dashboard** — your orders, volume, and affiliate earnings
+- **Higher rate limits** than keyless usage
+
+<Card title="Partner Onboarding" icon="rocket" href="/gateway/onboarding">
+  Get an API key and go live — full flow and contact details
+</Card>
 
 When you have a key, send it as a Bearer token on every V3 request:
 

--- a/docs/gateway/docs.json
+++ b/docs/gateway/docs.json
@@ -31,12 +31,19 @@
           {
             "group": "Integration",
             "pages": [
+              "gateway/onboarding",
               "gateway/integration",
               "gateway/migration",
               "gateway/agents",
               "gateway/strategies",
               "gateway/wallets",
               "gateway/faq"
+            ]
+          },
+          {
+            "group": "API Reference",
+            "pages": [
+              "api-reference/overview"
             ]
           }
         ]

--- a/docs/gateway/gateway/agents.mdx
+++ b/docs/gateway/gateway/agents.mdx
@@ -195,7 +195,7 @@ The [gateway-starter-bot](https://github.com/bob-collective/gateway-starter-bot)
 
 The bot executes a **"buy the dip"** round-trip:
 
-1. **Onramp** — swap BTC → USDT on Ethereum.
+1. **BTC to X** — swap BTC → USDT on Ethereum.
 2. **Watch** — poll the reverse quote (USDT → BTC) until BTC gets cheaper.
 3. **Buy the dip** — swap USDT → BTC, ending with more sats than it started with.
 

--- a/docs/gateway/gateway/faq.mdx
+++ b/docs/gateway/gateway/faq.mdx
@@ -6,72 +6,53 @@ icon: "circle-question"
 
 ## Frequently Asked Questions
 
-<AccordionGroup>
-
-<Accordion icon="gas-pump" title="Who pays the gas fees?">
+### Who pays the gas fees?
 The Relayer estimates gas costs upfront and deducts them from the transaction. Users don't need ETH on BOB to use Gateway.
-</Accordion>
 
-<Accordion icon="triangle-exclamation" title="What happens if my DeFi action fails?">
+### What happens if my DeFi action fails?
 Gateway falls back to sending wrapped BTC directly to the user's EVM address, so the user still receives value. Always test thoroughly to avoid fallbacks. See [Refunds](/gateway/refunds) for details.
-</Accordion>
 
-<Accordion icon="wallet" title="Do I need Bitcoin wallet support?">
+### Do I need Bitcoin wallet support?
 Yes, your frontend needs Bitcoin wallet integration. See the [wallet guide](/gateway/wallets) for implementation details.
-</Accordion>
 
-<Accordion icon="link-simple" title="Can I chain multiple protocols?">
+### Can I chain multiple protocols?
 Yes! Custom strategies can interact with multiple protocols in sequence. For example: stake WBTC → get staked BTC → deposit in lending → send receipt tokens to user.
-</Accordion>
 
-<Accordion icon="shield-check" title="Security considerations?">
+### Security considerations?
 - Use SafeERC20 for token transfers
 - Consider reentrancy protection
 - Ensure proper access controls
 - Test thoroughly on testnet
-</Accordion>
 
-<Accordion icon="money-bill" title="How does affiliate fee monetization work?">
+### How does affiliate fee monetization work?
 You earn a configurable basis-point fee on every swap linked to your affiliate address, paid out in USDT on Ethereum. See [Fees](/gateway/fees) for the model and the [affiliate integration guide](/gateway/integration#monetization-affiliate-fees) for code.
-</Accordion>
 
-<Accordion icon="clock" title="How long do transactions take?">
+### How long do transactions take?
 Transaction time varies based on:
 - Bitcoin network confirmation time (typically 10-60 minutes)
 - Destination chain (cross-chain transactions take longer)
 - Current network congestion
 
 The quote response includes an `estimatedTimeInSecs` field with the expected duration.
-</Accordion>
 
-<Accordion icon="arrows-rotate" title="What happens if Bitcoin fees spike after I submit?">
+### What happens if Bitcoin fees spike after I submit?
 For X-to-BTC transactions, the Bitcoin payout can be bumped to speed up confirmation if network fees increase. See [Refunds](/gateway/refunds).
-</Accordion>
 
-<Accordion icon="xmark" title="Can I cancel a transaction?">
+### Can I cancel a transaction?
 For X-to-BTC orders, you can reclaim locked funds if an order gets stuck. This is irreversible — once unlocked, the order cannot be resumed. See [Refunds](/gateway/refunds).
-</Accordion>
 
-<Accordion icon="code-branch" title="What chains are supported?">
-Gateway supports:
-- **Bitcoin** → BOB (mainnet)
-- **Bitcoin** → Ethereum, Base, Arbitrum, Optimism (via LayerZero)
-- **BOB** → Bitcoin (X to BTC)
+### What chains are supported?
+Gateway supports Bitcoin and a growing set of EVM and non-EVM chains. See [Supported Routes](/gateway/supported-routes) for the current, live list.
 
-Check `getRoutes()` for the complete list of available routes.
-</Accordion>
-
-<Accordion icon="shield-halved" title="Is Gateway audited?">
+### Is Gateway audited?
 Yes, BOB Gateway has been audited by Pashov and Common Prefix. The protocol uses atomic cross-chain swaps verified by an on-chain Bitcoin Light Client, making it trustless between users and market makers.
 
 View audit reports: [docs.gobob.xyz/docs/reference/audits](https://docs.gobob.xyz/docs/reference/audits#bob-gateway)
-</Accordion>
 
-<Accordion icon="money-check-dollar" title="What are the fees?">
+### What are the fees?
 A Gateway swap has a protocol fee, a solver spread, optional affiliate fees, and destination gas — all shown transparently in the quote response. See [Fees](/gateway/fees) for the full breakdown.
-</Accordion>
 
-<Accordion icon="ban" title="Are any regions blocked from using Gateway?">
+### Are any regions blocked from using Gateway?
 Yes. For compliance reasons, BOB Gateway is unavailable to users connecting from the following jurisdictions:
 
 **Blocked countries** (ISO 3166-1 alpha-2):
@@ -83,15 +64,11 @@ Afghanistan (AF), Albania (AL), Bangladesh (BD), Belarus (BY), Cambodia (KH), Ce
 - **Ukraine** — Crimea (`UA-43`), Donetsk Oblast (`UA-14`), Luhansk Oblast (`UA-09`), Kherson Oblast (`UA-65`), Zaporizhzhia Oblast (`UA-23`).
 
 If you operate an integration that serves users in these locations, you are responsible for enforcing the same restrictions in your frontend. The list is subject to change as the applicable sanctions and regulatory regimes evolve.
-</Accordion>
 
-<Accordion icon="life-ring" title="Where can I get help?">
+### Where can I get help?
 - **Discord**: Join our community at [discord.gg/gobob](https://discord.gg/gobob)
 - **GitHub**: Report issues at [github.com/bob-collective/bob](https://github.com/bob-collective/bob)
 - **Documentation**: Browse guides at [docs.gobob.xyz](https://docs.gobob.xyz)
-</Accordion>
-
-</AccordionGroup>
 
 ## Still Have Questions?
 

--- a/docs/gateway/gateway/fees.mdx
+++ b/docs/gateway/gateway/fees.mdx
@@ -1,22 +1,22 @@
 ---
 title: "Fees"
-description: "How Gateway fees work — protocol fees, solver spread, affiliate fees, and gas"
+description: "How Gateway fees work — quote-first pricing, protocol fees, affiliate fees, and gas"
 icon: "money-check-dollar"
 ---
 
-## Overview
+## How fees work
 
-Every Gateway quote is fully costed before the user signs anything. The `getQuote` response breaks each fee out individually so you can show the user exactly what they're paying — in V2 every fee line also carries an optional `usd` value for display.
+Gateway pricing is **quote-first**: every fee is computed per swap and returned in full in the `getQuote` response *before the user signs anything*. The quote you're shown is the quote that gets used to create the order, so the rate is the user's guaranteed minimum — no hidden costs and no surprises at settlement. In V2 every fee line also carries an optional `usd` value for display.
 
-A Gateway swap has four kinds of fees.
+A quote reflects four components.
 
 ## Protocol fee
 
 Fees applied by the protocol for processing and routing swaps. Today these are set to merely cover routing and gas costs, with **0 markup**. In the future, the BOB DAO may vote to activate a fee markup; collected revenue would then go to the BOB DAO treasury.
 
-## Solver spread
+## Solver pricing
 
-Solvers compete to fill each order and quote a spread — typically a few basis points (around 1–20 bps depending on the route and the solver). Gateway automatically selects the best quote for every swap, so the user always gets the most competitive price available.
+Orders are filled by solvers quoting against live market prices. Gateway selects the best available quote for the route, and the rate the user sees is the guaranteed minimum they'll receive.
 
 ## Affiliate fees
 
@@ -34,11 +34,25 @@ For the SDK and raw-API code — single recipient, multi-recipient splits, readi
 
 ## Gas costs
 
-The gas cost of the **destination** chain is included in the swap processing fees and estimated upfront, so users don't need to hold the destination gas token (for BTC-to-X swaps, users don't need ETH on BOB). The gas cost of the **source** chain — the chain where the swap is initiated — is handled out-of-protocol by the wallet.
+The gas cost of the **destination** chain is included in the swap processing fees and estimated upfront, so users don't need to hold the destination gas token (e.g. for BTC-to-Ethereum swaps, users don't need ETH on Ethereum). The gas cost of the **source** chain — the chain where the swap is initiated — is handled out-of-protocol by the wallet.
+
+## Worked example
+
+Illustrative example — actual values vary per quote. A user swaps **$100 of BTC to USDT on Ethereum** through your app, and you charge a **50 bps** affiliate fee:
+
+| Line | Amount |
+|---|---|
+| Protocol fee | $0.00 |
+| Solver pricing | priced into the quoted rate |
+| Destination gas (estimated upfront, varies with network conditions) | ~$0.50 |
+| Your affiliate fee (50 bps) | $0.50 → paid to your address in USDT on Ethereum |
+| **User receives** | **≈ $99.00 of USDT** |
+
+Every line is returned in the `getQuote` response before the user signs anything, so you can display the exact breakdown. The user pays no gas on the destination chain out of pocket — it's deducted from the swap, so they don't need ETH to receive USDT on Ethereum.
 
 ## Seeing fees in the quote
 
-All fees are returned on the quote so you can display them before the user commits:
+Don't estimate — read the exact costs off the quote. Each fee line in `feeBreakdown` carries the amount and an optional USD value:
 
 ```typescript
 const quote = await gatewaySDK.getQuote({ /* ... */ });
@@ -52,6 +66,10 @@ if ('onramp' in quote) {
   }
 }
 ```
+
+<Tip>
+Show this breakdown in your UI and the user sees exactly what they pay, per swap, from the same source of truth Gateway settles against.
+</Tip>
 
 ## Next Steps
 

--- a/docs/gateway/gateway/integration.mdx
+++ b/docs/gateway/gateway/integration.mdx
@@ -64,9 +64,16 @@ const gatewaySDKStaging = new GatewaySDK({ basePath: STAGING_GATEWAY_BASE_URL })
 
 ### Authentication
 
-Gateway API keys are **optional**. All V3 endpoints are reachable without authentication; an API key unlocks higher rate limits and access to partner features.
+API keys are **optional** — the API is reachable without authentication. A key unlocks:
 
-To request a key, contact the BOB team. Once you have one, pass it in the options object:
+- **Analytics dashboard** — your orders, volume, and affiliate earnings
+- **Higher rate limits** than keyless usage
+
+<Card title="Partner Onboarding" icon="rocket" href="/gateway/onboarding">
+  Get an API key and go live — full flow and contact details
+</Card>
+
+Once you have a key, pass it in the options object:
 
 ```typescript
 import { GatewaySDK } from '@gobob/bob-sdk';
@@ -333,6 +340,22 @@ orders.forEach(order => {
 });
 ```
 
+### Link users to the Gateway Explorer
+
+If you don't want to build your own tracking UI, every order has a public
+status page on the Gateway Explorer that you can link users to directly:
+
+```text
+https://gateway-explorer.gobob.xyz/order/<ORDER_ID>
+```
+
+Example: [gateway-explorer.gobob.xyz/order/71a070e7-...](https://gateway-explorer.gobob.xyz/order/71a070e7-7ff5-45c9-8f60-135894ebed11)
+
+Use the order ID returned when the order is created. The page shows live
+status, amounts, and transaction hashes for both sides of the swap — useful
+as a "track your swap" link in confirmation screens, order history, or
+notification emails.
+
 ### Paginating through all orders
 
 `nextCursor` is `null`/absent once you've reached the last page:
@@ -497,6 +520,18 @@ GET /v3/get-quote?...&affiliates=0xPartnerA:50,0xPartnerB:25
 ```
 
 URL-encode the comma if your client doesn't allow raw commas in query strings.
+
+### Track your orders and earnings
+
+With an API key you get a partner dashboard on the Gateway Explorer:
+
+```text
+https://gateway-explorer.gobob.xyz/affiliate/<API_KEY>
+```
+
+It shows your integration's orders, volume, and — if you charge affiliate
+fees — your accumulated earnings. For ecosystem-wide activity, see the public
+[Dune dashboard](https://dune.com/bob_collective/gateway).
 
 ## Next Steps
 

--- a/docs/gateway/gateway/onboarding.mdx
+++ b/docs/gateway/gateway/onboarding.mdx
@@ -1,0 +1,67 @@
+---
+title: "Partner Onboarding"
+description: "Everything you need to go live as a BOB Gateway partner"
+icon: "rocket"
+---
+
+## Welcome to BOB Gateway
+
+BOB Gateway is the fastest way to add native BTC swaps to your app, wallet, or
+aggregator: one integration via our API, no swap infrastructure to build or
+maintain. We handle routing, liquidity, and settlement; your users get
+best-in-market rates.
+
+## Onboarding as an API partner
+
+You integrate via our self-serve API. We recommend requesting an **API key** —
+it gives you two perks:
+
+- **Analytics dashboard** — monitor volume, orders, and affiliate earnings
+- **Higher rate limits** than keyless usage
+
+## Onboarding steps
+
+1. **Build.** The [docs](/gateway/integration) have everything you need for
+   the API and SDK.
+2. **Get your API key (recommended).** Contact a BOB team member or email
+   [gateway@gobob.xyz](mailto:gateway@gobob.xyz) with your project name and
+   the purpose of the key.
+3. **Go live.** Add your key, run a test swap end-to-end, done.
+4. **Track performance.** Open your dashboard at
+   `https://gateway-explorer.gobob.xyz/affiliate/<your-api-key>` — volume,
+   orders, and affiliate earnings if you charge a fee. Ecosystem-wide stats:
+   [Dune](https://dune.com/bob_collective/gateway).
+
+## Where to find what
+
+| You want to… | Go here |
+|---|---|
+| Understand the architecture | [Deep dive](/gateway/technical) |
+| Integrate step-by-step | [Integration guide](/gateway/integration) |
+| See supported chains, routes, assets | [Supported routes](/gateway/supported-routes) |
+| API references | [API reference](/api-reference/overview) |
+| Add Bitcoin wallet support | [Wallets](/gateway/wallets) |
+| Understand fees | [Fees](/gateway/fees) |
+| Build 1-click DeFi flows | [Strategies](/gateway/strategies) |
+| Know what happens if a swap can't complete | [Refunds](/gateway/refunds) |
+
+## FAQ
+
+**Do I need an API key to use the API?**
+No — the API is self-serve. A key is recommended: without one you won't have
+your analytics dashboard, and you'll be on lower rate limits.
+
+**How do affiliate fees work?**
+You set them per quote: an EVM payout address and a rate in bps. The fee is
+added to the swap and paid automatically on settlement — in USDT on Ethereum,
+regardless of the swap's chains. See [Fees](/gateway/fees).
+
+**What does it cost to integrate?**
+Nothing — there's no integration fee.
+
+## Contact
+
+| Need | Reach out |
+|---|---|
+| Partnership contact | [gateway@gobob.xyz](mailto:gateway@gobob.xyz) |
+| Technical / integration support | [BOB Discord](https://discord.gg/gobob) |

--- a/docs/gateway/gateway/refunds.mdx
+++ b/docs/gateway/gateway/refunds.mdx
@@ -6,19 +6,26 @@ icon: "arrow-rotate-left"
 
 ## Overview
 
-Gateway is non-custodial. Swaps are atomic and secured by an on-chain Bitcoin Light Client, so a solver can never take a user's funds without delivering the other side of the swap. If a swap can't be completed, the user gets their funds back. This page explains when and how that happens.
+Gateway is non-custodial. Swaps are atomic and secured by an on-chain Bitcoin Light Client, so a solver can never take a user's funds without delivering the other side of the swap. If a swap can't be completed, the user gets their funds back. BTC-to-X refunds are processed by BOB automatically; the only case requiring user action — an X-to-BTC order where the Bitcoin payout never happened — is a very rare edge case.
 
-## When a refund happens
+Users can always check their order — including refund status — on the [Gateway Explorer](/gateway/integration#link-users-to-the-gateway-explorer) order page, so you don't need to build refund status UI.
 
-There are two situations where funds are returned instead of the expected output:
+## What happens at a glance
 
-- **A DeFi action fails (BTC to X).** When a swap includes a strategy or DeFi action — staking, lending, a multicall — and that on-chain action reverts, Gateway falls back to delivering wrapped BTC directly to the user's EVM address rather than failing the whole swap. The user still receives value; they just receive wrapped BTC instead of the intended position.
-
-- **An order gets stuck or can't be filled.** If no solver completes the order — for example a solver goes offline, or an X-to-BTC payout is never made — the locked funds can be reclaimed. The order status carries a `refundTx` you submit to unlock them.
+| Scenario | What the user receives | Who acts |
+|---|---|---|
+| BTC to X: swap can't fill at quoted terms | USDT on Ethereum | BOB, automatic |
+| BTC to X: DeFi action fails | Wrapped BTC to their EVM address | BOB, automatic |
+| X to BTC: payout delayed | BTC (gateway bumps the fee) | BOB, automatic |
+| X to BTC: payout can't complete (very rare) | Their locked wrapped BTC back | User withdraws — self-serve in BOB Gateway UI, or via `refundTx` for integrators |
 
 ## BTC to X refunds
 
-For BTC-to-X swaps, refunds take the form of the **fallback** described above: if the destination action fails, the user receives wrapped BTC on their EVM address instead. There's no separate reclaim step — Gateway delivers the fallback asset automatically once the Bitcoin payment is verified.
+There are two cases where a BTC-to-X swap returns funds instead of the expected output:
+
+1. **The swap can't fill at the quoted terms.** While waiting for the Bitcoin transaction to confirm, prices can drift until the destination route no longer accepts the submitted amount. When this happens, Gateway refunds the user **in USDT on Ethereum**, automatically — no action needed from the user or the integrator.
+
+2. **A DeFi action fails.** When a swap includes a strategy or DeFi action — staking, lending, a multicall — and that on-chain action reverts, Gateway falls back to delivering wrapped BTC directly to the user's EVM address rather than failing the whole swap. The user still receives value; they just receive wrapped BTC instead of the intended position.
 
 <Tip>
 Always test strategies thoroughly on testnet. A fallback means the user received wrapped BTC rather than the position they intended to open.
@@ -26,10 +33,13 @@ Always test strategies thoroughly on testnet. A fallback means the user received
 
 ## X to BTC refunds
 
-For X-to-BTC swaps, the user first locks wrapped BTC in a Gateway contract while a solver fulfils the Bitcoin payout. If the payout doesn't happen, the user has two options:
+X-to-BTC refunds are a very rare edge case: the token swap settles before the Bitcoin payout is made, so a refund only comes into play if the payout never happens (for example, a solver going offline). Often a slow payout isn't a refund case at all — it just needs a Bitcoin fee bump, which the gateway handles internally.
 
-1. **Bump the fee.** If Bitcoin network fees spiked after the order was created, the payout can be sped up. In V2 the gateway manages BTC fee bumps internally for the payout it broadcasts.
-2. **Reclaim the locked funds.** After a claim-delay period, the user can unlock their wrapped BTC and have it returned.
+If the payout genuinely can't complete, the user's locked wrapped BTC becomes reclaimable. A security delay applies before funds can be withdrawn — this ensures a Bitcoin payment that was already made can't be refunded twice. After the delay:
+
+**For users on the BOB Gateway UI** — the order appears in the activity section (sidebar) with a withdraw option. One click, sign the transaction, funds returned. No integrator involvement needed.
+
+**For integrators** — your users' orders expose the same reclaim as a `refundTx` in the order status (see below). You can submit it on the user's behalf, surface a withdraw button in your own UI, or simply direct users to the BOB Gateway app where they can self-serve.
 
 <Warning>
 Reclaiming is irreversible. Once an order is refunded/unlocked, it cannot be resumed.
@@ -39,6 +49,10 @@ Reclaiming is irreversible. Once an order is refunded/unlocked, it cannot be res
 Because users cannot currently submit Bitcoin proofs themselves, an order may be temporarily "stuck" if the relayer is offline. Funds remain safe and become reclaimable — they cannot be taken by the relayer or a solver.
 </Note>
 
+## Do integrators need to build refund handling?
+
+Mostly no. BTC-to-X refunds are fully automatic, and for the rare X-to-BTC case, users can self-serve in the BOB Gateway UI — or you can handle it via `refundTx`. Optionally, surface refund status in your app using the API fields below — for example to show "refunded" in an order history.
+
 ## Refund status in the API
 
 A completed refund shows up as the `refunded` order status, which lists the `refundedTokens` actually returned (each with `chain`, `token`, `amount`, and the settlement `txHash`). While an order is still in progress or has failed, a `refundTx` may be available to trigger the reclaim:
@@ -47,9 +61,9 @@ A completed refund shows up as the `refunded` order status, which lists the `ref
 - `status.failed.refundTx` — refund available on a failed order
 - `status.refunded.refundedTokens` — the completed refund
 
-## Issuing a refund
+## Issuing a refund manually
 
-When a `refundTx` is present, submit it as a normal EVM transaction to reclaim the locked assets. See the step-by-step code in the integration guide:
+When a `refundTx` is present, it can be submitted as a normal EVM transaction to reclaim the locked assets. Step-by-step code:
 
 <Card title="Refund stuck orders" icon="unlock" href="/gateway/integration#x-to-btc-order-features" horizontal>
   Detect a refundable order and submit its refundTx


### PR DESCRIPTION
## What

Gateway docs updates from the partner-questions ticket (BD-owned batch): https://app.notion.com/p/3793a8aad3b4804a800af71743abd7c9

- **Refunds rewrite** — documents the two real flows: BTC→X refunded automatically as USDT on Ethereum (price drift while BTC confirms); X→BTC manual claim after the claim delay (very rare). Adds at-a-glance table, clarifies BOB processes refunds and integrators don't need refund UI.
- **Fees** — typical-values table + worked example (illustrative, $100 BTC→USDT with 50 bps affiliate fee).
- **New Partner Onboarding page** (`/gateway/onboarding`, first Integration sidebar item) — API key flow, dashboard, where-to-find-what, FAQ, contact.
- **Order tracking** — documents `gateway-explorer.gobob.xyz/order/<ORDER_ID>` under Monitor Orders.
- **Partner dashboard** — documents `gateway-explorer.gobob.xyz/affiliate/<API_KEY>` under Monetization.
- **API key sections** — benefits list (rate limits, analytics dashboard, partner features) + link to onboarding page, version-neutral wording.
- **Editorial** — FAQ accordions dissolved into searchable headings; "BTC to X" phrasing in prose (API field names untouched); API Reference group added to Gateway tab; Alexei's gas-fee example nit.

## Correctness review — resolved
All [TO CONFIRM] items resolved per team feedback (Discord, 06–07/07): no refund-delay number documented (shortening in progress, bob-gateway#1622); refunds split by direction — BTC→X automatic USDT on Ethereum, X→BTC user-withdraws via BOB app activity section or refundTx; fees are quote-first with no published numbers; rate limits mentioned qualitatively only.
