### PR TITLE
docs(gateway): point API reference nav to V3

### DIFF
--- a/docs/gateway/docs.json
+++ b/docs/gateway/docs.json
@@ -53,6 +53,19 @@
             "group": "API reference",
             "openapi": "api-reference/openapi.json",
             "pages": [
+              "GET /v3/get-routes",
+              "GET /v3/get-quote",
+              "POST /v3/create-order",
+              "PATCH /v3/register-tx",
+              "GET /v3/get-order/{id}",
+              "GET /v3/get-orders/{user_address}"
+            ]
+          },
+          {
+            "group": "API reference (V2, deprecated)",
+            "hidden": true,
+            "openapi": "api-reference/openapi.json",
+            "pages": [
               "GET /v2/get-routes",
               "GET /v2/get-quote",
               "POST /v2/create-order",


### PR DESCRIPTION
## Summary
- Repoint the Gateway docs **API Reference** navigation from V2 to V3 endpoints
- Demote the former V2 pages into a hidden `API reference (V2, deprecated)` group, mirroring the existing hidden V1 group so old endpoints stay reachable but out of the primary nav

The `overview.mdx` intro page already targeted V3, and all six `/v3/*` paths are present in `api-reference/openapi.json`, so this makes the nav consistent with the rest of the reference.

## Changes
`docs/gateway/docs.json`:
- Visible **API reference** group now lists `/v3/get-routes`, `/v3/get-quote`, `/v3/create-order`, `/v3/register-tx`, `/v3/get-order/{id}`, `/v3/get-orders/{user_address}`
- New hidden **API reference (V2, deprecated)** group holds the old V2 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)