### PR TITLE
docs(gateway): announce V1 API deprecation date (31 July 2026)

### DIFF
--- a/docs/gateway/api-reference/overview.mdx
+++ b/docs/gateway/api-reference/overview.mdx
@@ -22,6 +22,10 @@ The BOB Gateway API enables seamless cross-chain interactions for Bitcoin-powere
 This reference targets the V3 API. V1 and V2 endpoints remain reachable but are superseded — new integrations should use `/v3`. Upgrading from V1 or V2? See the [Migration Guide](/gateway/migration).
 </Info>
 
+<Warning>
+**The V1 API will be deprecated on 31 July 2026** and shut down afterwards. Migrate any V1 integration to V3 before that date — see the [Migration Guide](/gateway/migration). V2 remains supported.
+</Warning>
+
 V3 builds on V2 with multi-chain support and richer settlement data:
 
 - **Non-EVM chains (Tron & Solana)** — `srcChain`/`dstChain` and the address/token parameters now accept `0x…` on EVM chains and Base58 on Tron/Solana. `POST /v3/create-order` returns a tagged `GatewayTxData` union — `{ "type": "evm" | "tron" | "solana", ... }` — so a client dispatches on `type`. The Solana entry returns a base64-encoded, unsigned `VersionedTransaction`: decode, sign, re-serialize, and broadcast it (don't sign the base64 string directly). The Tron entry adds `feeLimit` (max TRX, in sun, the wallet may burn).

--- a/docs/gateway/api-reference/overview.mdx
+++ b/docs/gateway/api-reference/overview.mdx
@@ -23,7 +23,7 @@ This reference targets the V3 API. V1 and V2 endpoints remain reachable but are 
 </Info>
 
 <Warning>
-**The V1 API will be deprecated on 31 July 2026** and shut down afterwards. Migrate any V1 integration to V3 before that date — see the [Migration Guide](/gateway/migration). V2 remains supported.
+**The V1 API will be deprecated at the end of July 2026** and shut down afterwards. Migrate any V1 integration to V3 before that date — see the [Migration Guide](/gateway/migration). V2 remains supported.
 </Warning>
 
 V3 builds on V2 with multi-chain support and richer settlement data:

--- a/docs/gateway/gateway/integration.mdx
+++ b/docs/gateway/gateway/integration.mdx
@@ -17,7 +17,7 @@ This guide targets the V3 API. V1 and V2 endpoints remain reachable but are supe
 </Info>
 
 <Warning>
-**The V1 API will be deprecated on 31 July 2026** and shut down afterwards. Migrate any V1 integration to V3 before that date — see the [Migration Guide](/gateway/migration). V2 remains supported.
+**The V1 API will be deprecated at the end of July 2026** and shut down afterwards. Migrate any V1 integration to V3 before that date — see the [Migration Guide](/gateway/migration). V2 remains supported.
 </Warning>
 
 V3 builds on V2 with multi-chain support and richer settlement data:

--- a/docs/gateway/gateway/integration.mdx
+++ b/docs/gateway/gateway/integration.mdx
@@ -16,6 +16,10 @@ We recommend using the API directly, but you may use our SDK for convenience.
 This guide targets the V3 API. V1 and V2 endpoints remain reachable but are superseded — the SDK calls `/v3` under the hood. Upgrading an existing integration? See the [Migration Guide](/gateway/migration).
 </Info>
 
+<Warning>
+**The V1 API will be deprecated on 31 July 2026** and shut down afterwards. Migrate any V1 integration to V3 before that date — see the [Migration Guide](/gateway/migration). V2 remains supported.
+</Warning>
+
 V3 builds on V2 with multi-chain support and richer settlement data:
 
 - **Non-EVM chains (Tron & Solana)** — quotes and orders now span EVM, Tron, and Solana as well as Bitcoin. Addresses and token identifiers are `0x…` on EVM chains and Base58 on Tron/Solana. `executeQuote` signs and broadcasts the right transaction shape for each chain; if you build transactions yourself, `createOrder` returns a tagged union you dispatch on (`type: 'evm' | 'tron' | 'solana'`).

--- a/docs/gateway/gateway/migration.mdx
+++ b/docs/gateway/gateway/migration.mdx
@@ -8,6 +8,10 @@ icon: "arrow-up-right-dots"
 
 The V3 API is the current version of BOB Gateway. It adds non-EVM chains (Tron & Solana), richer settlement data, and cross-chain token swaps with affiliate fees. V1 and V2 endpoints remain reachable, but they are superseded and receive no new features — new integrations should target `/v3`, and existing ones should migrate.
 
+<Warning>
+**The V1 API will be deprecated on 31 July 2026.** V1 endpoints keep working until then, but will be shut down afterwards — migrate any V1 integration to V3 before that date. V2 remains supported.
+</Warning>
+
 <Info>
 If you use the **`@gobob/bob-sdk`** SDK, you don't call versioned endpoints directly — the SDK calls `/v3` under the hood. Skip to [Migrating the SDK](#migrating-the-sdk) for the package-level changes. The endpoint sections below are for integrators calling the API directly.
 </Info>

--- a/docs/gateway/gateway/migration.mdx
+++ b/docs/gateway/gateway/migration.mdx
@@ -9,7 +9,7 @@ icon: "arrow-up-right-dots"
 The V3 API is the current version of BOB Gateway. It adds non-EVM chains (Tron & Solana), richer settlement data, and cross-chain token swaps with affiliate fees. V1 and V2 endpoints remain reachable, but they are superseded and receive no new features — new integrations should target `/v3`, and existing ones should migrate.
 
 <Warning>
-**The V1 API will be deprecated on 31 July 2026.** V1 endpoints keep working until then, but will be shut down afterwards — migrate any V1 integration to V3 before that date. V2 remains supported.
+**The V1 API will be deprecated at the end of July 2026.** V1 endpoints keep working until then, but will be shut down afterwards — migrate any V1 integration to V3 before that date. V2 remains supported.
 </Warning>
 
 <Info>


### PR DESCRIPTION
## Summary

Adds a dated **V1 API deprecation notice** across the Gateway docs. V1 endpoints remain reachable until **31 July 2026** and are shut down afterwards; V2 remains supported.

Notice added as a `<Warning>` callout in three places:
- **Migration guide** (`gateway/migration`) — top of the overview
- **API reference overview** (`api-reference/overview`)
- **Integration guide** (`gateway/integration`) — under "What's new in V3"

Each links to the migration guide for the upgrade path.

## Context

Follow-up to #1107 (the migration guide). This surfaces the concrete sunset date now that it's decided, ahead of partner outreach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)