### PR TITLE
feat(sdk): add lean adapter-free ./gateway subpath export

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -3,6 +3,19 @@
     "version": "5.8.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
+    "sideEffects": false,
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./gateway": {
+            "types": "./dist/gateway/core.d.ts",
+            "default": "./dist/gateway/core.js"
+        },
+        "./package.json": "./package.json",
+        "./*": "./*"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/bob-collective/bob.git"

--- a/sdk/src/gateway/core.ts
+++ b/sdk/src/gateway/core.ts
@@ -1,0 +1,32 @@
+// Lean gateway entry for quote/order consumers that don't need the wallet adapters.
+// Importing the adapters (OkxWalletAdapter) pulls the whole wallet/ordinals/runes
+// stack (and @magiceden-oss/runestone-lib) into the bundle; this entry omits them so
+// bundlers only pull the quote/execute client + its generated types. The full surface
+// (including adapters) stays available from the package root and `@gobob/bob-sdk`.
+export { ExecuteQuoteResult, GatewayApiClient as GatewaySDK } from './client';
+export {
+    AnyGatewayError,
+    DetailsFor,
+    GatewayError,
+    GatewayErrorCode,
+    GatewayErrorDetailsMap,
+    isGatewayError,
+    type ExceededLimitDetails,
+    type InsufficientAmountDetails,
+    type QuoteAmountTooLowDetails,
+    type InsufficientSwapAmountDetails,
+    type NoRouteDetails,
+    type SimulationFailedDetails,
+    type UnableToCoverFeesDetails,
+} from './error/gateway-error';
+export * from './generated-client';
+export { BitcoinSigner, ExecuteQuoteStep, ExecuteQuoteStepType, GatewayQuoteParams, GetQuoteParams } from './types';
+export {
+    formatBtc,
+    getChainConfig,
+    getInnerQuote,
+    parseBtc,
+    ScureBitcoinSigner,
+    supportedChainsMapping,
+    type InnerQuote,
+} from './utils';


### PR DESCRIPTION
## What

Adds a lean, adapter-free **`@gobob/bob-sdk/gateway`** subpath export so consumers that only need the gateway quote/execute client stop bundling the entire SDK.

## Why

The swap app's First-Load JS is dominated by a ~492KB chunk that's mostly BTC/wallet code. Root cause: the SDK is **CJS (no tree-shaking)** and `index.ts` barrels `export *` from every module, so importing *anything* from `@gobob/bob-sdk` pulls in `ordinals`, `runes`, `inscription`, `wallet`, `esplora`, `mempool` **+ `@magiceden-oss/runestone-lib`** — none of which the quote path needs.

Traced: the gateway barrel itself drags them in via `gateway/adapters/okx-wallet` → `../wallet` → `utxo` → `inscription`/`runes`.

## How

- New entry `src/gateway/core.ts` — same surface as the gateway barrel **minus the wallet adapters** (client `GatewaySDK`, generated-client types/guards, error surface, quote utils).
- `exports` map: `.` (root, unchanged), **`./gateway` → the lean core**, `./package.json`, and an identity `./*` fallback so every existing specifier (incl. deep imports) keeps resolving.
- `"sideEffects": false` (verified: no module has import-time side effects).

**Non-breaking:** `@gobob/bob-sdk` root and all current imports are unchanged; `./gateway` is purely additive.

## Verified

Static require-graph trace of the built `./gateway` entry:

```
heavy modules still reachable: []        # ordinals/runes/inscription/wallet/esplora/mempool/relay all gone
runestone reachable? false
externals: @scure/base, @scure/bip32, @scure/btc-signer, bip39, bitcoinjs-lib, viem
```

`dist/gateway/core.js` exports 601 symbols incl. `GatewaySDK`.

## Scope / follow-up

`bitcoinjs-lib` (+ `@scure`) is still reachable via `gateway/utils/common` — removing it from the quote path (dual ESM build + splitting `common.ts`) is a **Tier 2 follow-up PR**.

## Note

The `tsc` build emits a **pre-existing** `TS2308` in the generated client (`generated-client/apis/index.ts` barrels both `V2Api` and `V3Api`, which both export `GetMaxSpendableV2Request`) — present on `master`, unrelated to this change. `core.ts` itself compiles clean; `dist` emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
