### PR TITLE
feat(sdk): drop bitcoinjs-lib + scure signer from the gateway quote path

### DIFF
--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -42,7 +42,9 @@ import {
     type GetQuoteParams,
     type StrategyParams,
 } from './types';
-import { estimateGasWithBuffer, formatBtc, isValidTronAddress, tronAddressToHex } from './utils';
+import { formatBtc } from './utils/common';
+import { estimateGasWithBuffer } from './utils/gas';
+import { isValidTronAddress, tronAddressToHex } from './utils/tron';
 
 const RETRY_COUNT = 8; // Number of times to retry fetching transaction receipt after sending a transaction
 

--- a/sdk/src/gateway/core.ts
+++ b/sdk/src/gateway/core.ts
@@ -21,12 +21,8 @@ export {
 } from './error/gateway-error';
 export * from './generated-client';
 export { BitcoinSigner, ExecuteQuoteStep, ExecuteQuoteStepType, GatewayQuoteParams, GetQuoteParams } from './types';
-export {
-    formatBtc,
-    getChainConfig,
-    getInnerQuote,
-    parseBtc,
-    ScureBitcoinSigner,
-    supportedChainsMapping,
-    type InnerQuote,
-} from './utils';
+// Import from specific util modules (not the './utils' barrel) so this lean entry does
+// not pull in the bitcoin-signer helper (and its scure signing deps). Consumers that need
+// the ScureBitcoinSigner helper import it from the package root / full gateway barrel.
+export { formatBtc, getChainConfig, parseBtc, supportedChainsMapping } from './utils/common';
+export { getInnerQuote, type InnerQuote } from './utils/quote';

--- a/sdk/src/gateway/utils/common.ts
+++ b/sdk/src/gateway/utils/common.ts
@@ -1,4 +1,3 @@
-import * as bitcoin from 'bitcoinjs-lib';
 import { createPublicClient, formatUnits, http, parseUnits, Chain as ViemChain } from 'viem';
 import {
     avalanche,
@@ -14,12 +13,6 @@ import {
     unichain,
     arbitrum,
 } from 'viem/chains';
-
-export function toHexScriptPubKey(userAddress: string, network: bitcoin.Network): string {
-    const address = bitcoin.address.toOutputScript(userAddress, network);
-    const buffer = Buffer.concat([Buffer.from([address.length]), address]);
-    return '0x' + buffer.toString('hex'); // Convert buffer to hex string
-}
 
 export function isHexPrefixed(str: string): boolean {
     return str.slice(0, 2) === '0x';

--- a/sdk/src/gateway/utils/script.ts
+++ b/sdk/src/gateway/utils/script.ts
@@ -1,0 +1,10 @@
+import * as bitcoin from 'bitcoinjs-lib';
+
+// Kept in its own module (not re-exported from the utils barrel) so that importing the
+// gateway quote/execute client does not pull bitcoinjs-lib into the bundle. The quote
+// path needs none of this; only callers that build BTC scripts do.
+export function toHexScriptPubKey(userAddress: string, network: bitcoin.Network): string {
+    const address = bitcoin.address.toOutputScript(userAddress, network);
+    const buffer = Buffer.concat([Buffer.from([address.length]), address]);
+    return '0x' + buffer.toString('hex'); // Convert buffer to hex string
+}


### PR DESCRIPTION
> **Stacked on #1110** (`perf/sdk-quote-only-entry`). Review the [delta vs that branch](https://github.com/bob-collective/bob/compare/perf/sdk-quote-only-entry...perf/sdk-quote-no-bitcoinjs). Base retargets to `master` once #1110 merges.

## What

Removes the last heavy BTC dependencies — **`bitcoinjs-lib`, `@scure/btc-signer`, `@scure/bip32`, `bip39`** — from the lean `@gobob/bob-sdk/gateway` quote/execute client's import graph.

## Why

#1110 gave a lean `./gateway` entry that dropped ordinals/runes/wallet/runestone, but `bitcoinjs-lib` (+ scure signer) still leaked in through `gateway/utils/common.ts` and the `./utils` barrel. `bitcoinjs-lib` is the single biggest lib in the swap app's 492KB mount-freeze chunk.

## How

- **Move `toHexScriptPubKey`** — the *only* `bitcoinjs-lib` user in `gateway/utils/common.ts` (and it has zero internal consumers) — into its own `gateway/utils/script.ts`. `common.ts` no longer imports `bitcoinjs-lib`.
- **Import util functions from their specific modules** in `client.ts` and `gateway/core.ts` (`./utils/common`, `./utils/gas`, `./utils/tron`, `./utils/quote`) instead of the `./utils` barrel, which `export *`s `bitcoin-signer` (`@scure/btc-signer` + `@scure/bip32`).
- **Drop `ScureBitcoinSigner`** from the lean `./gateway` entry (still exported from the package root + full gateway barrel for consumers that sign).

## Verified

Require-graph trace of the built `dist/gateway/core.js`:

```
bitcoinjs importers in graph: []
btc-signer importers:         []
bitcoin-signer.ts present:    false
```

Remaining externals on the quote path: `@scure/base` (tron address validation, small) + `viem`. **SDK tests: 77 passed / 11 skipped.**

## Note

Same **pre-existing** `TS2308` in the generated client as #1110 (unrelated to this change); the touched files compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
