### PR TITLE
docs: add NodeFlare to node providers

### DIFF
--- a/docs/docs/docs/tools/node-providers.md
+++ b/docs/docs/docs/tools/node-providers.md
@@ -24,3 +24,11 @@ Follow [Conduit's guide](https://docs.conduit.xyz/guides/run-a-node/op-stack-nod
 
 - [BOB Mainnet](https://drpc.org/chainlist/bob?utm_source=docs&utm_medium=bob)
 - [BOB Sepolia](https://drpc.org/chainlist/bob?utm_source=docs&utm_medium=bob#bob-testnet) (Testnet)
+
+## NodeFlare
+
+[NodeFlare](https://nodeflare.app/chains/bob) serves BOB from its own bare-metal nodes in two regions (Asia + US-East) with automatic failover — a free public endpoint (no API key) plus a free keyed tier with higher limits, `eth_getLogs` and debug/trace support.
+
+**Supported Networks**
+
+- [BOB Mainnet](https://nodeflare.app/chains/bob)


### PR DESCRIPTION
Adds NodeFlare to the node providers page, same format as existing entries.

NodeFlare serves BOB Mainnet (60808) from its own bare-metal nodes in two regions (Asia + US-East) with automatic failover — free public endpoint `https://rpc.nodeflare.app/bob/public` (no API key) plus a free keyed tier including `eth_getLogs` and debug/trace. Live and verifiable via `eth_chainId` → `0xed88`.

