### PR TITLE
fix(gateway-cli): never retry a swap after the source tx is broadcast

### DIFF
--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -1,8 +1,8 @@
 import { MempoolClient } from "@gobob/bob-sdk";
-import type { BitcoinSigner, GetQuoteParams, GatewayCreateOrderV3 } from "@gobob/bob-sdk";
+import type { BitcoinSigner, GetQuoteParams, GatewayCreateOrderV3, ExecuteQuoteStep } from "@gobob/bob-sdk";
 import { getInnerQuoteV3 } from "../util/quote.js";
 import { type WalletClient, type PublicClient } from "viem";
-import { withRetry, SwapError } from "../errors.js";
+import { withRetry, SwapError, PointOfNoReturnError } from "../errors.js";
 import { getRoutes } from "../util/route-provider.js";
 import { resolveSwapInputs, parseAssetChain, buildTokenIndex } from "../util/input-resolver.js";
 import { loadConfig, getSdk, getApi } from "../config.js";
@@ -165,18 +165,60 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
   // Signed flows go through executeQuote.
   // executeQuote handles createOrder + sign + registerTx in one call.
   // For BTC paths the SDK doesn't access walletClient/publicClient; cast to satisfy types.
-  const { order, tx, outputAmount } = await withRetry(async () => {
-    const quote = await sdk.getQuote(quoteParams);
-    // For BTC paths walletClient/publicClient are unused inside the SDK; the
-    // SDK's type forces them to be present, so we widen via `any` to satisfy it.
-    const result = await sdk.executeQuote({
-      quote,
-      walletClient: evmClients?.walletClient as any,
-      publicClient: evmClients?.publicClient as any,
-      btcSigner,
-    });
-    return { ...result, outputAmount: getInnerQuoteV3(quote).outputAmount.amount };
-  }, { retries, isTransient });
+  //
+  // ── Point of no return ─────────────────────────────────────────────────────
+  // `executeQuote` is NOT idempotent. Internally it runs:
+  //   createOrder → (ERC20 reset/approve) → SIGN + BROADCAST the source tx → registerTx
+  // Only that prefix is safe to re-run. If it throws *after* the wallet has been
+  // asked to sign — a `registerTx` 5xx, a solver's "504 Gateway Timeout", a dropped
+  // socket, i.e. exactly the errors `isTransient` matches — then retrying the closure
+  // fetches a fresh quote, creates a SECOND order and broadcasts a SECOND transaction.
+  // The user's funds leave the wallet twice.
+  //
+  // The SDK emits an ExecuteQuoteStep immediately BEFORE every wallet interaction
+  // (ResetApproval / Approve / SendTransaction / SignBitcoinTransaction — see
+  // sdk/src/gateway/client.ts), so the first step of *any* kind is the last instant at
+  // which re-running is still safe. We latch on all of them rather than only the two
+  // that move the funds: an approve is itself a signed, broadcast tx, and re-entering
+  // the closure while it is still pending races its own nonce. Over-latching costs at
+  // most one lost retry of an already-committed swap; under-latching costs the funds.
+  let executed;
+  try {
+    executed = await withRetry(async (guard) => {
+      const quote = await sdk.getQuote(quoteParams);
+      // For BTC paths walletClient/publicClient are unused inside the SDK; the
+      // SDK's type forces them to be present, so we widen via `any` to satisfy it.
+      const result = await sdk.executeQuote({
+        quote,
+        walletClient: evmClients?.walletClient as any,
+        publicClient: evmClients?.publicClient as any,
+        btcSigner,
+        callback: (step: ExecuteQuoteStep) => guard.pointOfNoReturn(step.type),
+      });
+      return { ...result, outputAmount: getInnerQuoteV3(quote).outputAmount.amount };
+    }, { retries, isTransient });
+  } catch (err) {
+    // Failed past the point of no return: a tx may be on-chain but we never got the
+    // order id back, so there is nothing to poll and nothing to reconcile automatically.
+    // Fail loudly and tell the operator not to do the one thing that would double-send.
+    if (err instanceof PointOfNoReturnError) {
+      throw new SwapError(
+        `Swap aborted after the wallet was asked to sign (step: ${err.reason}). ` +
+        `Funds may already have been sent — do NOT re-run this swap or you may send twice. ` +
+        `Check for an existing order from ${senderAddress ?? "your wallet"} with \`gateway-cli orders\` first. ` +
+        `Underlying error: ${err.originalError.message}`,
+        {
+          srcAsset: { symbol: srcAsset.symbol, chain: srcAsset.chain },
+          dstAsset: { symbol: dstAsset.symbol, chain: dstAsset.chain },
+          ...(variant !== "onramp" && {
+            txParams: { from: senderAddress, chainId: CHAIN_IDS[evmChain], chainName: evmChain },
+          }),
+        },
+      );
+    }
+    throw err;
+  }
+  const { order, tx, outputAmount } = executed;
 
   const orderData = (order as any)[variant];
   if (!orderData?.orderId) {

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -204,8 +204,10 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
     if (err instanceof PointOfNoReturnError) {
       throw new SwapError(
         `Swap aborted after the wallet was asked to sign (step: ${err.reason}). ` +
-        `Funds may already have been sent — do NOT re-run this swap or you may send twice. ` +
-        `Check for an existing order from ${senderAddress ?? "your wallet"} with \`gateway-cli orders\` first. ` +
+        `A transaction may already have been broadcast — do NOT re-run this swap or you may send twice. ` +
+        `(The signature was requested but we never learned whether it reached the chain; a failure during ` +
+        `transaction preparation may mean nothing was sent.) ` +
+        `Confirm with \`gateway-cli orders ${ownerAddress}\` before re-running. ` +
         `Underlying error: ${err.originalError.message}`,
         {
           srcAsset: { symbol: srcAsset.symbol, chain: srcAsset.chain },

--- a/gateway-cli/src/errors.ts
+++ b/gateway-cli/src/errors.ts
@@ -27,7 +27,47 @@ export class SwapError extends Error {
 }
 
 /**
+ * Handle given to a retryable operation so it can declare that it has crossed a
+ * *point of no return* — an irreversible side effect (a wallet signature, a
+ * broadcast) that makes re-running the whole operation unsafe, no matter what
+ * error follows.
+ */
+export interface RetryGuard {
+  /**
+   * Latch. From this call onward the current operation will NOT be retried,
+   * however transient the subsequent error looks. Idempotent; the first reason wins.
+   */
+  pointOfNoReturn(reason: string): void;
+}
+
+/**
+ * Thrown by {@link withRetry} when an operation failed *after* it declared a
+ * {@link RetryGuard.pointOfNoReturn}. Its existence tells the caller "this failed
+ * with side effects already committed" — which is a different, louder outcome
+ * than a clean failure, and must never be papered over as a plain retry exhaustion.
+ */
+export class PointOfNoReturnError extends Error {
+  constructor(
+    /** The failure that actually occurred, after the irreversible step. */
+    readonly originalError: Error,
+    /** Which irreversible step had been reached when it failed. */
+    readonly reason: string,
+  ) {
+    super(originalError.message);
+    this.name = "PointOfNoReturnError";
+  }
+}
+
+/**
  * Retry `fn` while it throws a transient error; stop immediately on anything else.
+ *
+ * `fn` receives a {@link RetryGuard}. Once `fn` trips the guard, the attempt is
+ * never retried — the guard **dominates `isTransient`**, because no amount of
+ * "this error looks transient" can make it safe to re-run an operation that has
+ * already broadcast a transaction. The latch is created, and consulted, *inside*
+ * this function: a caller can arm it but cannot forget to wire it into the retry
+ * decision, which is what makes "retried after an irreversible step" an
+ * unrepresentable state rather than merely an unlikely one.
  *
  * p-retry's `AbortError` is an internal detail here, never exposed to callers: it
  * always wraps the ORIGINAL Error, so a {@link SwapError}'s `context` survives
@@ -35,16 +75,22 @@ export class SwapError extends Error {
  * for terminal, a transient sentinel to keep retrying) and never touch AbortError.
  */
 export async function withRetry<T>(
-  fn: () => Promise<T>,
+  fn: (guard: RetryGuard) => Promise<T>,
   opts: { retries: number; isTransient: (e: unknown) => boolean; minTimeout?: number; maxTimeout?: number },
 ): Promise<T> {
   return pRetry(
     async () => {
+      let crossed: string | undefined;
+      const guard: RetryGuard = { pointOfNoReturn: (reason) => { crossed ??= reason; } };
       try {
-        return await fn();
+        return await fn(guard);
       } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        // Checked BEFORE isTransient, deliberately: past the point of no return the
+        // only safe move is to stop and tell the operator what was already done.
+        if (crossed !== undefined) throw new AbortError(new PointOfNoReturnError(err, crossed));
         if (opts.isTransient(e)) throw e; // retryable → let p-retry retry
-        throw new AbortError(e instanceof Error ? e : new Error(String(e))); // terminal → stop, preserve the Error (+ context)
+        throw new AbortError(err); // terminal → stop, preserve the Error (+ context)
       }
     },
     { retries: opts.retries, minTimeout: opts.minTimeout, maxTimeout: opts.maxTimeout, factor: 1 },

--- a/gateway-cli/src/errors.ts
+++ b/gateway-cli/src/errors.ts
@@ -35,7 +35,14 @@ export class SwapError extends Error {
 export interface RetryGuard {
   /**
    * Latch. From this call onward the current operation will NOT be retried,
-   * however transient the subsequent error looks. Idempotent; the first reason wins.
+   * however transient the subsequent error looks.
+   *
+   * Safe to call repeatedly as the operation progresses: the latch itself is
+   * monotonic (once armed it never disarms), and the LAST reason wins, so the
+   * error reports the *furthest* irreversible step reached — not the first.
+   * Reporting the first would understate how far the operation got (e.g. naming
+   * an ERC20 `approve` when the funds tx had in fact already been broadcast),
+   * which is precisely the misreading that leads someone to re-run and double-send.
    */
   pointOfNoReturn(reason: string): void;
 }
@@ -81,7 +88,7 @@ export async function withRetry<T>(
   return pRetry(
     async () => {
       let crossed: string | undefined;
-      const guard: RetryGuard = { pointOfNoReturn: (reason) => { crossed ??= reason; } };
+      const guard: RetryGuard = { pointOfNoReturn: (reason) => { crossed = reason; } };
       try {
         return await fn(guard);
       } catch (e) {

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -330,6 +330,25 @@ describe("handleSwap", () => {
     expect(caught.message).toContain("approve");
   });
 
+  it("reports the FURTHEST step reached, not the first, when several steps fired", async () => {
+    // An EVM ERC20 swap fires approve → send_transaction. If the error names the first
+    // step, an operator reads "only the approve went out" and concludes it is safe to
+    // re-run — while the funds tx is already on-chain. That misreading is the exact
+    // double-send this fix exists to prevent, so the furthest step must win.
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "approve", totalSteps: 2 });
+      callback?.({ step: 2, type: "send_transaction", totalSteps: 2 });
+      throw new Error("registerTx failed: 503 Service Unavailable");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const caught = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+    expect(caught.message).toContain("send_transaction");
+    expect(caught.message).not.toContain("step: approve");
+  });
+
   it("DOES still retry a transient error raised BEFORE anything was broadcast", async () => {
     // The other half of the invariant: the fix must not disable retries wholesale.
     // Nothing has been signed yet here, so re-quoting is free of side effects.

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -269,6 +269,84 @@ describe("handleSwap", () => {
     expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
   });
 
+  // ─── Point of no return: never retry a swap once the source tx is broadcast ──
+  //
+  // `executeQuote` is not idempotent: createOrder → sign + BROADCAST → registerTx.
+  // Re-running it after the broadcast sends the user's funds a SECOND time. The SDK
+  // fires its step callback immediately before it asks the wallet to sign, which is
+  // the signal these tests rely on.
+
+  it("does NOT retry executeQuote when a transient error is thrown AFTER the source tx was broadcast", async () => {
+    // Exactly the real staging incident: the solver returned 504 *after* the source
+    // funds had already left the wallet. "504 Gateway Timeout" matches /timeout/i in
+    // TRANSIENT, so before the fix --retry re-ran the closure → second broadcast.
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "send_transaction", totalSteps: 1 });
+      throw new Error("bungee api error: status=504 Gateway Timeout");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const { SwapError } = await import("../../src/errors.js");
+
+    const caught = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    // The funds-safety invariant: one broadcast, one attempt. Never two.
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+
+    expect(caught).toBeInstanceOf(SwapError);
+    // The operator must not be told "it failed, try again" while funds are in flight.
+    expect(caught.message).toMatch(/do NOT re-run/i);
+    expect(caught.message).toContain("send_transaction");
+    // Original error text is preserved so downstream categorization still matches.
+    expect(caught.message).toContain("504 Gateway Timeout");
+  });
+
+  it("does NOT retry after a BTC signature was requested, even on a transient error", async () => {
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "sign_bitcoin_transaction", totalSteps: 1 });
+      throw new Error("ECONNRESET");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const caught = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+    expect(caught.message).toMatch(/do NOT re-run/i);
+  });
+
+  it("does NOT retry after an ERC20 approve was signed (conservative: approve is a broadcast tx too)", async () => {
+    // An approve alone is not a double-send, but re-entering the closure while it is
+    // still pending races its own nonce — and the next step would broadcast the funds.
+    // The line is drawn at the FIRST wallet interaction of any kind.
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "approve", totalSteps: 2 });
+      throw new Error("rate limit exceeded");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const caught = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+    expect(caught.message).toContain("approve");
+  });
+
+  it("DOES still retry a transient error raised BEFORE anything was broadcast", async () => {
+    // The other half of the invariant: the fix must not disable retries wholesale.
+    // Nothing has been signed yet here, so re-quoting is free of side effects.
+    let quoteCalls = 0;
+    mockGetQuote.mockImplementation(async () => {
+      if (++quoteCalls === 1) throw new Error("429 Too Many Requests");
+      return onrampQuote;
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const result = await handleSwap({ ...baseOpts, retry: true }, silentLogger);
+
+    expect(result.type).toBe("confirmed");
+    expect(quoteCalls).toBe(2);
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+  });
+
   it("tokenSwap order-failed error carries txId + txParams.chainId for receipt lookup", async () => {
     // An EVM→EVM tokenSwap settles via an on-chain tx. When the order fails,
     // the thrown error must carry the settlement tx hash + chainId so downstream

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -314,6 +314,25 @@ describe("handleSwap", () => {
     expect(caught.message).toMatch(/do NOT re-run/i);
   });
 
+  it("names the EVM owner, not the BTC sender, in the recovery hint on a BTC onramp", async () => {
+    // `gateway-cli orders` rejects BTC addresses outright, and orders are indexed by the
+    // EVM-side owner. Naming the BTC sender leaves the operator unable to check whether an
+    // order exists — exactly the moment they are tempted to re-run, and double-send.
+    const { deriveAddress, resolveRecipient } = await import("../../src/chains/index.js");
+    vi.mocked(deriveAddress).mockResolvedValue("bc1qsender");
+    vi.mocked(resolveRecipient).mockResolvedValue("0xEvmOwner");
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "sign_bitcoin_transaction", totalSteps: 1 });
+      throw new Error("ECONNRESET");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const caught = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    expect(caught.message).toContain("gateway-cli orders 0xEvmOwner");
+    expect(caught.message).not.toContain("bc1qsender");
+  });
+
   it("does NOT retry after an ERC20 approve was signed (conservative: approve is a broadcast tx too)", async () => {
     // An approve alone is not a double-send, but re-entering the closure while it is
     // still pending races its own nonce — and the next step would broadcast the funds.


### PR DESCRIPTION
## Condition

`sdk.executeQuote` is **not idempotent**. Internally it runs:

```
createOrder → (ERC20 reset/approve) → SIGN + BROADCAST the source tx → registerTx
```

Only that prefix is safe to re-run. But in `src/commands/swap.ts` the whole thing sat inside a `withRetry`:

```ts
const { order, tx, outputAmount } = await withRetry(async () => {
  const quote = await sdk.getQuote(quoteParams);
  const result = await sdk.executeQuote({ quote, walletClient, publicClient, btcSigner });
  return { ...result, outputAmount: ... };
}, { retries, isTransient });
```

The retry boundary was drawn around an operation spanning both an idempotent prefix (quote, createOrder) and an irreversible action (sign + broadcast).

## Mechanism

If `executeQuote` throws **after** broadcasting — `registerTx` returns a 5xx, the solver times out, the socket drops — `isTransient` is consulted. Its regex list is:

```ts
[/TRM screening/i, /429/, /Too Many Requests/i, /rate limit/i, /not yet propagated/i,
 /BTC propagation/i, /timeout/i, /ECONNRESET/, /ETIMEDOUT/]
```

A match re-runs the closure: it fetches a **new quote**, creates a **new order**, and **signs and broadcasts a second transaction**. The funds leave the wallet again. `retries = 5`, so a persistently-timing-out solver produces up to **six broadcasts**.

The regression test added here confirms this on `master` — `executeQuote` is called **6 times** after the SDK has already reported the tx as sent:

```
× does NOT retry executeQuote when a transient error is thrown AFTER the source tx was broadcast
  → expected "spy" to be called 1 times, but got 6 times
```

## Impact

**Reachability is `--retry` only.** `const retries = opts.retry ? 5 : 0;` — without the flag the closure runs once and cannot double-send. `bob-collective/gateway-bot`'s CI does **not** pass `--retry`, so scheduled bot runs are **not exposed today**. This is not an actively-firing incident.

It is still a real funds bug: `--retry` is a public, documented flag; the volume workflow moves **$1,500/leg**; and a human running a swap by hand, or any future workflow adding the flag, would be exposed.

The trigger is not hypothetical. Two staging swaps threw exactly these post-broadcast errors *after* the source funds had left the wallet — a solver `504 Gateway Timeout` and a network failure. **`"504 Gateway Timeout"` matches `/timeout/i`.** With `--retry` set, that swap would have re-broadcast.

## Fix — the point of no return

Retrying is only ever safe *before* the first signature. `executeQuote` accepts a `callback`, and the SDK fires an `ExecuteQuoteStep` **immediately before every wallet interaction** (`ResetApproval`, `Approve`, `SendTransaction`, `SignBitcoinTransaction` — see `sdk/src/gateway/client.ts`; each `callback?.(...)` directly precedes the `writeContract` / `sendBitcoin` / `signAllInputs`). **No SDK change is needed** — published `@gobob/bob-sdk@5.8.0` already exposes it.

`withRetry` now hands the operation a `RetryGuard`. The operation latches it on crossing the point of no return, and **the guard is checked inside `withRetry`, before `isTransient`**:

```ts
if (crossed !== undefined) throw new AbortError(new PointOfNoReturnError(err, crossed));
if (opts.isTransient(e)) throw e;
```

The latch is created and consulted *inside* `withRetry`; a caller can arm it but cannot forget to wire it into the retry decision. That is deliberate — it makes "retried after a broadcast" an **unrepresentable** state rather than a merely unlikely one. No error classification can override it, because no amount of "this looks transient" makes re-running a broadcast safe.

### Where the line is drawn, and why

**At the first wallet interaction of *any* kind — including `Approve`.**

An ERC20 approve is not itself a funds double-send, so a narrower line (latch only on `SendTransaction` / `SignBitcoinTransaction`) is defensible. I rejected it:

- An approve is a **real signed, broadcast transaction**. Re-entering the closure while it is still pending races its own nonce — and the CLI's pending-nonce preflight runs *before* the retry loop, not inside it, so nothing catches that.
- The callback fires *before* the write, so on an error we **cannot know whether the write landed**. "A signature was requested" is the strongest fact available; treating it as "may have been broadcast" is the only sound reading.
- The costs are wildly asymmetric. Over-latching loses at most one retry of a swap the user already committed gas to. Under-latching loses their funds.
- It fails safe as the SDK evolves: a future step type we don't know about is treated as irreversible by default rather than silently falling outside an enumerated list.

**Accepted cost of that line:** errors that are thrown *after* the step callback but *before* anything actually reached the mempool (e.g. viem raising insufficient-funds-for-gas inside `writeContract`) now also report "funds may have been sent" and stop retrying. That over-warns on a common, in fact safe, failure. This is intentional: the only way to suppress it would be to classify errors by message on the funds path, which is the very anti-pattern this PR removes. The message tells the operator how to resolve the ambiguity (`gateway-cli orders`).

### What the CLI does when it fails past that line

It must not claim a clean failure while funds are in flight. It raises a `SwapError`:

> Swap aborted after the wallet was asked to sign (step: send_transaction). Funds may already have been sent — do NOT re-run this swap or you may send twice. Check for an existing order from `<sender>` with `gateway-cli orders` first. Underlying error: `<original>`

The original error text is preserved as a substring, so `gateway-bot`'s `alert.ts` message categorization still matches.

The guard reports the **furthest** step reached, not the first. (Caught in self-review: with first-reason-wins, an EVM ERC20 swap failing at `registerTx` reported `step: approve` while the funds tx was already on-chain — an operator reading "only the approve went out" would conclude it was safe to re-run, causing the very double-send this PR prevents. Pinned by a test.)

This deliberately does **not** reuse #1120's `in_flight` state, even once that merges: `in_flight` means "we have an order id, go follow it." Here `executeQuote` threw, so **we never got an order id back** — there is nothing to poll and nothing to reconcile automatically. A loud terminal failure telling the operator not to retry is the honest outcome. This applies on the default path too (no `--retry`), where it strictly improves an otherwise-bare transient error — incident #1's exact scenario.

## Scope vs #1120

Disjoint by construction. #1120 rewrites the **order-polling loop** (post-`executeQuote`); this changes only the **quote+execute retry block** (pre-poll) plus `errors.ts`. They should rebase cleanly in either order.

## Tests

`gateway-cli/tests/commands/swap.test.ts`, following existing vitest conventions. Each verified **failing on `master`** and passing here:

- transient error (`504 Gateway Timeout`) thrown *after* a `send_transaction` step, with `--retry` → `executeQuote` called **once**, error says do-not-retry *(master: 6 calls)*
- same after `sign_bitcoin_transaction` (BTC path) → one call *(master: 6 calls)*
- same after `approve` → one call, documenting the conservative line *(master: 6 calls)*
- `approve` → `send_transaction` → failure reports the furthest step *(fails against first-reason-wins)*
- transient error *before* any broadcast (`getQuote` throws `429`) → **still retries** and confirms — the fix must not disable retries wholesale *(passes on master, and must keep passing)*

`pnpm build` + `pnpm test` — **117 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
