### PR TITLE
fix(gateway-cli): single swap context, signal-driven polling, no retry past broadcast

### DIFF
--- a/gateway-cli/README.md
+++ b/gateway-cli/README.md
@@ -177,8 +177,8 @@ All config via environment variables. No config files.
 --private-key <key>      Signing key (or use env vars)
 --unsigned               Output unsigned PSBT/tx without signing
 --no-wait                Exit after submitting without polling
---no-retry               Fail immediately on transient errors
---timeout <seconds>      Polling timeout (default: 1800)
+--no-retry               Fail immediately on transient errors (retry is on by default)
+--timeout <seconds>      Polling timeout (default: 1800, max: 86400)
 ```
 
 ### Send only
@@ -226,6 +226,17 @@ git push origin cli-v0.3.0-rc0
 
 ## Error handling
 
-- **Transient errors** (rate limits, timeouts): automatically retried on quote and registration steps. Use `--no-retry` to disable.
+- **Transient errors** (rate limits, timeouts): automatically retried, but only *before* the
+  wallet is asked to sign. Retrying is enabled by default; use `--no-retry` to disable.
+- **Point of no return**: once the wallet has been asked to sign, the swap is never retried,
+  however transient the error looks — re-running `executeQuote` would broadcast a second
+  transaction and send the funds twice. Such a failure is reported as terminal, tells you not
+  to re-run, and points at `gateway-cli orders <owner-address>` to check whether an order exists.
 - **Registration failure**: if a signed tx fails to register, the error includes the order ID and a recovery command: `gateway-cli register <order-id> <txid>`.
+- **Status read failures while polling**: a swap's funds are committed once it is submitted, so
+  the order status is the only authority on whether it failed. Errors while *reading* that status
+  (gateway 5xx, network failures) are retried until `--timeout`, never reported as swap failures.
+- **`--timeout` reached without a terminal status**: reported as `in_flight` (exit 0), carrying
+  the order id and source txid — the swap is still settling, not failed. Follow it up with
+  `gateway-cli status <order-id>`.
 - **Balance errors**: per-chain failures show "N/A" instead of failing the entire command.

--- a/gateway-cli/src/chains/index.ts
+++ b/gateway-cli/src/chains/index.ts
@@ -28,11 +28,11 @@ export function getChainFamily(chain: string): ChainFamily {
  * Validate that a recipient address matches the asset's chain family.
  * @throws Error if a BTC address is used for an EVM chain or vice-versa.
  */
-export function validateRecipient(chain: string, to: string): void {
+export function validateAddressFamily(chain: string, address: string, flag = '--to'): void {
   if (getChainFamily(chain) === 'bitcoin') {
-    if (!isValidBtcAddress(to)) throw new Error(`--to "${to}" is not a valid Bitcoin address.`);
+    if (!isValidBtcAddress(address)) throw new Error(`${flag} "${address}" is not a valid Bitcoin address.`);
   } else {
-    if (!isAddress(to, { strict: false })) throw new Error(`--to "${to}" is not a valid EVM address.`);
+    if (!isAddress(address, { strict: false })) throw new Error(`${flag} "${address}" is not a valid EVM address.`);
   }
 }
 

--- a/gateway-cli/src/cli.ts
+++ b/gateway-cli/src/cli.ts
@@ -89,7 +89,7 @@ program
     const mode = modeOf(opts);
     const parsed = quoteSchema.parse(opts);
     const { handleQuote } = await import("./commands/quote.js");
-    const result = await handleQuote({ ...parsed, sender: parsed.sender, ownerAddress: parsed.owner });
+    const result = await handleQuote(parsed);
     render(result.quote, mode, () => formatConfirmation(result.confirmation));
   }));
 
@@ -118,7 +118,7 @@ program
 
     const log = createLogger(mode);
     const { handleSwap } = await import("./commands/swap.js");
-    const result = await handleSwap({ ...parsed, sender: parsed.sender, owner: parsed.owner }, log);
+    const result = await handleSwap(parsed, log);
 
     render("data" in result ? result.data : result, mode);
   }));

--- a/gateway-cli/src/commands/quote.ts
+++ b/gateway-cli/src/commands/quote.ts
@@ -1,23 +1,13 @@
 import { getInnerQuoteV3 } from "../util/quote.js";
 import { getRoutes } from "../util/route-provider.js";
-import { resolveSwapInputs } from "../util/input-resolver.js";
+import { resolveSwapContext, type SwapContextOptions } from "../util/swap-context.js";
 import { MempoolClient } from "@gobob/bob-sdk";
 import { loadConfig, getSdk } from "../config.js";
-import { resolveRecipient, deriveAddress, getChainFamily, resolvePrivateKey } from "../chains/index.js";
 import type { QuoteJson, ConfirmationData } from "../output.js";
 
 /** Quote command options. */
-export interface QuoteOptions {
-  src: string;
-  dst: string;
-  amount: string;
-  recipient?: string;
-  sender?: string;
-  ownerAddress?: string;
-  slippage?: number;
+export interface QuoteOptions extends SwapContextOptions {
   btcFeeRate?: number;
-  feeToken?: string;
-  feeReserve?: string;
 }
 
 /** Quote command result with quote data and confirmation display. */
@@ -28,47 +18,29 @@ export interface QuoteResult {
 
 /**
  * Handle the quote command: fetch a swap quote without executing.
- * Resolves asset inputs, recipient, and fee rate, then requests quote from Gateway.
- * 
+ *
+ * The swap is resolved through the SAME {@link resolveSwapContext} that `swap` uses,
+ * so the two cannot disagree about the source chain, the sender or the owner — every
+ * such disagreement in the past was a bug, most recently an offramp quote sending the
+ * Bitcoin recipient as `ownerAddress` and being rejected by the API every time.
+ *
+ * A quote signs nothing, so it declares no need for a key: one is touched only if the
+ * owner or an `--amount ALL` balance genuinely depends on it.
+ *
  * @param opts - Quote options including source, destination, amount
  * @returns Quote data and confirmation display info
  */
 export async function handleQuote(opts: QuoteOptions): Promise<QuoteResult> {
   const config = loadConfig();
   const sdk = getSdk();
-  const slippageBps = opts.slippage ?? config.slippageBps;
 
   const routes = await getRoutes();
-
-  // Derive sender from env keys only when needed (--amount ALL requires it).
-  // Don't derive eagerly — a malformed key shouldn't break ordinary quotes.
-  let senderAddress = opts.sender;
-  if (!senderAddress && opts.amount.toUpperCase() === "ALL") {
-    const srcRaw = opts.src.includes(":") ? opts.src.split(":")[1] : opts.src;
-    const srcFamily = getChainFamily(srcRaw === "BTC" || srcRaw === "btc" ? "bitcoin" : srcRaw);
-    const key = resolvePrivateKey(srcFamily === "bitcoin" ? "bitcoin" : "evm", undefined, config);
-    if (key) {
-      try {
-        senderAddress = await deriveAddress(srcFamily === "bitcoin" ? "bitcoin" : "evm", key);
-      } catch (err) {
-        const envVar = srcFamily === "bitcoin" ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY";
-        throw new Error(`Failed to derive sender address from ${envVar}: ${err instanceof Error ? err.message : String(err)}\n  Use --sender <address> to provide the address directly.`);
-      }
-    }
-  }
-
-  const { srcAsset, dstAsset, atomicUnits, display } = await resolveSwapInputs(
-    opts.src, opts.dst, opts.amount, routes,
-    { senderAddress, feeToken: opts.feeToken, feeReserve: opts.feeReserve },
-  );
-
-  // ── Resolve recipient ────────────────────────────────────────────────────
-  const recipient = await resolveRecipient(dstAsset.chain, opts.recipient, config);
+  const ctx = await resolveSwapContext(opts, routes, config, { signing: false, senderAddress: false });
 
   // Fee rate is informational only — the Gateway backend determines the actual fee.
   // We show the current mempool rate so users know what to expect.
   let feeRate: number | undefined;
-  if (srcAsset.chain === "bitcoin") {
+  if (ctx.srcFamily === "bitcoin") {
     feeRate = opts.btcFeeRate ?? config.btcFeeRate;
     if (feeRate == null) {
       const fees = await new MempoolClient().getRecommendedFees();
@@ -76,44 +48,29 @@ export async function handleQuote(opts: QuoteOptions): Promise<QuoteResult> {
     }
   }
 
-  // ownerAddress (required by V3) is the EVM-side address controlling the order.
-  // Use the explicit --owner override when given; otherwise derive the EVM-side
-  // address: recipient for onramp (BTC→EVM), sender for offramp/tokenSwap.
-  const ownerAddress = opts.ownerAddress ?? (srcAsset.chain === "bitcoin" ? recipient : (senderAddress ?? recipient));
-
-  const quote = await sdk.getQuote({
-    fromChain: srcAsset.chain,
-    toChain: dstAsset.chain,
-    fromToken: srcAsset.address,
-    toToken: dstAsset.address,
-    toUserAddress: recipient,
-    fromUserAddress: senderAddress,
-    ownerAddress,
-    amount: atomicUnits,
-    maxSlippage: slippageBps,
-  });
+  const quote = await sdk.getQuote(ctx.quoteParams);
   const outputAmount = getInnerQuoteV3(quote).outputAmount.amount;
 
   return {
     quote: {
-      srcAmount: atomicUnits,
-      srcAsset: srcAsset.symbol,
+      srcAmount: ctx.atomicUnits,
+      srcAsset: ctx.srcAsset.symbol,
       dstAmount: outputAmount,
-      dstAsset: dstAsset.symbol,
-      dstChain: dstAsset.chain,
-      slippageBps,
+      dstAsset: ctx.dstAsset.symbol,
+      dstChain: ctx.dstAsset.chain,
+      slippageBps: ctx.slippageBps,
       feeRateSatPerVbyte: feeRate,
     },
     confirmation: {
-      srcAmount: atomicUnits,
-      srcAsset: srcAsset.symbol,
-      srcDisplay: display,
+      srcAmount: ctx.atomicUnits,
+      srcAsset: ctx.srcAsset.symbol,
+      srcDisplay: ctx.display,
       dstAmount: outputAmount,
-      dstAsset: dstAsset.symbol,
-      dstChain: dstAsset.chain,
+      dstAsset: ctx.dstAsset.symbol,
+      dstChain: ctx.dstAsset.chain,
       feeRateSatPerVbyte: feeRate,
-      slippageBps,
-      recipient: recipient,
+      slippageBps: ctx.slippageBps,
+      recipient: ctx.recipient,
     },
   };
 }

--- a/gateway-cli/src/commands/send.ts
+++ b/gateway-cli/src/commands/send.ts
@@ -4,7 +4,7 @@ import { parseAmount } from "../util/input-resolver.js";
 import { resolveSendAsset } from "../util/asset-resolver.js";
 import { loadConfig } from "../config.js";
 import {
-  validateRecipient, getChainFamily, resolvePrivateKey, deriveAddress, resolveSigner,
+  validateAddressFamily, getChainFamily, resolvePrivateKey, deriveAddress, resolveSigner,
   type BtcSigner, type EvmSigner,
 } from "../chains/index.js";
 import { sendEvm, buildUnsignedEvmTx, nativeSweepAmount, getEvmBalances, CHAIN_IDS } from "../chains/evm.js";
@@ -53,17 +53,17 @@ export async function handleSend(opts: SendOptions, log: Logger): Promise<SendRe
   const asset = await resolveSendAsset(opts.asset);
   const family = getChainFamily(asset.chain);
 
-  validateRecipient(asset.chain, opts.to);
+  validateAddressFamily(asset.chain, opts.to, "--to");
 
   const key = resolvePrivateKey(asset.chain, opts.privateKey, config);
   // The key-derived address wins; otherwise --from supplies the sender for the keyless
   // unsigned path. A source address only needs to be valid for the asset's chain family
-  // (validateRecipient checks exactly that), so reuse it here for --from.
+  // (validateAddressFamily checks exactly that), so reuse it here for --from.
   let senderAddress: string | undefined;
   if (key) {
     senderAddress = await deriveAddress(asset.chain, key);
   } else if (opts.from) {
-    validateRecipient(asset.chain, opts.from);
+    validateAddressFamily(asset.chain, opts.from, "--from");
     senderAddress = opts.from;
   }
 

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -1,29 +1,19 @@
 import { MempoolClient } from "@gobob/bob-sdk";
-import type { BitcoinSigner, GetQuoteParams, GatewayCreateOrderV3 } from "@gobob/bob-sdk";
+import type { BitcoinSigner, GatewayCreateOrderV3 } from "@gobob/bob-sdk";
 import { getInnerQuoteV3 } from "../util/quote.js";
 import { type WalletClient, type PublicClient } from "viem";
 import { withRetry, SwapError } from "../errors.js";
 import { getRoutes } from "../util/route-provider.js";
-import { resolveSwapInputs, parseAssetChain, buildTokenIndex } from "../util/input-resolver.js";
+import { resolveSwapContext, type SwapContextOptions } from "../util/swap-context.js";
 import { loadConfig, getSdk, getApi } from "../config.js";
-import { deriveAddress, resolveSigner, getChainFamily, resolvePrivateKey, resolveRecipient } from "../chains/index.js";
+import { resolveSigner } from "../chains/index.js";
 import { CHAIN_IDS } from "../chains/evm.js";
 import type { Logger, SwapSuccessJson, SwapSubmittedJson, SwapMempoolPendingJson } from "../output.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-export interface SwapOptions {
-  src: string;
-  dst: string;
-  amount: string;
-  recipient?: string;
-  sender?: string;
-  owner?: string;
-  slippage?: number;
+export interface SwapOptions extends SwapContextOptions {
   btcFeeRate?: number;
-  feeToken?: string;
-  feeReserve?: string;
-  privateKey?: string;
   unsigned: boolean;
   wait: boolean;
   retry: boolean;
@@ -44,76 +34,34 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
   const retries = opts.retry ? 5 : 0;
 
   // ── Resolve inputs ──────────────────────────────────────────────────────────
-
-  // Fetch routes first so we can accurately determine the source chain family
-  // via the full alias/token resolution path rather than ad-hoc string parsing.
+  // The SAME context `quote` builds: assets, families, sender, recipient, owner,
+  // amount and quote params. `swap` additionally needs the sender address (it is the
+  // quote's fromUserAddress, the nonce-check subject and the PSBT's input owner) and,
+  // unless --unsigned, the key to sign with.
   const routes = await getRoutes();
-  const tokenIndex = buildTokenIndex(routes);
-  const srcFamily = getChainFamily(parseAssetChain(opts.src, routes, tokenIndex).chain);
-
-  const key = resolvePrivateKey(srcFamily === "bitcoin" ? "bitcoin" : "evm", opts.privateKey, config);
-  const derivedAddress = key ? await deriveAddress(srcFamily === "bitcoin" ? "bitcoin" : "evm", key) : undefined;
-  const senderAddress = opts.sender ?? derivedAddress;
-
-  // Reject --sender that doesn't match the signing key — the order would be created for one address but signed by another
-  if (opts.sender && derivedAddress && opts.sender.toLowerCase() !== derivedAddress.toLowerCase()) {
-    throw new Error(
-      `--sender ${opts.sender} does not match the signing key (${derivedAddress}).\n` +
-      `  The order would be created for one address but signed by another.\n` +
-      `  Remove --sender to use the key-derived address, or use --unsigned to skip signing.`,
-    );
-  }
+  const ctx = await resolveSwapContext(opts, routes, config, {
+    signing: !opts.unsigned,
+    senderAddress: true,
+  });
+  const { srcAsset, dstAsset, srcFamily, dstFamily, variant, evmChain, senderAddress, recipient, atomicUnits } = ctx;
 
   // UX-8: BTC onramp --unsigned requires a sender address to construct the PSBT
   if (opts.unsigned && srcFamily === "bitcoin" && !senderAddress) {
     throw new Error("BTC onramp --unsigned requires --sender or BITCOIN_PRIVATE_KEY to construct the PSBT.");
   }
-  const { srcAsset, dstAsset, atomicUnits, display } = await resolveSwapInputs(
-    opts.src, opts.dst, opts.amount, routes,
-    { senderAddress, feeToken: opts.feeToken, feeReserve: opts.feeReserve },
-  );
 
-  // ── Resolve recipient ────────────────────────────────────────────────────
-  const recipient = await resolveRecipient(dstAsset.chain, opts.recipient, config);
   if (!opts.recipient) {
-    const dstFamily = getChainFamily(dstAsset.chain);
     log.progress(`Using recipient: ${recipient} (derived from ${dstFamily === "bitcoin" ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY"})`);
   }
 
-  const slippageBps = opts.slippage ?? config.slippageBps;
   const timeoutMs = opts.timeout ? opts.timeout * 1000 : config.timeoutMs;
 
-  // Resolve signer
-  if (!opts.unsigned && !key) {
-    const isBtc = getChainFamily(srcAsset.chain) === "bitcoin";
-    throw new Error(`no signer configured for ${isBtc ? "Bitcoin" : "EVM"}.\n  Set ${isBtc ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY"} or pass --private-key.\n  Use --unsigned to output the ${isBtc ? "PSBT" : "unsigned transaction"} without signing.`);
-  }
-  const evmChain = getChainFamily(srcAsset.chain) === "bitcoin" ? dstAsset.chain : srcAsset.chain;
-  const signer = opts.unsigned ? null : await resolveSigner(getChainFamily(srcAsset.chain) === "bitcoin" ? "bitcoin" : evmChain, key!);
-
-  const ownerAddress = opts.owner ?? (srcFamily === "bitcoin" ? recipient : (senderAddress ?? recipient));
-
-  const quoteParams: GetQuoteParams = {
-    fromChain: srcAsset.chain,
-    toChain: dstAsset.chain,
-    fromToken: srcAsset.address,
-    toToken: dstAsset.address,
-    toUserAddress: recipient,
-    fromUserAddress: senderAddress,
-    ownerAddress,
-    amount: atomicUnits,
-    maxSlippage: slippageBps,
-  };
+  const signer = opts.unsigned ? null : await resolveSigner(srcFamily === "bitcoin" ? "bitcoin" : evmChain, ctx.key!);
 
   // ── Quote + execute (retryable) ─────────────────────────────────────────────
 
   const TRANSIENT = [/TRM screening/i, /429/, /Too Many Requests/i, /rate limit/i, /not yet propagated/i, /BTC propagation/i, /timeout/i, /ECONNRESET/, /ETIMEDOUT/];
   const isTransient = (e: unknown) => TRANSIENT.some(p => p.test(e instanceof Error ? e.message : String(e)));
-
-  // Determine variant from chain families: bitcoin src = onramp, bitcoin dst = offramp, else tokenSwap
-  const variant = srcFamily === "bitcoin" ? "onramp"
-    : getChainFamily(dstAsset.chain) === "bitcoin" ? "offramp"
-    : "tokenSwap";
 
   // For BTC source, signer holds a BitcoinSigner; for EVM, walletClient + publicClient.
   const btcSigner = !opts.unsigned && variant === "onramp"
@@ -147,7 +95,7 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
   // Use the V3 API directly to fetch the order with its PSBT (BTC) or unsigned tx (EVM).
   if (opts.unsigned) {
     const order: GatewayCreateOrderV3 = await withRetry(async () => {
-      const quote = await sdk.getQuote(quoteParams);
+      const quote = await sdk.getQuote(ctx.quoteParams);
       return await getApi().createOrderV3({ gatewayQuoteV3: quote });
     }, { retries, isTransient });
     const orderData = (order as any)[variant];
@@ -166,7 +114,7 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
   // executeQuote handles createOrder + sign + registerTx in one call.
   // For BTC paths the SDK doesn't access walletClient/publicClient; cast to satisfy types.
   const { order, tx, outputAmount } = await withRetry(async () => {
-    const quote = await sdk.getQuote(quoteParams);
+    const quote = await sdk.getQuote(ctx.quoteParams);
     // For BTC paths walletClient/publicClient are unused inside the SDK; the
     // SDK's type forces them to be present, so we widen via `any` to satisfy it.
     const result = await sdk.executeQuote({
@@ -239,7 +187,7 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
       data: { orderId, status: "confirmed", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAmount: outAmt, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, quotedDstAmount: outputAmount, actualSlippageBps: slipBps, txId, elapsedMs },
     };
   } catch (err) {
-    if (getChainFamily(dstAsset.chain) === "bitcoin" && err instanceof Error && err.message === "pending") {
+    if (dstFamily === "bitcoin" && err instanceof Error && err.message === "pending") {
       log.progress(`Poll timeout reached. Checking mempool for pending delivery...`);
       const pendingTxs = await new MempoolClient().getAddressMempoolTxs(recipient).catch(mempoolErr => {
         log.warn(`could not check mempool: ${mempoolErr instanceof Error ? mempoolErr.message : String(mempoolErr)}`);

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -4,6 +4,8 @@ import { type WalletClient, type PublicClient } from "viem";
 import { withRetry, SwapError, PointOfNoReturnError } from "../errors.js";
 import { getRoutes } from "../util/route-provider.js";
 import { resolveSwapContext, type SwapContext, type SwapContextOptions } from "../util/swap-context.js";
+import { watchOrder } from "../util/order-watcher.js";
+import { sleep } from "../util/sleep.js";
 import { loadConfig, getSdk, getApi } from "../config.js";
 import { resolveSigner } from "../chains/index.js";
 import { CHAIN_IDS } from "../chains/evm.js";
@@ -26,55 +28,9 @@ export type SwapResult =
   | { type: "mempoolPending"; data: SwapMempoolPendingJson }
   | { type: "inFlight"; data: SwapInFlightJson };
 
-/** Timings for the post-submission poll loop. Overridable so tests can drive it fast. */
-export interface PollTimings {
-  /** Wait between two ordinary in-progress polls. */
-  pollIntervalMs: number;
-  /** Ceiling for the exponential backoff applied after consecutive read failures. */
-  maxBackoffMs: number;
-  /** Budget for a SINGLE `getOrder` read, enforced by aborting the request. */
-  getOrderTimeoutMs: number;
-}
-
-const DEFAULT_POLL_TIMINGS: PollTimings = {
-  pollIntervalMs: 15_000,
-  maxBackoffMs: 60_000,
-  getOrderTimeoutMs: 30_000,
-};
-
-/** V2 order status is a discriminated object union: {success} | {refunded} | {failed} | {inProgress}. */
-const hasKey = <K extends string>(s: unknown, k: K): s is Record<K, unknown> =>
-  typeof s === "object" && s !== null && k in s;
-
-/**
- * Sleep that resolves early — never rejects — when `signal` aborts.
- *
- * The poll loop's backoff must not outlive the overall timeout, and the way to
- * express that is to hang the sleep off the same signal that bounds everything
- * else. The alternative, clamping the delay against a computed remaining window,
- * is clock arithmetic — and clock arithmetic is what a hand-maintained deadline turns
- * into a negative delay when two of its reads disagree.
- */
-function sleep(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise<void>(resolve => {
-    if (signal.aborted) return resolve();
-    const done = () => {
-      clearTimeout(timer);
-      signal.removeEventListener("abort", done);
-      resolve();
-    };
-    const timer = setTimeout(done, ms);
-    signal.addEventListener("abort", done, { once: true });
-  });
-}
-
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
-export async function handleSwap(
-  opts: SwapOptions,
-  log: Logger,
-  timings: PollTimings = DEFAULT_POLL_TIMINGS,
-): Promise<SwapResult> {
+export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapResult> {
   const config = loadConfig();
   const sdk = getSdk();
   const retries = opts.retry ? 5 : 0;
@@ -216,137 +172,81 @@ export async function handleSwap(
     };
   }
 
-  // ── Poll ────────────────────────────────────────────────────────────────────
+  // ── Observe the order's state machine ───────────────────────────────────────
   //
-  // The source funds are committed on-chain from here on, so the ONLY authority on
-  // whether the swap failed is the order status itself. Failing to *read* that status
-  // (gateway 5xx, Cloudflare 403, connection reset, DNS blip) says nothing about the
-  // swap and must never be reported as a swap failure — the order settles regardless
-  // of whether we can see it. Read errors are therefore always retried, with backoff,
-  // until the overall timeout aborts; an order that has still not settled by then exits
-  // in the non-failure "in flight" state below, carrying orderId + source txId.
-  //
-  // The timeout is expressed ONCE, as a signal. There is no deadline variable, no
-  // clock arithmetic and nothing to clamp: the loop is driven by abort state, each read
-  // is bounded by its own budget ANDed with the overall one, and the backoff sleep ends
-  // early when the overall signal fires. `startedAt` exists only to report elapsedMs —
-  // it never gates a branch.
-  const overall = AbortSignal.timeout(timeoutMs);
+  // The swap is now an async process the GATEWAY owns; all that is left for this
+  // command is to wait for its terminal state and say what happened. The waiting —
+  // the loop, the backoff, the per-read abort budget, the read failures that must
+  // never be mistaken for swap failures — is the watcher's job, not ours. The whole
+  // budget is expressed ONCE, as a signal handed to it; no deadline, no clock
+  // arithmetic. `startedAt` is measurement only: it is reported, never obeyed.
   const startedAt = Date.now();
+  const outcome = await watchOrder(orderId, AbortSignal.timeout(timeoutMs), {
+    getOrder: (id, init) => sdk.getOrder(id, init),
+    log,
+  });
+  const elapsedMs = Date.now() - startedAt;
 
-  let readFailures = 0;
-  let lastReadError: string | undefined;
-  /** The BTC payout tx the ORDER itself reports having broadcast (offramp only). */
-  let payoutTxId: string | undefined;
+  switch (outcome.kind) {
+    // ── The order settled ────────────────────────────────────────────────────
+    case "settled": {
+      const outAmt = outcome.order.dstInfo?.amount ?? "?";
+      const slipBps = outputAmount && BigInt(outputAmount) !== 0n && outcome.order.dstInfo?.amount
+        ? Number(10000n - BigInt(outcome.order.dstInfo.amount) * 10000n / BigInt(outputAmount))
+        : 0;
 
-  while (!overall.aborted) {
-    let order: Awaited<ReturnType<typeof sdk.getOrder>> | undefined;
-    // Bound this single read by its own budget as well as the overall one. Passing the
-    // signal to the SDK genuinely cancels the request (it spreads initOverrides into
-    // fetch), unlike racing a timer, which would leak a socket per attempt.
-    const perAttempt = AbortSignal.timeout(timings.getOrderTimeoutMs);
-    const readSignal = AbortSignal.any([overall, perAttempt]);
-    try {
-      log.progress(`  Waiting for confirmation... (${Math.round((Date.now() - startedAt) / 1000)}s elapsed)`);
-      order = await sdk.getOrder(orderId, { signal: readSignal });
-      readFailures = 0;
-      lastReadError = undefined;
-    } catch (err) {
-      // The overall timeout firing mid-read is not a read failure — it is the loop
-      // ending. Leave the last genuine read error (if any) intact and fall through.
-      if (overall.aborted && !perAttempt.aborted) break;
-      // Anything else — including this read's own abort — is just a failed read: it
-      // says nothing about the swap, so it feeds the backoff and never becomes terminal.
-      readFailures++;
-      lastReadError = perAttempt.aborted
-        ? `reading order status timed out after ${timings.getOrderTimeoutMs}ms`
-        : err instanceof Error ? err.message : String(err);
-      log.warn(`could not read status of order ${orderId} (attempt ${readFailures}, retrying): ${lastReadError}`);
+      log.progress(`✓ Confirmed — ${outAmt} ${dstAsset.symbol} delivered to ${recipient}`);
+      return {
+        type: "confirmed",
+        data: { orderId, status: "confirmed", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAmount: outAmt, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, quotedDstAmount: outputAmount, actualSlippageBps: slipBps, txId, elapsedMs },
+      };
     }
 
-    if (order) {
-      if (hasKey(order.status, "success")) {
-        const elapsedMs = Date.now() - startedAt;
-        const outAmt = order.dstInfo?.amount ?? "?";
-        const slipBps = outputAmount && BigInt(outputAmount) !== 0n && order.dstInfo?.amount
-          ? Number(10000n - BigInt(order.dstInfo.amount) * 10000n / BigInt(outputAmount))
-          : 0;
+    // ── The order declared failure — the one and only terminal failure signal ──
+    // Carry the on-chain settlement tx hash + route so the --json serializer surfaces
+    // them (downstream alerting fetches the receipt to detect out-of-gas). Message
+    // unchanged so existing categorization still matches. Only offramp/tokenSwap have
+    // an EVM settlement tx; onramp settles on BTC.
+    case "failed":
+      throw new SwapError(`Order ${orderId} failed: ${JSON.stringify(outcome.order.status)}`, {
+        orderId,
+        ...(variant !== "onramp" && {
+          txId,
+          txParams: { to: orderData.tx?.to, from: senderAddress, chainId: CHAIN_IDS[evmChain], chainName: evmChain },
+          srcAsset: { symbol: srcAsset.symbol, chain: srcAsset.chain },
+          dstAsset: { symbol: dstAsset.symbol, chain: dstAsset.chain },
+        }),
+      });
 
-        log.progress(`✓ Confirmed — ${outAmt} ${dstAsset.symbol} delivered to ${recipient}`);
+    // ── No terminal status within the budget → in flight, NOT a failure ───────
+    case "inFlight": {
+      // The order told us it had broadcast a BTC payout: that txid is this order's
+      // payout, reported by the order and never inferred from the destination address.
+      if (outcome.payoutTxId) {
+        log.progress(`~ BTC payout broadcast, not yet confirmed: ${outcome.payoutTxId}`);
         return {
-          type: "confirmed",
-          data: { orderId, status: "confirmed", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAmount: outAmt, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, quotedDstAmount: outputAmount, actualSlippageBps: slipBps, txId, elapsedMs },
+          type: "mempoolPending",
+          data: { orderId, status: "mempool_pending", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, mempoolTxId: outcome.payoutTxId },
         };
       }
 
-      if (hasKey(order.status, "refunded") || hasKey(order.status, "failed")) {
-        // The order itself declares failure — the one and only terminal signal.
-        // Carry the on-chain settlement tx hash + route so the --json serializer
-        // surfaces them (downstream alerting fetches the receipt to detect
-        // out-of-gas). Message unchanged so existing categorization still matches.
-        // Only offramp/tokenSwap have an EVM settlement tx; onramp settles on BTC.
-        throw new SwapError(`Order ${orderId} failed: ${JSON.stringify(order.status)}`, {
-          orderId,
-          ...(variant !== "onramp" && {
-            txId,
-            txParams: { to: orderData.tx?.to, from: senderAddress, chainId: CHAIN_IDS[evmChain], chainName: evmChain },
-            srcAsset: { symbol: srcAsset.symbol, chain: srcAsset.chain },
-            dstAsset: { symbol: dstAsset.symbol, chain: dstAsset.chain },
-          }),
-        });
-      }
-
-      // inProgress → keep polling, but remember the BTC payout if the order has one.
-      // `pendingBtcPayment` is the order's own record of the tx the gateway broadcast:
-      // null until it broadcasts, then carrying the exact txid. It is the only sound way
-      // to name THIS order's payout — the recipient address cannot identify it, since one
-      // address is reused across orders and parallel offramps to it overlap in the mempool.
-      const inProgress = hasKey(order.status, "inProgress")
-        ? order.status.inProgress as { pendingBtcPayment?: { txid?: string } | null } | undefined
-        : undefined;
-      if (inProgress?.pendingBtcPayment?.txid) {
-        payoutTxId = inProgress.pendingBtcPayment.txid;
-      }
+      // Otherwise we have no tx we can honestly attribute to this order — including when
+      // every read failed. An order id that can be followed up beats a confidently wrong txid.
+      log.progress(
+        `~ Still in flight after ${Math.round(elapsedMs / 1000)}s — order ${orderId} has not settled yet.\n` +
+        `  The source funds are committed (tx ${txId}). This is not a failure.\n` +
+        `  Follow it up with: gateway-cli status ${orderId}`,
+      );
+      return {
+        type: "inFlight",
+        data: {
+          orderId, status: "in_flight", srcAmount: atomicUnits, srcAsset: srcAsset.symbol,
+          dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, txId, elapsedMs,
+          ...(outcome.lastError && { lastError: outcome.lastError }),
+        },
+      };
     }
-
-    // Back off on consecutive read failures so we don't hammer a struggling API; an
-    // ordinary in-progress poll just waits the fixed interval. The sleep ends as soon
-    // as the overall signal fires, so it cannot overrun the timeout.
-    const delay = readFailures > 0
-      ? Math.min(timings.pollIntervalMs * 2 ** (readFailures - 1), timings.maxBackoffMs)
-      : timings.pollIntervalMs;
-    await sleep(delay, overall);
   }
-
-  // ── Timed out without a terminal status → in flight, NOT a failure ──────────
-
-  const elapsedMs = Date.now() - startedAt;
-
-  // If the order reported a BTC payout while we were polling, that txid is this order's
-  // payout — reported by the order, not inferred from the destination address.
-  if (payoutTxId) {
-    log.progress(`~ BTC payout broadcast, not yet confirmed: ${payoutTxId}`);
-    return {
-      type: "mempoolPending",
-      data: { orderId, status: "mempool_pending", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, mempoolTxId: payoutTxId },
-    };
-  }
-
-  // Otherwise we have no tx we can honestly attribute to this order — including when
-  // every read failed. An order id that can be followed up beats a confidently wrong txid.
-  log.progress(
-    `~ Still in flight after ${Math.round(elapsedMs / 1000)}s — order ${orderId} has not settled yet.\n` +
-    `  The source funds are committed (tx ${txId}). This is not a failure.\n` +
-    `  Follow it up with: gateway-cli status ${orderId}`,
-  );
-  return {
-    type: "inFlight",
-    data: {
-      orderId, status: "in_flight", srcAmount: atomicUnits, srcAsset: srcAsset.symbol,
-      dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, txId, elapsedMs,
-      ...(lastReadError && { lastError: lastReadError }),
-    },
-  };
 }
 
 // ─── Point-of-no-return reporting ────────────────────────────────────────────

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -1,4 +1,3 @@
-import { MempoolClient } from "@gobob/bob-sdk";
 import type { BitcoinSigner, GatewayCreateOrderV3 } from "@gobob/bob-sdk";
 import { getInnerQuoteV3 } from "../util/quote.js";
 import { type WalletClient, type PublicClient } from "viem";
@@ -8,7 +7,7 @@ import { resolveSwapContext, type SwapContextOptions } from "../util/swap-contex
 import { loadConfig, getSdk, getApi } from "../config.js";
 import { resolveSigner } from "../chains/index.js";
 import { CHAIN_IDS } from "../chains/evm.js";
-import type { Logger, SwapSuccessJson, SwapSubmittedJson, SwapMempoolPendingJson } from "../output.js";
+import type { Logger, SwapSuccessJson, SwapSubmittedJson, SwapMempoolPendingJson, SwapInFlightJson } from "../output.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -24,11 +23,58 @@ export type SwapResult =
   | { type: "unsigned"; orderId: string; psbtBase64?: string; txInfo?: any }
   | { type: "submitted"; data: SwapSubmittedJson }
   | { type: "confirmed"; data: SwapSuccessJson }
-  | { type: "mempoolPending"; data: SwapMempoolPendingJson };
+  | { type: "mempoolPending"; data: SwapMempoolPendingJson }
+  | { type: "inFlight"; data: SwapInFlightJson };
+
+/** Timings for the post-submission poll loop. Overridable so tests can drive it fast. */
+export interface PollTimings {
+  /** Wait between two ordinary in-progress polls. */
+  pollIntervalMs: number;
+  /** Ceiling for the exponential backoff applied after consecutive read failures. */
+  maxBackoffMs: number;
+  /** Budget for a SINGLE `getOrder` read, enforced by aborting the request. */
+  getOrderTimeoutMs: number;
+}
+
+const DEFAULT_POLL_TIMINGS: PollTimings = {
+  pollIntervalMs: 15_000,
+  maxBackoffMs: 60_000,
+  getOrderTimeoutMs: 30_000,
+};
+
+/** V2 order status is a discriminated object union: {success} | {refunded} | {failed} | {inProgress}. */
+const hasKey = <K extends string>(s: unknown, k: K): s is Record<K, unknown> =>
+  typeof s === "object" && s !== null && k in s;
+
+/**
+ * Sleep that resolves early — never rejects — when `signal` aborts.
+ *
+ * The poll loop's backoff must not outlive the overall timeout, and the way to
+ * express that is to hang the sleep off the same signal that bounds everything
+ * else. The alternative, clamping the delay against a computed remaining window,
+ * is clock arithmetic — and clock arithmetic is what a hand-maintained deadline turns
+ * into a negative delay when two of its reads disagree.
+ */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>(resolve => {
+    if (signal.aborted) return resolve();
+    const done = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    signal.addEventListener("abort", done, { once: true });
+  });
+}
 
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
-export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapResult> {
+export async function handleSwap(
+  opts: SwapOptions,
+  log: Logger,
+  timings: PollTimings = DEFAULT_POLL_TIMINGS,
+): Promise<SwapResult> {
   const config = loadConfig();
   const sdk = getSdk();
   const retries = opts.retry ? 5 : 0;
@@ -75,16 +121,16 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
   if (evmClients && senderAddress) {
     const addr = senderAddress as `0x${string}`;
     const { publicClient } = evmClients;
-    const deadline = Date.now() + 120_000;
+    const settleSignal = AbortSignal.timeout(120_000);
     let settled = false;
-    while (Date.now() < deadline) {
+    while (!settleSignal.aborted) {
       const [latest, pending] = await Promise.all([
         publicClient.getTransactionCount({ address: addr, blockTag: "latest" }),
         publicClient.getTransactionCount({ address: addr, blockTag: "pending" }),
       ]);
       if (pending <= latest) { settled = true; break; }
       log.progress(`  Waiting for pending tx to settle (pending nonce: ${pending}, latest: ${latest})...`);
-      await new Promise(r => setTimeout(r, 5000));
+      await sleep(5000, settleSignal);
     }
     if (!settled) {
       throw new Error(`Timed out waiting for pending transactions to settle for ${addr}. There may be stuck transactions — check your wallet before retrying.`);
@@ -146,23 +192,75 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
   }
 
   // ── Poll ────────────────────────────────────────────────────────────────────
+  //
+  // The source funds are committed on-chain from here on, so the ONLY authority on
+  // whether the swap failed is the order status itself. Failing to *read* that status
+  // (gateway 5xx, Cloudflare 403, connection reset, DNS blip) says nothing about the
+  // swap and must never be reported as a swap failure — the order settles regardless
+  // of whether we can see it. Read errors are therefore always retried, with backoff,
+  // until the overall timeout aborts; an order that has still not settled by then exits
+  // in the non-failure "in flight" state below, carrying orderId + source txId.
+  //
+  // The timeout is expressed ONCE, as a signal. There is no deadline variable, no
+  // clock arithmetic and nothing to clamp: the loop is driven by abort state, each read
+  // is bounded by its own budget ANDed with the overall one, and the backoff sleep ends
+  // early when the overall signal fires. `startedAt` exists only to report elapsedMs —
+  // it never gates a branch.
+  const overall = AbortSignal.timeout(timeoutMs);
+  const startedAt = Date.now();
 
-  const startMs = Date.now();
-  // V2 status is a discriminated object union: {success} | {refunded} | {failed} | {inProgress}.
-  const hasKey = <K extends string>(s: unknown, k: K): s is Record<K, unknown> =>
-    typeof s === "object" && s !== null && k in s;
+  let readFailures = 0;
+  let lastReadError: string | undefined;
+  /** The BTC payout tx the ORDER itself reports having broadcast (offramp only). */
+  let payoutTxId: string | undefined;
 
-  try {
-    const finalOrder = await withRetry(async () => {
-      log.progress(`  Waiting for confirmation... (${Math.round((Date.now() - startMs) / 1000)}s elapsed)`);
-      const o = await sdk.getOrder(orderId);
-      if (hasKey(o.status, "success")) return o;
-      if (hasKey(o.status, "refunded") || hasKey(o.status, "failed")) {
+  while (!overall.aborted) {
+    let order: Awaited<ReturnType<typeof sdk.getOrder>> | undefined;
+    // Bound this single read by its own budget as well as the overall one. Passing the
+    // signal to the SDK genuinely cancels the request (it spreads initOverrides into
+    // fetch), unlike racing a timer, which would leak a socket per attempt.
+    const perAttempt = AbortSignal.timeout(timings.getOrderTimeoutMs);
+    const readSignal = AbortSignal.any([overall, perAttempt]);
+    try {
+      log.progress(`  Waiting for confirmation... (${Math.round((Date.now() - startedAt) / 1000)}s elapsed)`);
+      order = await sdk.getOrder(orderId, { signal: readSignal });
+      readFailures = 0;
+      lastReadError = undefined;
+    } catch (err) {
+      // The overall timeout firing mid-read is not a read failure — it is the loop
+      // ending. Leave the last genuine read error (if any) intact and fall through.
+      if (overall.aborted && !perAttempt.aborted) break;
+      // Anything else — including this read's own abort — is just a failed read: it
+      // says nothing about the swap, so it feeds the backoff and never becomes terminal.
+      readFailures++;
+      lastReadError = perAttempt.aborted
+        ? `reading order status timed out after ${timings.getOrderTimeoutMs}ms`
+        : err instanceof Error ? err.message : String(err);
+      log.warn(`could not read status of order ${orderId} (attempt ${readFailures}, retrying): ${lastReadError}`);
+    }
+
+    if (order) {
+      if (hasKey(order.status, "success")) {
+        const elapsedMs = Date.now() - startedAt;
+        const outAmt = order.dstInfo?.amount ?? "?";
+        const slipBps = outputAmount && BigInt(outputAmount) !== 0n && order.dstInfo?.amount
+          ? Number(10000n - BigInt(order.dstInfo.amount) * 10000n / BigInt(outputAmount))
+          : 0;
+
+        log.progress(`✓ Confirmed — ${outAmt} ${dstAsset.symbol} delivered to ${recipient}`);
+        return {
+          type: "confirmed",
+          data: { orderId, status: "confirmed", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAmount: outAmt, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, quotedDstAmount: outputAmount, actualSlippageBps: slipBps, txId, elapsedMs },
+        };
+      }
+
+      if (hasKey(order.status, "refunded") || hasKey(order.status, "failed")) {
+        // The order itself declares failure — the one and only terminal signal.
         // Carry the on-chain settlement tx hash + route so the --json serializer
         // surfaces them (downstream alerting fetches the receipt to detect
         // out-of-gas). Message unchanged so existing categorization still matches.
         // Only offramp/tokenSwap have an EVM settlement tx; onramp settles on BTC.
-        throw new SwapError(`Order ${orderId} failed: ${JSON.stringify(o.status)}`, {
+        throw new SwapError(`Order ${orderId} failed: ${JSON.stringify(order.status)}`, {
           orderId,
           ...(variant !== "onramp" && {
             txId,
@@ -172,36 +270,56 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
           }),
         });
       }
-      throw new Error("pending");
-    }, { retries: Math.ceil(timeoutMs / 15_000), isTransient: (e) => e instanceof Error && e.message === "pending", minTimeout: 15_000, maxTimeout: 15_000 });
 
-    const elapsedMs = Date.now() - startMs;
-    const outAmt = finalOrder.dstInfo?.amount ?? "?";
-    const slipBps = outputAmount && BigInt(outputAmount) !== 0n && finalOrder.dstInfo?.amount
-      ? Number(10000n - BigInt(finalOrder.dstInfo.amount) * 10000n / BigInt(outputAmount))
-      : 0;
-
-    log.progress(`✓ Confirmed — ${outAmt} ${dstAsset.symbol} delivered to ${recipient}`);
-    return {
-      type: "confirmed",
-      data: { orderId, status: "confirmed", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAmount: outAmt, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, quotedDstAmount: outputAmount, actualSlippageBps: slipBps, txId, elapsedMs },
-    };
-  } catch (err) {
-    if (dstFamily === "bitcoin" && err instanceof Error && err.message === "pending") {
-      log.progress(`Poll timeout reached. Checking mempool for pending delivery...`);
-      const pendingTxs = await new MempoolClient().getAddressMempoolTxs(recipient).catch(mempoolErr => {
-        log.warn(`could not check mempool: ${mempoolErr instanceof Error ? mempoolErr.message : String(mempoolErr)}`);
-        return [];
-      });
-      const mempoolTxId = pendingTxs.find(tx => !tx.status.confirmed)?.txid;
-      if (mempoolTxId) {
-        log.progress(`~ BTC tx found in mempool (unconfirmed): ${mempoolTxId}`);
-        return {
-          type: "mempoolPending",
-          data: { orderId, status: "mempool_pending", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, mempoolTxId },
-        };
+      // inProgress → keep polling, but remember the BTC payout if the order has one.
+      // `pendingBtcPayment` is the order's own record of the tx the gateway broadcast:
+      // null until it broadcasts, then carrying the exact txid. It is the only sound way
+      // to name THIS order's payout — the recipient address cannot identify it, since one
+      // address is reused across orders and parallel offramps to it overlap in the mempool.
+      const inProgress = hasKey(order.status, "inProgress")
+        ? order.status.inProgress as { pendingBtcPayment?: { txid?: string } | null } | undefined
+        : undefined;
+      if (inProgress?.pendingBtcPayment?.txid) {
+        payoutTxId = inProgress.pendingBtcPayment.txid;
       }
     }
-    throw err;
+
+    // Back off on consecutive read failures so we don't hammer a struggling API; an
+    // ordinary in-progress poll just waits the fixed interval. The sleep ends as soon
+    // as the overall signal fires, so it cannot overrun the timeout.
+    const delay = readFailures > 0
+      ? Math.min(timings.pollIntervalMs * 2 ** (readFailures - 1), timings.maxBackoffMs)
+      : timings.pollIntervalMs;
+    await sleep(delay, overall);
   }
+
+  // ── Timed out without a terminal status → in flight, NOT a failure ──────────
+
+  const elapsedMs = Date.now() - startedAt;
+
+  // If the order reported a BTC payout while we were polling, that txid is this order's
+  // payout — reported by the order, not inferred from the destination address.
+  if (payoutTxId) {
+    log.progress(`~ BTC payout broadcast, not yet confirmed: ${payoutTxId}`);
+    return {
+      type: "mempoolPending",
+      data: { orderId, status: "mempool_pending", srcAmount: atomicUnits, srcAsset: srcAsset.symbol, dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, mempoolTxId: payoutTxId },
+    };
+  }
+
+  // Otherwise we have no tx we can honestly attribute to this order — including when
+  // every read failed. An order id that can be followed up beats a confidently wrong txid.
+  log.progress(
+    `~ Still in flight after ${Math.round(elapsedMs / 1000)}s — order ${orderId} has not settled yet.\n` +
+    `  The source funds are committed (tx ${txId}). This is not a failure.\n` +
+    `  Follow it up with: gateway-cli status ${orderId}`,
+  );
+  return {
+    type: "inFlight",
+    data: {
+      orderId, status: "in_flight", srcAmount: atomicUnits, srcAsset: srcAsset.symbol,
+      dstAsset: dstAsset.symbol, dstChain: dstAsset.chain, txId, elapsedMs,
+      ...(lastReadError && { lastError: lastReadError }),
+    },
+  };
 }

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -1,9 +1,9 @@
-import type { BitcoinSigner, GatewayCreateOrderV3 } from "@gobob/bob-sdk";
+import type { BitcoinSigner, ExecuteQuoteStep, GatewayCreateOrderV3 } from "@gobob/bob-sdk";
 import { getInnerQuoteV3 } from "../util/quote.js";
 import { type WalletClient, type PublicClient } from "viem";
-import { withRetry, SwapError } from "../errors.js";
+import { withRetry, SwapError, PointOfNoReturnError } from "../errors.js";
 import { getRoutes } from "../util/route-provider.js";
-import { resolveSwapContext, type SwapContextOptions } from "../util/swap-context.js";
+import { resolveSwapContext, type SwapContext, type SwapContextOptions } from "../util/swap-context.js";
 import { loadConfig, getSdk, getApi } from "../config.js";
 import { resolveSigner } from "../chains/index.js";
 import { CHAIN_IDS } from "../chains/evm.js";
@@ -89,7 +89,7 @@ export async function handleSwap(
     signing: !opts.unsigned,
     senderAddress: true,
   });
-  const { srcAsset, dstAsset, srcFamily, dstFamily, variant, evmChain, senderAddress, recipient, atomicUnits } = ctx;
+  const { srcAsset, dstAsset, srcFamily, dstFamily, variant, evmChain, senderAddress, recipient, ownerAddress, atomicUnits } = ctx;
 
   // UX-8: BTC onramp --unsigned requires a sender address to construct the PSBT
   if (opts.unsigned && srcFamily === "bitcoin" && !senderAddress) {
@@ -104,7 +104,7 @@ export async function handleSwap(
 
   const signer = opts.unsigned ? null : await resolveSigner(srcFamily === "bitcoin" ? "bitcoin" : evmChain, ctx.key!);
 
-  // ── Quote + execute (retryable) ─────────────────────────────────────────────
+  // ── Quote + execute (retryable up to the point of no return) ────────────────
 
   const TRANSIENT = [/TRM screening/i, /429/, /Too Many Requests/i, /rate limit/i, /not yet propagated/i, /BTC propagation/i, /timeout/i, /ECONNRESET/, /ETIMEDOUT/];
   const isTransient = (e: unknown) => TRANSIENT.some(p => p.test(e instanceof Error ? e.message : String(e)));
@@ -139,6 +139,7 @@ export async function handleSwap(
 
   // --unsigned has no public SDK path: executeQuote always signs.
   // Use the V3 API directly to fetch the order with its PSBT (BTC) or unsigned tx (EVM).
+  // Nothing here touches a wallet, so it is freely retryable.
   if (opts.unsigned) {
     const order: GatewayCreateOrderV3 = await withRetry(async () => {
       const quote = await sdk.getQuote(ctx.quoteParams);
@@ -156,21 +157,45 @@ export async function handleSwap(
     return { type: "unsigned", orderId: orderData.orderId, txInfo: orderData.tx };
   }
 
-  // Signed flows go through executeQuote.
-  // executeQuote handles createOrder + sign + registerTx in one call.
-  // For BTC paths the SDK doesn't access walletClient/publicClient; cast to satisfy types.
-  const { order, tx, outputAmount } = await withRetry(async () => {
-    const quote = await sdk.getQuote(ctx.quoteParams);
-    // For BTC paths walletClient/publicClient are unused inside the SDK; the
-    // SDK's type forces them to be present, so we widen via `any` to satisfy it.
-    const result = await sdk.executeQuote({
-      quote,
-      walletClient: evmClients?.walletClient as any,
-      publicClient: evmClients?.publicClient as any,
-      btcSigner,
-    });
-    return { ...result, outputAmount: getInnerQuoteV3(quote).outputAmount.amount };
-  }, { retries, isTransient });
+  // ── Point of no return ─────────────────────────────────────────────────────
+  // `executeQuote` is NOT idempotent. Internally it runs:
+  //   createOrder → (ERC20 reset/approve) → SIGN + BROADCAST the source tx → registerTx
+  // Only that prefix is safe to re-run. If it throws *after* the wallet has been asked
+  // to sign — a `registerTx` 5xx, a solver's "504 Gateway Timeout", a dropped socket,
+  // i.e. exactly the errors `isTransient` matches — then retrying the closure fetches a
+  // fresh quote, creates a SECOND order and broadcasts a SECOND transaction. The user's
+  // funds leave the wallet twice.
+  //
+  // The SDK fires an ExecuteQuoteStep immediately BEFORE every wallet interaction
+  // (ResetApproval / Approve / SendTransaction / SignBitcoinTransaction), so the first
+  // step of ANY kind is the last instant at which re-running is still safe. We latch on
+  // all of them rather than only the two that move the funds: an approve is itself a
+  // signed, broadcast tx, and re-entering the closure while it is still pending races
+  // its own nonce. Over-latching costs at most one lost retry; under-latching costs the
+  // funds.
+  let executed;
+  try {
+    executed = await withRetry(async (guard) => {
+      const quote = await sdk.getQuote(ctx.quoteParams);
+      // For BTC paths walletClient/publicClient are unused inside the SDK; the
+      // SDK's type forces them to be present, so we widen via `any` to satisfy it.
+      const result = await sdk.executeQuote({
+        quote,
+        walletClient: evmClients?.walletClient as any,
+        publicClient: evmClients?.publicClient as any,
+        btcSigner,
+        callback: (step: ExecuteQuoteStep) => guard.pointOfNoReturn(step.type),
+      });
+      return { ...result, outputAmount: getInnerQuoteV3(quote).outputAmount.amount };
+    }, { retries, isTransient });
+  } catch (err) {
+    // Failed past the point of no return: a tx may be on-chain, but we never got the
+    // order id back, so there is nothing to poll and nothing to reconcile automatically.
+    // Fail loudly and tell the operator not to do the one thing that would double-send.
+    if (err instanceof PointOfNoReturnError) throw pointOfNoReturnError(err, ctx);
+    throw err;
+  }
+  const { order, tx, outputAmount } = executed;
 
   const orderData = (order as any)[variant];
   if (!orderData?.orderId) {
@@ -322,4 +347,38 @@ export async function handleSwap(
       ...(lastReadError && { lastError: lastReadError }),
     },
   };
+}
+
+// ─── Point-of-no-return reporting ────────────────────────────────────────────
+
+/**
+ * Turn a {@link PointOfNoReturnError} into the loud, terminal {@link SwapError} an
+ * operator sees. It must not assert that funds *were* sent — the latch arms when the
+ * wallet is asked to sign, which is before viem prepares the transaction, so a
+ * transient RPC failure during gas estimation or nonce fetch also lands here and may
+ * mean nothing was broadcast at all. That over-warning is deliberate and stated: it
+ * costs one manual check, whereas under-warning costs the funds. (SDK follow-up to
+ * narrow the window: bob-collective/bob#1122.)
+ *
+ * The reconciliation step it points at uses `ownerAddress` — the EVM address orders are
+ * indexed by. Naming the sender would print a `bc1q…` address on an onramp, and
+ * `gateway-cli orders` rejects BTC addresses outright, leaving the operator with no way
+ * to check — at exactly the moment they are tempted to re-run and double-send.
+ */
+function pointOfNoReturnError(err: PointOfNoReturnError, ctx: SwapContext): SwapError {
+  return new SwapError(
+    `Swap aborted after the wallet was asked to sign (step: ${err.reason}). ` +
+    `A transaction may already have been broadcast — do NOT re-run this swap or you may send twice. ` +
+    `(The signature was requested but we never learned whether it reached the chain; a failure during ` +
+    `transaction preparation may mean nothing was sent.) ` +
+    `Confirm with \`gateway-cli orders ${ctx.ownerAddress}\` before re-running. ` +
+    `Underlying error: ${err.originalError.message}`,
+    {
+      srcAsset: { symbol: ctx.srcAsset.symbol, chain: ctx.srcAsset.chain },
+      dstAsset: { symbol: ctx.dstAsset.symbol, chain: ctx.dstAsset.chain },
+      ...(ctx.variant !== "onramp" && {
+        txParams: { from: ctx.senderAddress, chainId: CHAIN_IDS[ctx.evmChain], chainName: ctx.evmChain },
+      }),
+    },
+  );
 }

--- a/gateway-cli/src/errors.ts
+++ b/gateway-cli/src/errors.ts
@@ -27,24 +27,77 @@ export class SwapError extends Error {
 }
 
 /**
+ * Handle given to a retryable operation so it can declare that it has crossed a
+ * *point of no return* — an irreversible side effect (a wallet signature, a
+ * broadcast) that makes re-running the whole operation unsafe, no matter what
+ * error follows.
+ */
+export interface RetryGuard {
+  /**
+   * Latch. From this call onward the current operation will NOT be retried,
+   * however transient the subsequent error looks.
+   *
+   * Safe to call repeatedly as the operation progresses: the latch is monotonic
+   * (once armed it never disarms) and the LAST reason wins, so the error reports
+   * the *furthest* irreversible step reached — not the first. Reporting the first
+   * would understate how far the operation got (e.g. naming an ERC20 `approve`
+   * when the funds tx had in fact already been broadcast), which is precisely the
+   * misreading that leads someone to re-run and double-send.
+   */
+  pointOfNoReturn(reason: string): void;
+}
+
+/**
+ * Thrown by {@link withRetry} when an operation failed *after* it declared a
+ * {@link RetryGuard.pointOfNoReturn}. Its existence tells the caller "this failed
+ * with side effects possibly already committed" — a different, louder outcome than
+ * a clean failure, which must never be papered over as plain retry exhaustion.
+ */
+export class PointOfNoReturnError extends Error {
+  constructor(
+    /** The failure that actually occurred, after the irreversible step. */
+    readonly originalError: Error,
+    /** The furthest irreversible step reached when it failed. */
+    readonly reason: string,
+  ) {
+    super(originalError.message);
+    this.name = "PointOfNoReturnError";
+  }
+}
+
+/**
  * Retry `fn` while it throws a transient error; stop immediately on anything else.
+ *
+ * `fn` receives a {@link RetryGuard}. Once `fn` trips the guard, the attempt is
+ * never retried — the guard **dominates `isTransient`**, because no amount of
+ * "this error looks transient" can make it safe to re-run an operation that has
+ * already asked a wallet to sign. The latch is created, and consulted, *inside*
+ * this function: a caller can arm it but cannot forget to wire it into the retry
+ * decision, which makes "retried past an irreversible step" an unrepresentable
+ * state rather than merely an unlikely one.
  *
  * p-retry's `AbortError` is an internal detail here, never exposed to callers: it
  * always wraps the ORIGINAL Error, so a {@link SwapError}'s `context` survives
  * p-retry's `throw originalError`. Callers throw domain errors (e.g. `SwapError`
- * for terminal, a transient sentinel to keep retrying) and never touch AbortError.
+ * for terminal) and never touch AbortError.
  */
 export async function withRetry<T>(
-  fn: () => Promise<T>,
+  fn: (guard: RetryGuard) => Promise<T>,
   opts: { retries: number; isTransient: (e: unknown) => boolean; minTimeout?: number; maxTimeout?: number },
 ): Promise<T> {
   return pRetry(
     async () => {
+      let crossed: string | undefined;
+      const guard: RetryGuard = { pointOfNoReturn: (reason) => { crossed = reason; } };
       try {
-        return await fn();
+        return await fn(guard);
       } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        // Checked BEFORE isTransient, deliberately: past the point of no return the
+        // only safe move is to stop and tell the operator what was already done.
+        if (crossed !== undefined) throw new AbortError(new PointOfNoReturnError(err, crossed));
         if (opts.isTransient(e)) throw e; // retryable → let p-retry retry
-        throw new AbortError(e instanceof Error ? e : new Error(String(e))); // terminal → stop, preserve the Error (+ context)
+        throw new AbortError(err); // terminal → stop, preserve the Error (+ context)
       }
     },
     { retries: opts.retries, minTimeout: opts.minTimeout, maxTimeout: opts.maxTimeout, factor: 1 },

--- a/gateway-cli/src/output.ts
+++ b/gateway-cli/src/output.ts
@@ -64,6 +64,28 @@ export interface SwapSubmittedJson {
   txId: string;
 }
 
+/**
+ * Swap submitted, source funds committed, but the order had not reached a terminal
+ * status before `--timeout` expired — either because it is still settling, or because
+ * its status could not be read (gateway 5xx/403, network failure).
+ *
+ * This is NOT a failure: the order is in flight. `orderId` + `txId` are carried so an
+ * operator (or gateway-bot) can follow it up with `gateway-cli status <orderId>`.
+ * Additive: it does not change any existing shape.
+ */
+export interface SwapInFlightJson {
+  orderId: string;
+  status: "in_flight";
+  srcAmount: string;
+  srcAsset: string;
+  dstAsset: string;
+  dstChain: string;
+  txId: string;
+  elapsedMs: number;
+  /** Last error seen while reading the order status, when the poll ended on a read failure. */
+  lastError?: string;
+}
+
 /** Swap pending in mempool (unconfirmed Bitcoin transaction). */
 export interface SwapMempoolPendingJson {
   orderId: string;

--- a/gateway-cli/src/schemas.ts
+++ b/gateway-cli/src/schemas.ts
@@ -44,7 +44,11 @@ export const swapSchema = quoteSchema.and(z.object({
   privateKey: z.string().optional(),
   wait: z.boolean().default(true),
   unsigned: z.boolean().default(false),
-  timeout: positiveInt.pipe(z.number().min(1, "timeout must be >= 1")).optional(),
+  // Capped at 24h. The poll timeout becomes an `AbortSignal.timeout(timeoutMs)` created
+  // AFTER the source tx is broadcast, and `AbortSignal.timeout` throws `RangeError`
+  // synchronously above 2^32-1 ms — which would report an already-committed swap as a
+  // hard failure. Reject the impossible value at the boundary instead.
+  timeout: positiveInt.pipe(z.number().min(1, "timeout must be >= 1").max(86_400, "timeout must be <= 86400 (24h)")).optional(),
   retry: z.boolean().default(true),
 }));
 

--- a/gateway-cli/src/util/input-resolver.ts
+++ b/gateway-cli/src/util/input-resolver.ts
@@ -245,37 +245,32 @@ export async function parseAmount(
   throw new Error(`Invalid amount "${raw}". ${AMOUNT_HELP}`);
 }
 
-// ─── Combined asset + amount resolution ──────────────────────────────────────
+// ─── Amount resolution against an already-resolved asset ─────────────────────
 
-/**
- * Combined result of resolving swap inputs: source/destination assets and atomic amount.
- */
-export interface ResolvedInputs {
-  srcAsset: ResolvedAsset;
-  dstAsset: ResolvedAsset;
+/** A source amount resolved to atomic units, with a human-readable rendering. */
+export interface ResolvedAmount {
   atomicUnits: string;
   display: string;
 }
 
 /**
- * Resolve all swap inputs (source, destination, amount) into structured data.
- * Handles asset parsing, amount conversion, and "ALL" balance lookup.
- * @param src - Source asset string (e.g., "BTC", "USDC:base")
- * @param dst - Destination asset string
+ * Resolve the source amount for an ALREADY-RESOLVED source asset, including the
+ * `ALL` balance lookup.
+ *
+ * It takes a {@link ResolvedAsset} rather than the raw `--src` string on purpose:
+ * the caller has already resolved the source (that is what tells it whether a key
+ * is even needed), and re-parsing it here would be a second, divergable definition
+ * of the same thing.
+ *
+ * @param srcAsset - The resolved source asset
  * @param amount - Amount string (e.g., "0.05BTC", "100USD", "ALL")
- * @param routes - Available routes for token lookup
- * @param opts - Optional sender address and fee token/reserve for balance calculations
+ * @param opts - Sender address (required by `ALL`) and fee token/reserve for gas reservation
  */
-export async function resolveSwapInputs(
-  src: string,
-  dst: string,
+export async function resolveAmount(
+  srcAsset: ResolvedAsset,
   amount: string,
-  routes: RouteInfo[],
   opts?: { senderAddress?: string; feeToken?: string; feeReserve?: string },
-): Promise<ResolvedInputs> {
-  const tokenIndex = buildTokenIndex(routes);
-  const srcAsset = parseAssetChain(src, routes, tokenIndex);
-  const dstAsset = parseAssetChain(dst, routes, tokenIndex);
+): Promise<ResolvedAmount> {
   const parsed = await parseAmount(amount, srcAsset.symbol, srcAsset.decimals, srcAsset.coingeckoId);
 
   if (parsed.type === "all") {
@@ -299,9 +294,11 @@ export async function resolveSwapInputs(
     if (BigInt(allSpendable) === 0n) {
       throw new Error(`No ${srcAsset.symbol} balance found for ${opts.senderAddress}`);
     }
-    const display = `${formatUnits(BigInt(allSpendable), srcAsset.decimals)} ${srcAsset.symbol} (all spendable)`;
-    return { srcAsset, dstAsset, atomicUnits: allSpendable, display };
+    return {
+      atomicUnits: allSpendable,
+      display: `${formatUnits(BigInt(allSpendable), srcAsset.decimals)} ${srcAsset.symbol} (all spendable)`,
+    };
   }
 
-  return { srcAsset, dstAsset, atomicUnits: parsed.atomicUnits, display: parsed.display };
+  return { atomicUnits: parsed.atomicUnits, display: parsed.display };
 }

--- a/gateway-cli/src/util/order-watcher.ts
+++ b/gateway-cli/src/util/order-watcher.ts
@@ -1,0 +1,165 @@
+import type { GatewayOrderInfoV2 } from "@gobob/bob-sdk";
+import type { Logger } from "../output.js";
+import { sleep } from "./sleep.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * What the gateway's order state machine told us.
+ *
+ * A swap is an async process whose state the GATEWAY owns: `inProgress → success |
+ * failed | refunded`. These are the only three answers there are — the order settled,
+ * the order declared failure, or we ran out of budget before it reached either.
+ * "In flight" is not an error: the source funds are committed and the order keeps
+ * settling whether or not anyone is watching.
+ */
+export type OrderOutcome =
+  /** The order reached `success`. */
+  | { kind: "settled"; order: GatewayOrderInfoV2 }
+  /** The order itself declared `failed` or `refunded` — the one terminal failure signal. */
+  | { kind: "failed"; order: GatewayOrderInfoV2 }
+  /**
+   * The budget ran out with no terminal status: the order is still settling, or its
+   * status could not be read at all. Facts only — `payoutTxId` is set iff the order
+   * told us it had broadcast a BTC payout; `lastError` iff the last read failed.
+   * What to *call* this (mempool-pending vs in-flight) is the caller's decision.
+   */
+  | { kind: "inFlight"; payoutTxId?: string; lastError?: string };
+
+/** Timings for the poll loop. A genuine parameter of the watcher — internal to it. */
+export interface PollTimings {
+  /** Wait between two ordinary in-progress polls. */
+  pollIntervalMs: number;
+  /** Ceiling for the exponential backoff applied after consecutive read failures. */
+  maxBackoffMs: number;
+  /** Budget for a SINGLE `getOrder` read, enforced by aborting the request. */
+  getOrderTimeoutMs: number;
+}
+
+export const DEFAULT_POLL_TIMINGS: PollTimings = {
+  pollIntervalMs: 15_000,
+  maxBackoffMs: 60_000,
+  getOrderTimeoutMs: 30_000,
+};
+
+/**
+ * What the watcher needs from the outside world: a way to read the order, and a way to
+ * say what it is doing. Nothing else — in particular it has no access to a mempool
+ * client, so it *cannot* guess a payout tx from an address even if it wanted to.
+ */
+export interface OrderWatcherDeps {
+  getOrder: (id: string, init?: RequestInit) => Promise<GatewayOrderInfoV2>;
+  log: Logger;
+}
+
+/** V2 order status is a discriminated object union: {success} | {refunded} | {failed} | {inProgress}. */
+const hasKey = <K extends string>(s: unknown, k: K): s is Record<K, unknown> =>
+  typeof s === "object" && s !== null && k in s;
+
+// ─── Watcher ─────────────────────────────────────────────────────────────────
+
+/**
+ * Await the order's terminal state, or report that we could not.
+ *
+ * Polling is not a feature — it is the machinery for observing a state machine the
+ * gateway owns, which is why it lives here rather than smeared through the command
+ * that started the swap. The contract is exactly one thing: return what the state
+ * machine said ({@link OrderOutcome}). It never throws for a swap-level reason; the
+ * caller decides how to present each outcome.
+ *
+ * By the time this is called the source funds are committed on-chain, so the ONLY
+ * authority on whether the swap failed is the order status itself. Failing to *read*
+ * that status (gateway 5xx, Cloudflare 403, connection reset, DNS blip) says nothing
+ * about the swap and must never become a failure — the order settles regardless of
+ * whether we can see it. Read errors are therefore always retried, with backoff, until
+ * `signal` aborts; an order that has still not settled by then is `inFlight`.
+ *
+ * The budget is expressed ONCE, as `signal`. There is no deadline variable, no clock
+ * arithmetic and nothing to clamp: the loop is driven by abort state, each read is
+ * bounded by its own budget ANDed with the caller's, and the backoff sleep ends early
+ * when the caller's signal fires. `startedAt` exists only to report elapsed seconds in
+ * the progress line — it never gates a branch.
+ *
+ * @param orderId  The order to observe.
+ * @param signal   The caller's budget — the ONLY deadline.
+ * @param deps     How to read the order, and where to report progress.
+ * @param timings  Poll interval, backoff ceiling and per-read budget.
+ */
+export async function watchOrder(
+  orderId: string,
+  signal: AbortSignal,
+  deps: OrderWatcherDeps,
+  timings: PollTimings = DEFAULT_POLL_TIMINGS,
+): Promise<OrderOutcome> {
+  const { getOrder, log } = deps;
+  const startedAt = Date.now();
+
+  let readFailures = 0;
+  let lastError: string | undefined;
+  /** The BTC payout tx the ORDER itself reports having broadcast (offramp only). */
+  let payoutTxId: string | undefined;
+
+  while (!signal.aborted) {
+    let order: GatewayOrderInfoV2 | undefined;
+    // Bound this single read by its own budget as well as the caller's. Passing the
+    // signal to the SDK genuinely cancels the request (it spreads initOverrides into
+    // fetch), unlike racing a timer, which would leak a socket per attempt.
+    const perRead = AbortSignal.timeout(timings.getOrderTimeoutMs);
+    const readSignal = AbortSignal.any([signal, perRead]);
+    try {
+      log.progress(`  Waiting for confirmation... (${Math.round((Date.now() - startedAt) / 1000)}s elapsed)`);
+      order = await getOrder(orderId, { signal: readSignal });
+      readFailures = 0;
+      lastError = undefined;
+    } catch (err) {
+      // The caller's budget firing mid-read is not a read failure — it is the watch
+      // ending. Leave the last genuine read error (if any) intact and fall through.
+      if (signal.aborted && !perRead.aborted) break;
+      // Anything else — including this read's own abort — is just a failed read: it
+      // says nothing about the swap, so it feeds the backoff and never becomes terminal.
+      readFailures++;
+      lastError = perRead.aborted
+        ? `reading order status timed out after ${timings.getOrderTimeoutMs}ms`
+        : err instanceof Error ? err.message : String(err);
+      log.warn(`could not read status of order ${orderId} (attempt ${readFailures}, retrying): ${lastError}`);
+    }
+
+    if (order) {
+      if (hasKey(order.status, "success")) return { kind: "settled", order };
+
+      // The order itself declares failure — the one and only terminal failure signal.
+      if (hasKey(order.status, "refunded") || hasKey(order.status, "failed")) {
+        return { kind: "failed", order };
+      }
+
+      // inProgress → keep polling, but remember the BTC payout if the order has one.
+      // `pendingBtcPayment` is the order's own record of the tx the gateway broadcast:
+      // null until it broadcasts, then carrying the exact txid. It is the only sound way
+      // to name THIS order's payout — the recipient address cannot identify it, since one
+      // address is reused across orders and parallel offramps to it overlap in the mempool.
+      const inProgress = hasKey(order.status, "inProgress")
+        ? order.status.inProgress as { pendingBtcPayment?: { txid?: string } | null } | undefined
+        : undefined;
+      if (inProgress?.pendingBtcPayment?.txid) {
+        payoutTxId = inProgress.pendingBtcPayment.txid;
+      }
+    }
+
+    // Back off on consecutive read failures so we don't hammer a struggling API; an
+    // ordinary in-progress poll just waits the fixed interval. The sleep ends as soon
+    // as the caller's signal fires, so it cannot overrun the budget.
+    const delay = readFailures > 0
+      ? Math.min(timings.pollIntervalMs * 2 ** (readFailures - 1), timings.maxBackoffMs)
+      : timings.pollIntervalMs;
+    await sleep(delay, signal);
+  }
+
+  // Budget exhausted with no terminal status. Everything we know, and nothing we don't:
+  // when every read failed we have no payout txid, and an order id that can be followed
+  // up beats a confidently wrong txid.
+  return {
+    kind: "inFlight",
+    ...(payoutTxId && { payoutTxId }),
+    ...(lastError && { lastError }),
+  };
+}

--- a/gateway-cli/src/util/sleep.ts
+++ b/gateway-cli/src/util/sleep.ts
@@ -1,0 +1,21 @@
+/**
+ * Sleep that resolves early — never rejects — when `signal` aborts.
+ *
+ * A wait must not outlive the budget that bounds the operation it is part of, and the
+ * way to express that is to hang the sleep off the same signal that bounds everything
+ * else. The alternative, clamping the delay against a computed remaining window, is
+ * clock arithmetic — and clock arithmetic is what a hand-maintained deadline turns into
+ * a negative delay when two of its reads disagree.
+ */
+export function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>(resolve => {
+    if (signal.aborted) return resolve();
+    const done = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    signal.addEventListener("abort", done, { once: true });
+  });
+}

--- a/gateway-cli/src/util/swap-context.ts
+++ b/gateway-cli/src/util/swap-context.ts
@@ -1,6 +1,7 @@
+import { isAddress } from "viem";
 import type { GetQuoteParams, RouteInfo } from "@gobob/bob-sdk";
 import type { ChainFamily } from "../chains/index.js";
-import { deriveAddress, getChainFamily, resolvePrivateKey, resolveRecipient } from "../chains/index.js";
+import { deriveAddress, getChainFamily, resolvePrivateKey, resolveRecipient, validateAddressFamily } from "../chains/index.js";
 import { buildTokenIndex, parseAssetChain, resolveAmount, type ResolvedAsset } from "./input-resolver.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -84,10 +85,12 @@ export interface SwapContext {
 /**
  * The ONE definition of `ownerAddress`: the EVM-side address that controls the order.
  *
- * It can never be a Bitcoin address, by construction:
- *  - an explicit `--owner` is validated as an EVM address by the CLI schema;
- *  - on a BTC-source swap the destination is an EVM chain, so the recipient is EVM;
- *  - on an EVM-source swap it is the sender.
+ * It can never be a Bitcoin address — and this function *enforces* that rather than
+ * assuming it. Which flag supplies the value depends on the direction (the recipient on
+ * a BTC-source onramp, the sender on an EVM-source swap), and neither `--recipient` nor
+ * `--sender` can be pinned to a family by the CLI schema: on a BTC onramp a Bitcoin
+ * `--sender` is correct (it builds the PSBT). So the family is only knowable here, where
+ * the source chain is known — which makes this the only place the invariant can hold.
  *
  * The recipient is NOT a fallback for an EVM-source swap: on an offramp it is a
  * Bitcoin address, and the API rejects the quote outright with
@@ -102,15 +105,33 @@ export function resolveOwnerAddress(opts: {
   senderAddress?: string;
   recipient: string;
 }): string {
-  if (opts.explicit) return opts.explicit;
-  if (opts.srcFamily === "bitcoin" && opts.dstFamily === "evm") return opts.recipient;
-  if (opts.srcFamily === "evm" && opts.senderAddress) return opts.senderAddress;
-  throw new Error(
-    `Could not determine the EVM owner address for this swap.\n` +
-    `  The order is controlled by an EVM address — on an EVM-source swap the sender, and it\n` +
-    `  cannot fall back to the recipient (on an offramp the recipient is a Bitcoin address).\n` +
-    `  Set EVM_PRIVATE_KEY, or pass --sender <evm-address> or --owner <evm-address>.`,
-  );
+  const picked =
+    opts.explicit ? { owner: opts.explicit, from: "--owner" } :
+    opts.srcFamily === "bitcoin" && opts.dstFamily === "evm" ? { owner: opts.recipient, from: "--recipient" } :
+    opts.srcFamily === "evm" && opts.senderAddress ? { owner: opts.senderAddress, from: "--sender" } :
+    undefined;
+
+  if (!picked) {
+    throw new Error(
+      `Could not determine the EVM owner address for this swap.\n` +
+      `  The order is controlled by an EVM address — on an EVM-source swap the sender, and it\n` +
+      `  cannot fall back to the recipient (on an offramp the recipient is a Bitcoin address).\n` +
+      `  Set EVM_PRIVATE_KEY, or pass --sender <evm-address> or --owner <evm-address>.`,
+    );
+  }
+
+  // Verify, don't assume. The value reaching here can come straight from a user-supplied
+  // flag that no schema could have family-checked, so the guarantee this function makes is
+  // only real if it is checked. Otherwise a Bitcoin `--sender`/`--recipient` sails through
+  // into `ownerAddress` and the gateway rejects it remotely instead of us failing locally.
+  if (!isAddress(picked.owner, { strict: false })) {
+    throw new Error(
+      `The order's owner must be an EVM address, but ${picked.from} supplied "${picked.owner}".\n` +
+      `  The order is controlled by an EVM address, whatever the direction of the swap.\n` +
+      `  Pass an EVM address, or set --owner <evm-address> explicitly.`,
+    );
+  }
+  return picked.owner;
 }
 
 // ─── Context ─────────────────────────────────────────────────────────────────
@@ -195,6 +216,11 @@ export async function resolveSwapContext(
   });
 
   const recipient = await resolveRecipient(dstAsset.chain, opts.recipient, config);
+  // An explicit --recipient is taken verbatim, so check it belongs to the destination's
+  // family. Without this a Bitcoin --recipient on an EVM destination reaches the gateway as
+  // `toUserAddress` (and, on an onramp, as `ownerAddress`) and comes back as a remote 400
+  // instead of a local error naming the flag. `send` already validates this way.
+  validateAddressFamily(dstAsset.chain, recipient, "--recipient");
 
   const ownerAddress = resolveOwnerAddress({
     explicit: opts.owner, srcFamily, dstFamily, senderAddress, recipient,

--- a/gateway-cli/src/util/swap-context.ts
+++ b/gateway-cli/src/util/swap-context.ts
@@ -1,0 +1,220 @@
+import type { GetQuoteParams, RouteInfo } from "@gobob/bob-sdk";
+import type { ChainFamily } from "../chains/index.js";
+import { deriveAddress, getChainFamily, resolvePrivateKey, resolveRecipient } from "../chains/index.js";
+import { buildTokenIndex, parseAssetChain, resolveAmount, type ResolvedAsset } from "./input-resolver.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** The gateway order variant implied by the source/destination chain families. */
+export type SwapVariant = "onramp" | "offramp" | "tokenSwap";
+
+/** Options common to `quote` and `swap` — everything the context is resolved from. */
+export interface SwapContextOptions {
+  src: string;
+  dst: string;
+  amount: string;
+  recipient?: string;
+  sender?: string;
+  owner?: string;
+  slippage?: number;
+  feeToken?: string;
+  feeReserve?: string;
+  privateKey?: string;
+}
+
+/**
+ * What the *caller* independently needs out of the context, beyond what the swap
+ * itself implies. Stated as dependencies rather than as per-command booleans, so
+ * "is the key load-bearing here?" is answered in exactly one place ({@link
+ * resolveSwapContext}) instead of being re-derived by each command.
+ */
+export interface SwapContextNeeds {
+  /**
+   * The caller will sign and broadcast the source transaction, so the private key
+   * itself is load-bearing (`swap` without `--unsigned`).
+   */
+  signing: boolean;
+  /**
+   * The caller needs the source-side sender address for its own reasons, whoever
+   * owns the order: `swap` sends it as `fromUserAddress`, checks its pending nonce,
+   * and builds the PSBT from it. `quote` does not — so a `quote` that needs no key
+   * for any *other* reason must never touch one.
+   */
+  senderAddress: boolean;
+}
+
+/**
+ * Everything `quote` and `swap` need about a swap, resolved once.
+ *
+ * Both commands previously built this pipeline by hand — routes → source family →
+ * key → sender → inputs → recipient → owner → quote params — and every divergence
+ * between the two copies was a bug. There is now one pipeline, and both consume it.
+ */
+export interface SwapContext {
+  srcAsset: ResolvedAsset;
+  dstAsset: ResolvedAsset;
+  srcFamily: ChainFamily;
+  dstFamily: ChainFamily;
+  /** Order variant implied by the chain families. */
+  variant: SwapVariant;
+  /** The EVM chain involved in the swap (the destination on an onramp, else the source). */
+  evmChain: string;
+  /** Source-side sender. Undefined only when nothing on this path needed it. */
+  senderAddress?: string;
+  /** Destination-side recipient — a Bitcoin address on an offramp. */
+  recipient: string;
+  /**
+   * The EVM-side address that controls the order. Required by the V3 API; never a
+   * Bitcoin address. See {@link resolveOwnerAddress}.
+   */
+  ownerAddress: string;
+  /** Source amount in atomic units. */
+  atomicUnits: string;
+  /** Human-readable rendering of the source amount. */
+  display: string;
+  slippageBps: number;
+  /** The signing key, resolved only when {@link SwapContextNeeds.signing} asked for it. */
+  key?: string;
+  /** Quote parameters, identical for `quote` and `swap` by construction. */
+  quoteParams: GetQuoteParams;
+}
+
+// ─── Owner address ───────────────────────────────────────────────────────────
+
+/**
+ * The ONE definition of `ownerAddress`: the EVM-side address that controls the order.
+ *
+ * It can never be a Bitcoin address, by construction:
+ *  - an explicit `--owner` is validated as an EVM address by the CLI schema;
+ *  - on a BTC-source swap the destination is an EVM chain, so the recipient is EVM;
+ *  - on an EVM-source swap it is the sender.
+ *
+ * The recipient is NOT a fallback for an EVM-source swap: on an offramp it is a
+ * Bitcoin address, and the API rejects the quote outright with
+ * `INVALID_REQUEST: Invalid Ethereum address: Expected an EVM address but found a
+ * Bitcoin address`. `ownerAddress` is also mandatory, so omitting it is not an
+ * option either — an undeterminable owner is a hard, actionable error.
+ */
+export function resolveOwnerAddress(opts: {
+  explicit?: string;
+  srcFamily: ChainFamily;
+  dstFamily: ChainFamily;
+  senderAddress?: string;
+  recipient: string;
+}): string {
+  if (opts.explicit) return opts.explicit;
+  if (opts.srcFamily === "bitcoin" && opts.dstFamily === "evm") return opts.recipient;
+  if (opts.srcFamily === "evm" && opts.senderAddress) return opts.senderAddress;
+  throw new Error(
+    `Could not determine the EVM owner address for this swap.\n` +
+    `  The order is controlled by an EVM address — on an EVM-source swap the sender, and it\n` +
+    `  cannot fall back to the recipient (on an offramp the recipient is a Bitcoin address).\n` +
+    `  Set EVM_PRIVATE_KEY, or pass --sender <evm-address> or --owner <evm-address>.`,
+  );
+}
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a swap end to end: assets, chain families, sender, recipient, owner and
+ * amount, plus the quote parameters built from them.
+ *
+ * The private key is touched only where it is load-bearing. A key nothing needs is
+ * never read, so a malformed `EVM_PRIVATE_KEY` cannot break a quote that does not
+ * need one (a BTC→EVM quote, or any quote given an explicit `--owner`/`--sender`).
+ */
+export async function resolveSwapContext(
+  opts: SwapContextOptions,
+  routes: RouteInfo[],
+  config: { bitcoinPrivateKey?: string; evmPrivateKey?: string; slippageBps: number },
+  needs: SwapContextNeeds,
+): Promise<SwapContext> {
+  // The source is resolved ONLY here, through the same resolver the rest of the CLI
+  // uses. Re-parsing `opts.src` with an ad-hoc string heuristic is what previously
+  // made `--src Btc` an EVM chain and made a bare `--src USDT` derive a key before
+  // the asset was even validated.
+  const tokenIndex = buildTokenIndex(routes);
+  const srcAsset = parseAssetChain(opts.src, routes, tokenIndex);
+  const dstAsset = parseAssetChain(opts.dst, routes, tokenIndex);
+
+  const srcFamily = getChainFamily(srcAsset.chain);
+  const dstFamily = getChainFamily(dstAsset.chain);
+  const variant: SwapVariant = srcFamily === "bitcoin" ? "onramp" : dstFamily === "bitcoin" ? "offramp" : "tokenSwap";
+  const evmChain = srcFamily === "bitcoin" ? dstAsset.chain : srcAsset.chain;
+
+  // ── Who needs the sender, and when ─────────────────────────────────────────
+  // These are the only places the sender is load-bearing. Expressed once, as
+  // dependencies, rather than as hand-written booleans duplicated per command.
+  const ownerNeedsSender = srcFamily === "evm" && !opts.owner;
+  const balanceNeedsSender = opts.amount.trim().toUpperCase() === "ALL";
+  const wantsSender = needs.senderAddress || ownerNeedsSender || balanceNeedsSender;
+
+  // ...and therefore the only conditions under which the KEY is load-bearing: to
+  // sign, or to produce a sender address nobody supplied. Anything else must not
+  // touch it — reading a key that is not needed turns a malformed key into a
+  // failure of an operation that never required it.
+  const keyIsLoadBearing = needs.signing || (wantsSender && !opts.sender);
+  const key = keyIsLoadBearing ? resolvePrivateKey(srcFamily, opts.privateKey, config) : undefined;
+
+  if (needs.signing && !key) {
+    const isBtc = srcFamily === "bitcoin";
+    throw new Error(
+      `no signer configured for ${isBtc ? "Bitcoin" : "EVM"}.\n` +
+      `  Set ${isBtc ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY"} or pass --private-key.\n` +
+      `  Use --unsigned to output the ${isBtc ? "PSBT" : "unsigned transaction"} without signing.`,
+    );
+  }
+
+  let derivedAddress: string | undefined;
+  if (key && wantsSender) {
+    try {
+      derivedAddress = await deriveAddress(srcFamily, key);
+    } catch (err) {
+      const envVar = srcFamily === "bitcoin" ? "BITCOIN_PRIVATE_KEY" : "EVM_PRIVATE_KEY";
+      throw new Error(
+        `Failed to derive sender address from ${envVar}: ${err instanceof Error ? err.message : String(err)}\n` +
+        `  Use --sender <address> to provide the address directly.`,
+      );
+    }
+  }
+
+  const senderAddress = opts.sender ?? derivedAddress;
+
+  // A --sender that disagrees with the signing key would create the order for one
+  // address and sign it with another.
+  if (opts.sender && derivedAddress && opts.sender.toLowerCase() !== derivedAddress.toLowerCase()) {
+    throw new Error(
+      `--sender ${opts.sender} does not match the signing key (${derivedAddress}).\n` +
+      `  The order would be created for one address but signed by another.\n` +
+      `  Remove --sender to use the key-derived address, or use --unsigned to skip signing.`,
+    );
+  }
+
+  const { atomicUnits, display } = await resolveAmount(srcAsset, opts.amount, {
+    senderAddress, feeToken: opts.feeToken, feeReserve: opts.feeReserve,
+  });
+
+  const recipient = await resolveRecipient(dstAsset.chain, opts.recipient, config);
+
+  const ownerAddress = resolveOwnerAddress({
+    explicit: opts.owner, srcFamily, dstFamily, senderAddress, recipient,
+  });
+
+  const slippageBps = opts.slippage ?? config.slippageBps;
+
+  return {
+    srcAsset, dstAsset, srcFamily, dstFamily, variant, evmChain,
+    senderAddress, recipient, ownerAddress, atomicUnits, display, slippageBps, key,
+    quoteParams: {
+      fromChain: srcAsset.chain,
+      toChain: dstAsset.chain,
+      fromToken: srcAsset.address,
+      toToken: dstAsset.address,
+      toUserAddress: recipient,
+      fromUserAddress: senderAddress,
+      ownerAddress,
+      amount: atomicUnits,
+      maxSlippage: slippageBps,
+    },
+  };
+}

--- a/gateway-cli/tests/chains/recipient.test.ts
+++ b/gateway-cli/tests/chains/recipient.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { validateRecipient } from "../../src/chains/index.js";
+import { validateAddressFamily } from "../../src/chains/index.js";
 
 const EVM = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 const BTC = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
 
-describe("validateRecipient", () => {
+describe("validateAddressFamily", () => {
   it("accepts an EVM address for an EVM chain", () => {
-    expect(() => validateRecipient("base", EVM)).not.toThrow();
+    expect(() => validateAddressFamily("base", EVM)).not.toThrow();
   });
   it("accepts a BTC address for bitcoin", () => {
-    expect(() => validateRecipient("bitcoin", BTC)).not.toThrow();
+    expect(() => validateAddressFamily("bitcoin", BTC)).not.toThrow();
   });
   it("rejects a BTC address for an EVM chain", () => {
-    expect(() => validateRecipient("base", BTC)).toThrow(/valid EVM address/i);
+    expect(() => validateAddressFamily("base", BTC)).toThrow(/valid EVM address/i);
   });
   it("rejects an EVM address for bitcoin", () => {
-    expect(() => validateRecipient("bitcoin", EVM)).toThrow(/valid Bitcoin address/i);
+    expect(() => validateAddressFamily("bitcoin", EVM)).toThrow(/valid Bitcoin address/i);
   });
 });

--- a/gateway-cli/tests/commands/quote.test.ts
+++ b/gateway-cli/tests/commands/quote.test.ts
@@ -10,6 +10,8 @@ vi.mock("../../src/config.js", () => ({
   loadConfig: vi.fn(() => ({
     slippageBps: 300,
     btcFeeRate: undefined,
+    bitcoinPrivateKey: undefined,
+    evmPrivateKey: undefined,
   })),
   getSdk: vi.fn(() => ({
     getQuote: mockGetQuote,
@@ -29,23 +31,25 @@ vi.mock("@gobob/bob-sdk", async (importOriginal) => {
 
 vi.mock("../../src/util/route-provider.js", () => ({
   getRoutes: vi.fn().mockResolvedValue([
-    {
-      srcChain: "bitcoin",
-      dstChain: "base",
-      srcToken: "BTC",
-      dstToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-    },
+    { srcChain: "bitcoin", dstChain: "base", srcToken: "BTC", dstToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" },
+    // an offramp route, so the EVM-source cases resolve through the real resolver
+    { srcChain: "ethereum", dstChain: "bitcoin", srcToken: "0xdAC17F958D2ee523a2206206994597C13D831ec7", dstToken: "BTC" },
   ]),
 }));
 
-vi.mock("../../src/util/input-resolver.js", () => ({
-  resolveSwapInputs: vi.fn().mockResolvedValue({
-    srcAsset: { chain: "bitcoin", address: "BTC", symbol: "BTC", decimals: 8 },
-    dstAsset: { chain: "base", address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 },
-    atomicUnits: "5000000",
-    display: "0.05 BTC",
+vi.mock("../../src/chains/evm.js", () => ({
+  CHAIN_IDS: { ethereum: 1, base: 8453 } as Record<string, number>,
+  getTokenMetadata: vi.fn((address: string, chain: string) => {
+    if (chain === "bitcoin" || address === "BTC") return { symbol: "BTC", decimals: 8 };
+    if (address.toLowerCase() === "0xdac17f958d2ee523a2206206994597c13d831ec7") return { symbol: "USDT", decimals: 6 };
+    return { symbol: "USDC", decimals: 6 };
   }),
+  getEvmBalances: vi.fn(),
 }));
+
+// The REAL input-resolver is used here on purpose: `parseAssetChain` is the resolver whose
+// verdict on the source chain `handleQuote` must defer to, and the bugs below were all
+// caused by second-guessing it. Mocking it would only re-test a mock.
 
 vi.mock("../../src/chains/index.js", () => ({
   getChainFamily: vi.fn((chain: string) => chain === "bitcoin" ? "bitcoin" : "evm"),
@@ -54,7 +58,7 @@ vi.mock("../../src/chains/index.js", () => ({
   resolveRecipient: vi.fn().mockResolvedValue("0xDerived"),
 }));
 
-// ─── Tests ───────────────────────────────────────────────────────────────────
+// ─── Fixtures ────────────────────────────────────────────────────────────────
 
 const sdkQuote = {
   onramp: {
@@ -63,6 +67,24 @@ const sdkQuote = {
     fee: { amount: "10000" },
   },
 };
+
+const offrampSdkQuote = {
+  offramp: {
+    inputAmount: { amount: "47000000" },
+    outputAmount: { amount: "74489" },
+  },
+};
+
+const BTC_RECIPIENT = "bc1q4xdatls497ea76fmuefu9we4ld4yu2vy8hedne";
+const EVM_SENDER = "0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb";
+
+/** Point the mocked recipient at the BTC address a USDT@ethereum → BTC offramp pays out to. */
+async function mockOfframpRecipient() {
+  const { resolveRecipient } = await import("../../src/chains/index.js");
+  vi.mocked(resolveRecipient).mockResolvedValueOnce(BTC_RECIPIENT);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("handleQuote", () => {
   beforeEach(() => {
@@ -93,4 +115,94 @@ describe("handleQuote", () => {
     expect(result.quote.feeRateSatPerVbyte).toBe(15);
   });
 
+  // ─── A1 ────────────────────────────────────────────────────────────────────
+  // `ownerAddress` is the EVM-side address controlling the order — the sender on an
+  // offramp. `quote` derived the sender only for `--amount ALL`, so on an ordinary
+  // offramp it was undefined and `ownerAddress` fell back to the (Bitcoin) recipient.
+  // Staging rejected EVERY offramp quote with
+  // "INVALID_REQUEST: Invalid Ethereum address: Expected an EVM address but found a
+  // Bitcoin address". `swap` derived it unconditionally, which is why only `quote` broke.
+
+  it("sends the EVM sender as ownerAddress on an offramp quote with a fixed amount", async () => {
+    const { resolvePrivateKey, deriveAddress } = await import("../../src/chains/index.js");
+    await mockOfframpRecipient();
+    vi.mocked(resolvePrivateKey).mockReturnValueOnce("0xevmkey");
+    vi.mocked(deriveAddress).mockResolvedValueOnce(EVM_SENDER);
+    mockGetQuote.mockResolvedValueOnce(offrampSdkQuote);
+
+    await handleQuote({ src: "USDT:ethereum", dst: "BTC", amount: "47000000" });
+
+    expect(mockGetQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerAddress: EVM_SENDER, toUserAddress: BTC_RECIPIENT }),
+    );
+  });
+
+  it("fails with an actionable error rather than quoting an offramp with no EVM sender", async () => {
+    // The API makes ownerAddress mandatory (omitting it → MISSING_OWNER_ADDRESS), and the
+    // BTC recipient is not a legal substitute. There is nothing to send, so say so.
+    const { resolvePrivateKey } = await import("../../src/chains/index.js");
+    await mockOfframpRecipient();
+    vi.mocked(resolvePrivateKey).mockReturnValueOnce(undefined);
+
+    await expect(
+      handleQuote({ src: "USDT:ethereum", dst: "BTC", amount: "47000000" }),
+    ).rejects.toThrow(/EVM owner address/);
+    expect(mockGetQuote).not.toHaveBeenCalled();
+  });
+
+  // ─── A2 ────────────────────────────────────────────────────────────────────
+
+  it("reports the invalid asset, not a key error, when the source has no chain qualifier", async () => {
+    // `quote` re-parsed `--src` with an ad-hoc heuristic, so a bare symbol was classified
+    // as an EVM chain and a key was derived BEFORE the asset was validated: a malformed
+    // EVM_PRIVATE_KEY surfaced as "Failed to derive sender address" instead of the real
+    // problem. The asset resolver's verdict must come first.
+    const { resolvePrivateKey, deriveAddress } = await import("../../src/chains/index.js");
+    vi.mocked(resolvePrivateKey).mockReturnValue("0xmalformed");
+    vi.mocked(deriveAddress).mockRejectedValue(new Error("invalid private key"));
+
+    await expect(
+      handleQuote({ src: "USDT", dst: "BTC", amount: "5000000", recipient: BTC_RECIPIENT }),
+    ).rejects.toThrow(/chain required/);
+
+    expect(deriveAddress).not.toHaveBeenCalled();
+  });
+
+  it.each(["BTC", "Btc", "BTC:Bitcoin"])(
+    "does not derive an EVM key for a BTC onramp quote (src: %s)",
+    async (src) => {
+      // The same ad-hoc parser read the source family case-sensitively, so `--src Btc`
+      // was classified as an EVM chain — deriving EVM_PRIVATE_KEY and sending an EVM
+      // address as the onramp's fromUserAddress. A BTC source needs no EVM key at all.
+      const { resolvePrivateKey } = await import("../../src/chains/index.js");
+      mockGetQuote.mockResolvedValueOnce(sdkQuote);
+
+      await handleQuote({
+        src, dst: "USDC:base", amount: "5000000", recipient: "0xRecipient", btcFeeRate: 15,
+      });
+
+      expect(resolvePrivateKey).not.toHaveBeenCalled();
+      expect(mockGetQuote).toHaveBeenCalledWith(expect.objectContaining({ fromUserAddress: undefined }));
+    },
+  );
+
+  // ─── A3 ────────────────────────────────────────────────────────────────────
+
+  it("does not touch the EVM key when --owner already supplies the owner", async () => {
+    // With --owner given, the derived sender is not used for anything on a quote. Deriving
+    // it anyway makes a malformed EVM_PRIVATE_KEY break a quote that needs no key — a key
+    // must only be touched where it is load-bearing.
+    const { resolvePrivateKey, deriveAddress } = await import("../../src/chains/index.js");
+    await mockOfframpRecipient();
+    vi.mocked(resolvePrivateKey).mockReturnValue("0xmalformed");
+    vi.mocked(deriveAddress).mockRejectedValue(new Error("invalid private key"));
+    mockGetQuote.mockResolvedValueOnce(offrampSdkQuote);
+
+    await handleQuote({
+      src: "USDT:ethereum", dst: "BTC", amount: "47000000", owner: EVM_SENDER,
+    });
+
+    expect(deriveAddress).not.toHaveBeenCalled();
+    expect(mockGetQuote).toHaveBeenCalledWith(expect.objectContaining({ ownerAddress: EVM_SENDER }));
+  });
 });

--- a/gateway-cli/tests/commands/quote.test.ts
+++ b/gateway-cli/tests/commands/quote.test.ts
@@ -52,10 +52,11 @@ vi.mock("../../src/chains/evm.js", () => ({
 // caused by second-guessing it. Mocking it would only re-test a mock.
 
 vi.mock("../../src/chains/index.js", () => ({
+  validateAddressFamily: vi.fn(),
   getChainFamily: vi.fn((chain: string) => chain === "bitcoin" ? "bitcoin" : "evm"),
-  deriveAddress: vi.fn().mockResolvedValue("0xDerived"),
+  deriveAddress: vi.fn().mockResolvedValue("0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb"),
   resolvePrivateKey: vi.fn(() => undefined),
-  resolveRecipient: vi.fn().mockResolvedValue("0xDerived"),
+  resolveRecipient: vi.fn().mockResolvedValue("0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb"),
 }));
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -96,7 +97,7 @@ describe("handleQuote", () => {
     mockGetRecommendedFees.mockResolvedValueOnce({ fastestFee: 25 });
 
     const result = await handleQuote({
-      src: "BTC", dst: "USDC:base", amount: "5000000", recipient: "0xRecipient",
+      src: "BTC", dst: "USDC:base", amount: "5000000", recipient: "0x1111111111111111111111111111111111111111",
     });
 
     expect(mockGetRecommendedFees).toHaveBeenCalledOnce();
@@ -107,7 +108,7 @@ describe("handleQuote", () => {
     mockGetQuote.mockResolvedValueOnce(sdkQuote);
 
     const result = await handleQuote({
-      src: "BTC", dst: "USDC:base", amount: "5000000", recipient: "0xRecipient",
+      src: "BTC", dst: "USDC:base", amount: "5000000", recipient: "0x1111111111111111111111111111111111111111",
       btcFeeRate: 15,
     });
 
@@ -178,7 +179,7 @@ describe("handleQuote", () => {
       mockGetQuote.mockResolvedValueOnce(sdkQuote);
 
       await handleQuote({
-        src, dst: "USDC:base", amount: "5000000", recipient: "0xRecipient", btcFeeRate: 15,
+        src, dst: "USDC:base", amount: "5000000", recipient: "0x1111111111111111111111111111111111111111", btcFeeRate: 15,
       });
 
       expect(resolvePrivateKey).not.toHaveBeenCalled();

--- a/gateway-cli/tests/commands/swap-schema.test.ts
+++ b/gateway-cli/tests/commands/swap-schema.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { swapSchema } from "../../src/schemas.js";
+
+const base = { src: "BTC", dst: "USDC:base", amount: "5000000" };
+
+describe("swapSchema --timeout", () => {
+  it("accepts an ordinary polling timeout", () => {
+    expect(swapSchema.parse({ ...base, timeout: "5400" })).toMatchObject({ timeout: 5400 });
+  });
+
+  it("rejects a timeout large enough to make AbortSignal.timeout throw", () => {
+    // The poll timeout becomes `AbortSignal.timeout(timeoutMs)`, created AFTER the source tx
+    // is broadcast. Above 2^32-1 ms it throws RangeError *synchronously*, which would report
+    // a swap whose funds are already committed as a hard failure — the exact failure mode the
+    // signal-driven poll loop exists to make impossible. Reject it at the boundary instead,
+    // where nothing has been sent yet.
+    expect(() => swapSchema.parse({ ...base, timeout: "99999999" })).toThrow(/86400/);
+    // Sanity: the rejected value really is the one that would blow up.
+    expect(() => AbortSignal.timeout(99_999_999 * 1000)).toThrow(RangeError);
+    expect(() => AbortSignal.timeout(86_400 * 1000)).not.toThrow();
+  });
+});

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -65,17 +65,26 @@ vi.mock("../../src/util/route-provider.js", () => ({
   getRoutes: vi.fn(async () => mockRoutes),
 }));
 
-vi.mock("../../src/util/input-resolver.js", () => ({
-  resolveSwapInputs: vi.fn().mockResolvedValue({
-    srcAsset: { chain: "bitcoin", address: "BTC", symbol: "BTC", decimals: 8 },
-    dstAsset: { chain: "base", address: "0xUSDC", symbol: "USDC", decimals: 6 },
-    atomicUnits: "5000000",
-    display: "0.05 BTC",
-  }),
-  humanToAtomic: vi.fn((human: string, decimals: number) => "0"),
-  buildTokenIndex: vi.fn(() => ({ byChainAndSymbol: new Map(), byChainAndAddress: new Map() })),
-  parseAssetChain: vi.fn((asset: string) => ({ chain: "bitcoin", address: "BTC", symbol: "BTC", decimals: 8 })),
-}));
+// `parseAssetChain` must answer per-asset: the source and the destination are resolved
+// through the SAME resolver, and a mock that returned one fixed asset for both would
+// make every swap look like a BTC→BTC swap.
+vi.mock("../../src/util/input-resolver.js", () => {
+  const assets: Record<string, unknown> = {
+    "BTC": { chain: "bitcoin", address: "BTC", symbol: "BTC", decimals: 8 },
+    "USDC:base": { chain: "base", address: "0xUSDC", symbol: "USDC", decimals: 6 },
+    "USDT:ethereum": { chain: "ethereum", address: "0xUSDT", symbol: "USDT", decimals: 6 },
+  };
+  return {
+    humanToAtomic: vi.fn(() => "0"),
+    buildTokenIndex: vi.fn(() => ({ byChainAndSymbol: new Map(), byChainAndAddress: new Map() })),
+    parseAssetChain: vi.fn((asset: string) => {
+      const resolved = assets[asset];
+      if (!resolved) throw new Error(`test fixture: no asset for "${asset}"`);
+      return resolved;
+    }),
+    resolveAmount: vi.fn().mockResolvedValue({ atomicUnits: "5000000", display: "0.05 BTC" }),
+  };
+});
 
 vi.mock("../../src/util/price-oracle.js", () => ({
   fetchPrice: vi.fn().mockResolvedValue({ priceUsd: 100000, source: "mock" }),
@@ -90,7 +99,7 @@ vi.mock("../../src/chains/index.js", () => ({
     onramp: { orderId, bitcoinTxHex: txId },
   })),
   resolvePrivateKey: vi.fn((chain: string, privateKey?: string) => privateKey),
-  resolveRecipient: vi.fn().mockResolvedValue("bc1qtest"),
+  resolveRecipient: vi.fn().mockResolvedValue("0xEvmRecipient"),
 }));
 
 vi.mock("@gobob/bob-sdk", () => ({
@@ -274,20 +283,8 @@ describe("handleSwap", () => {
     // the thrown error must carry the settlement tx hash + chainId so downstream
     // alerting can fetch the receipt and detect out-of-gas — without these the
     // failure is undiagnosable.
-    const { resolveSwapInputs, parseAssetChain } = await import("../../src/util/input-resolver.js");
-    // srcFamily is derived from parseAssetChain(opts.src) → drives variant.
-    // Make src EVM so variant resolves to "tokenSwap" (not onramp).
-    vi.mocked(parseAssetChain).mockReturnValueOnce({ chain: "ethereum", address: "0xUSDT", symbol: "USDT", decimals: 6 } as any);
-    vi.mocked(resolveSwapInputs).mockResolvedValueOnce({
-      srcAsset: { chain: "ethereum", address: "0xUSDT", symbol: "USDT", decimals: 6 },
-      dstAsset: { chain: "base", address: "0xUSDC", symbol: "USDC", decimals: 6 },
-      atomicUnits: "50000000",
-      display: "50 USDT",
-    } as any);
-    // EVM src means the signing-key path runs: getChainFamily("ethereum") → "evm".
-    const { getChainFamily, resolveSigner, deriveAddress, resolveRecipient } = await import("../../src/chains/index.js");
-    vi.mocked(getChainFamily).mockImplementation((chain: string) => chain === "bitcoin" ? "bitcoin" : "evm");
-    // EVM signed path uses { walletClient, publicClient }; pending-nonce check
+    const { resolveSigner, deriveAddress, resolveRecipient } = await import("../../src/chains/index.js");
+    // EVM signed path uses { walletClient, publicClient }; the pending-nonce check
     // calls publicClient.getTransactionCount (latest >= pending → settled).
     const publicClient = { getTransactionCount: vi.fn().mockResolvedValue(0) } as any;
     vi.mocked(resolveSigner).mockResolvedValue({ address: "0xSender", walletClient: {} as any, publicClient } as any);
@@ -301,15 +298,10 @@ describe("handleSwap", () => {
     const { handleSwap } = await import("../../src/commands/swap.js");
     const { SwapError } = await import("../../src/errors.js");
 
-    let caught: any;
-    try {
-      await handleSwap(
-        { ...baseOpts, src: "USDT:ethereum", dst: "USDC:base", privateKey: "0xevmkey" },
-        silentLogger,
-      );
-    } catch (e) {
-      caught = e;
-    }
+    const caught: any = await handleSwap(
+      { ...baseOpts, src: "USDT:ethereum", dst: "USDC:base", privateKey: "0xevmkey" },
+      silentLogger,
+    ).catch(e => e);
 
     expect(caught).toBeInstanceOf(SwapError);
     // Message preserved so existing categorization still matches as a fallback.
@@ -321,5 +313,4 @@ describe("handleSwap", () => {
     expect(caught.context.srcAsset).toEqual({ symbol: "USDT", chain: "ethereum" });
     expect(caught.context.dstAsset).toEqual({ symbol: "USDC", chain: "base" });
   });
-
 });

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Logger } from "../../src/output.js";
 import type { RouteInfo } from "@gobob/bob-sdk";
+import type { PollTimings } from "../../src/commands/swap.js";
 
 // ─── Mock fixtures ────────────────────────────────────────────────────────────
 
@@ -161,6 +162,15 @@ vi.mock("p-retry", () => ({
 
 const silentLogger: Logger = { progress: () => {}, warn: () => {} };
 
+/**
+ * Poll timings compressed so the loop's REAL machinery — AbortSignal.timeout,
+ * AbortSignal.any, the abortable sleep, the SDK's request cancellation — runs
+ * unmocked and still finishes in milliseconds. Fake timers cannot drive
+ * AbortSignal.timeout (it is not backed by the global timer), and faking the loop's
+ * clock is exactly the thing these tests exist to prove the loop no longer depends on.
+ */
+const FAST: PollTimings = { pollIntervalMs: 10, maxBackoffMs: 40, getOrderTimeoutMs: 50 };
+
 const baseOpts = {
   src: "BTC",
   dst: "USDC:base",
@@ -171,6 +181,22 @@ const baseOpts = {
   retry: true,
   privateKey: "cTestPrivateKey",
 };
+
+/** USDT@ethereum → BTC offramp paying the ONE BTC address gateway-bot reuses for every swap. */
+async function setupOfframp() {
+  const { resolveSigner, deriveAddress, resolveRecipient } = await import("../../src/chains/index.js");
+  const publicClient = { getTransactionCount: vi.fn().mockResolvedValue(0) } as any;
+  vi.mocked(resolveSigner).mockResolvedValue({ address: "0xSender", walletClient: {} as any, publicClient } as any);
+  vi.mocked(deriveAddress).mockResolvedValue("0xSender");
+  vi.mocked(resolveRecipient).mockResolvedValue("bc1qshared");
+
+  mockExecuteQuote.mockResolvedValue({
+    order: { offramp: { orderId: "order-btc-1", tx: { to: "0xGateway" } } },
+    tx: "0xsettlementhash",
+  });
+
+  return { ...baseOpts, src: "USDT:ethereum", dst: "BTC", privateKey: "0xevmkey" };
+}
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -202,7 +228,8 @@ describe("handleSwap", () => {
 
     expect(mockGetQuote).toHaveBeenCalledOnce();
     expect(mockExecuteQuote).toHaveBeenCalledOnce();
-    expect(mockGetOrder).toHaveBeenCalledWith("order-456");
+    // Every read carries an abort signal, so no single read can outlive --timeout.
+    expect(mockGetOrder).toHaveBeenCalledWith("order-456", { signal: expect.any(AbortSignal) });
   });
 
   it("--no-wait returns submitted without polling", async () => {
@@ -312,5 +339,198 @@ describe("handleSwap", () => {
     expect(caught.context.txParams.to).toBe("0xGatewayContract");
     expect(caught.context.srcAsset).toEqual({ symbol: "USDT", chain: "ethereum" });
     expect(caught.context.dstAsset).toEqual({ symbol: "USDC", chain: "base" });
+  });
+
+  // ─── B1/B2/B3 — polling never reports a committed swap as failed ────────────
+  //
+  // Once executeQuote returns, the source funds are committed on-chain. The order status
+  // is then the ONLY authority on whether the swap failed: an error while *reading* that
+  // status says nothing about the swap. Reporting those reads as terminal failures
+  // produced false "swap failed" alarms on swaps that had already succeeded — and, via
+  // gateway-bot, false critical GitHub issues.
+
+  describe("polling never reports a committed swap as failed", () => {
+    it("a transient gateway 5xx while polling does not fail an already-settling swap", async () => {
+      // Incident (staging order cbf7296e-340a-438a-981c-75980fafc40c): get-order returned
+      // "bungee api error: status=504", yet the swap SUCCEEDED — 74,130 sats confirmed on
+      // Bitcoin in tx 48abaaf1…, block 957986. The CLI exited 1 and gateway-bot opened a
+      // false critical issue for a swap that worked.
+      mockGetOrder
+        .mockRejectedValueOnce(new Error("bungee api error: status=504 Gateway Timeout, message=error code: 504\n"))
+        .mockResolvedValue(confirmedOrder);
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const result = await handleSwap({ ...baseOpts, timeout: 2 }, silentLogger, FAST);
+
+      expect(result.type).toBe("confirmed");
+      expect(mockGetOrder).toHaveBeenCalledTimes(2);
+    });
+
+    it("a generic fetch failure while polling reports in_flight, not failure", async () => {
+      // Incident (staging order a9a49f67-a2de-429f-bb44-2f32034a6f22): the SDK runtime threw
+      // its generic FetchError (underlying cause: a local Cloudflare 403) on every get-order.
+      // 44.6 USDC had already left the wallet; the order was `inProgress` and later settled
+      // fine. The CLI must not call that a failure — and must hand back the orderId + source
+      // tx so the in-flight funds can be followed up.
+      mockGetOrder.mockRejectedValue(
+        new Error("The request failed and the interceptors did not return an alternative response"),
+      );
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const result = await handleSwap({ ...baseOpts, timeout: 0.3 }, silentLogger, FAST);
+
+      expect(result.type).toBe("inFlight");
+      if (result.type !== "inFlight") return;
+      expect(result.data.status).toBe("in_flight");
+      expect(result.data.orderId).toBe("order-456");
+      expect(result.data.txId).toBe("signed-tx-hex-abc");
+      expect(result.data.lastError).toContain("interceptors did not return");
+      // Retried rather than bailing out on the first read error.
+      expect(mockGetOrder.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it("an order still inProgress at --timeout reports in_flight, not failure", async () => {
+      // Previously the poll loop exhausted its retries and threw its internal "pending"
+      // sentinel, which surfaced as {"error":{"message":"pending"}} with exit 1 — a terminal
+      // failure for a swap that was simply still settling.
+      mockGetOrder.mockResolvedValue({ id: "order-456", status: { inProgress: {} } });
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const result = await handleSwap({ ...baseOpts, timeout: 0.3 }, silentLogger, FAST);
+
+      expect(result.type).toBe("inFlight");
+      if (result.type !== "inFlight") return;
+      expect(result.data.orderId).toBe("order-456");
+      expect(result.data.txId).toBe("signed-tx-hex-abc");
+      // The status was readable throughout — nothing to report as a read error.
+      expect(result.data.lastError).toBeUndefined();
+      expect(mockGetOrder.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it("retrying read errors does not mask a genuine order failure", async () => {
+      // The order status stays the ONE authority on failure: surviving a transient read
+      // error must not make us swallow the `failed` status that follows it.
+      mockGetOrder
+        .mockRejectedValueOnce(new Error("bungee api error: status=504 Gateway Timeout"))
+        .mockResolvedValue({ id: "order-456", status: { failed: {} } });
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const { SwapError } = await import("../../src/errors.js");
+
+      await expect(
+        handleSwap({ ...baseOpts, timeout: 2 }, silentLogger, FAST),
+      ).rejects.toThrow(SwapError);
+    });
+
+    it("a stalled getOrder read is aborted, so the loop still ends at --timeout", async () => {
+      // B2: a stalled TCP connection — the server accepts the request and never answers. Like
+      // undici, the mock settles ONLY when its AbortSignal fires. Without a per-attempt signal
+      // the await never returns and --timeout is unenforceable; racing a timer instead would
+      // leak the socket. The read must be genuinely cancelled.
+      mockGetOrder.mockImplementation((_id: string, init?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal!.reason));
+        }),
+      );
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const startedAt = Date.now();
+      const result = await handleSwap({ ...baseOpts, timeout: 0.3 }, silentLogger, FAST);
+      const elapsedMs = Date.now() - startedAt;
+
+      // Bounded by --timeout, and the unreadable status is in_flight — never a failure.
+      expect(result.type).toBe("inFlight");
+      expect(elapsedMs).toBeLessThan(3_000);
+      expect(mockGetOrder).toHaveBeenCalledWith("order-456", { signal: expect.any(AbortSignal) });
+      if (result.type !== "inFlight") return;
+      expect(result.data.lastError).toContain("timed out");
+    }, 10_000);
+
+    it("survives a clock that jumps past the deadline mid-iteration (no RangeError)", async () => {
+      // B3: the first attempt at B2 kept a `deadline` and derived the per-attempt budget from
+      // `deadline - Date.now()`, reading the clock separately from the loop guard. A stall
+      // between the two reads makes the window negative, and AbortSignal.timeout(negative)
+      // throws RangeError *synchronously* — outside the read's try — so a swap whose funds are
+      // already committed exits 1 as a hard failure. That is B1 reintroduced through the clock.
+      //
+      // There is no clock arithmetic left to break: the loop is driven by abort state alone, so
+      // it must survive a clock that lies. Date.now() may now only be *reported*, never obeyed.
+      const nowSpy = vi.spyOn(Date, "now");
+      try {
+        let call = 0;
+        nowSpy.mockImplementation(() => {
+          call++;
+          if (call === 1) return 1_000;
+          if (call === 2) return 1_500;
+          return 999_999_999; // stalled: every later read is "past" any deadline
+        });
+        mockGetOrder.mockResolvedValue({ id: "order-456", status: { inProgress: {} } });
+
+        const { handleSwap } = await import("../../src/commands/swap.js");
+        const result = await handleSwap({ ...baseOpts, timeout: 0.3 }, silentLogger, FAST);
+
+        // Exits cleanly as in-flight rather than throwing RangeError — or "pending".
+        expect(result.type).toBe("inFlight");
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+  });
+
+  // ─── B4 — the BTC payout on timeout comes from the order, never from the address ──
+  //
+  // The only sound source for this order's payout tx is the order's own
+  // `pendingBtcPayment`. Scanning the recipient address for an unconfirmed tx is not
+  // correlation: gateway-bot reuses ONE BTC address for every swap and runs offramp legs
+  // in parallel, so several of its own payouts to that address are unconfirmed at once.
+
+  describe("BTC payout on timeout is taken from the order, never guessed from the address", () => {
+    /** A concurrent leg's payout to the same reused address, unconfirmed right now. */
+    const OTHER_LEGS_TX = { txid: "9c1d0b7e00000000000000000000000000000000000000000000000000000000", status: { confirmed: false } };
+    const OUR_PAYOUT_TXID = "48abaaf1000000000000000000000000000000000000000000000000000000ff";
+
+    it("reports the txid the order says it broadcast, not the first unconfirmed tx to the address", async () => {
+      const opts = await setupOfframp();
+
+      // The order tells us exactly which tx it broadcast for THIS order.
+      mockGetOrder.mockResolvedValue({
+        id: "order-btc-1",
+        status: { inProgress: { pendingBtcPayment: { txid: OUR_PAYOUT_TXID, amount: "74130" } } },
+      });
+      // Meanwhile another leg's payout to the same address is also unconfirmed. An address
+      // scan would pick this one and report someone else's tx as our payout.
+      mockGetAddressMempoolTxs.mockResolvedValue([OTHER_LEGS_TX]);
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const result = await handleSwap({ ...opts, timeout: 0.3 }, silentLogger, FAST);
+
+      expect(result.type).toBe("mempoolPending");
+      if (result.type !== "mempoolPending") return;
+      expect(result.data.mempoolTxId).toBe(OUR_PAYOUT_TXID);
+      expect(result.data.orderId).toBe("order-btc-1");
+      // The address heuristic is gone, not merely gated.
+      expect(mockGetAddressMempoolTxs).not.toHaveBeenCalled();
+    });
+
+    it("reports in_flight with no txid when no status was ever read", async () => {
+      const opts = await setupOfframp();
+
+      // Every read failed, so we know nothing about a payout — including whether one exists.
+      mockGetOrder.mockRejectedValue(
+        new Error("The request failed and the interceptors did not return an alternative response"),
+      );
+      mockGetAddressMempoolTxs.mockResolvedValue([OTHER_LEGS_TX]);
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const result = await handleSwap({ ...opts, timeout: 0.3 }, silentLogger, FAST);
+
+      // An order id that can be followed up beats a confident, wrong txid.
+      expect(result.type).toBe("inFlight");
+      if (result.type !== "inFlight") return;
+      expect(result.data.orderId).toBe("order-btc-1");
+      expect(result.data.txId).toBe("0xsettlementhash");
+      expect(result.data).not.toHaveProperty("mempoolTxId");
+      expect(mockGetAddressMempoolTxs).not.toHaveBeenCalled();
+    });
   });
 });

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Logger } from "../../src/output.js";
 import type { RouteInfo } from "@gobob/bob-sdk";
-import type { PollTimings } from "../../src/commands/swap.js";
 
 // ─── Mock fixtures ────────────────────────────────────────────────────────────
 
@@ -37,6 +36,7 @@ const mockExecuteQuote = vi.fn();
 const mockCreateOrder = vi.fn();
 const mockSignAllInputs = vi.fn();
 const mockGetAddressMempoolTxs = vi.fn();
+const mockWatchOrder = vi.fn();
 
 const mockBtcSigner = {
   signAllInputs: mockSignAllInputs,
@@ -64,6 +64,17 @@ vi.mock("../../src/config.js", () => ({
 
 vi.mock("../../src/util/route-provider.js", () => ({
   getRoutes: vi.fn(async () => mockRoutes),
+}));
+
+// The order's state machine belongs to the gateway, and observing it is the watcher's
+// job — tested for real, against real AbortSignals and a real backoff, in
+// tests/util/order-watcher.test.ts. What `handleSwap` owns is the MAPPING from the
+// outcome the watcher reports to what the CLI says: settled → confirmed, failed →
+// SwapError, in-flight-with-a-payout → mempool_pending, in-flight-without → in_flight.
+// So the watcher is mocked here and the mapping is what these tests assert. No timers,
+// no timings, no fake clocks — the command has no clock of its own to fake.
+vi.mock("../../src/util/order-watcher.js", () => ({
+  watchOrder: (...args: unknown[]) => mockWatchOrder(...args),
 }));
 
 // `parseAssetChain` must answer per-asset: the source and the destination are resolved
@@ -162,15 +173,6 @@ vi.mock("p-retry", () => ({
 
 const silentLogger: Logger = { progress: () => {}, warn: () => {} };
 
-/**
- * Poll timings compressed so the loop's REAL machinery — AbortSignal.timeout,
- * AbortSignal.any, the abortable sleep, the SDK's request cancellation — runs
- * unmocked and still finishes in milliseconds. Fake timers cannot drive
- * AbortSignal.timeout (it is not backed by the global timer), and faking the loop's
- * clock is exactly the thing these tests exist to prove the loop no longer depends on.
- */
-const FAST: PollTimings = { pollIntervalMs: 10, maxBackoffMs: 40, getOrderTimeoutMs: 50 };
-
 const baseOpts = {
   src: "BTC",
   dst: "USDC:base",
@@ -210,9 +212,10 @@ describe("handleSwap", () => {
     mockSignAllInputs.mockResolvedValue("signed-tx-hex-abc");
     mockGetOrder.mockResolvedValue(confirmedOrder);
     mockGetAddressMempoolTxs.mockResolvedValue([]);
+    mockWatchOrder.mockResolvedValue({ kind: "settled", order: confirmedOrder });
   });
 
-  it("full onramp BTC flow: quote → executeQuote → poll → confirmed", async () => {
+  it("full onramp BTC flow: quote → executeQuote → watch → confirmed", async () => {
     const { handleSwap } = await import("../../src/commands/swap.js");
     const result = await handleSwap(baseOpts, silentLogger);
 
@@ -228,11 +231,38 @@ describe("handleSwap", () => {
 
     expect(mockGetQuote).toHaveBeenCalledOnce();
     expect(mockExecuteQuote).toHaveBeenCalledOnce();
-    // Every read carries an abort signal, so no single read can outlive --timeout.
-    expect(mockGetOrder).toHaveBeenCalledWith("order-456", { signal: expect.any(AbortSignal) });
   });
 
-  it("--no-wait returns submitted without polling", async () => {
+  it("hands the watcher the order id and ONE signal carrying the whole --timeout budget", async () => {
+    // The command's entire contribution to the wait: name the order, and express the
+    // budget once, as a signal. There is no deadline to keep, nothing to clamp, and no
+    // timings to pass — those are the watcher's own.
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    await handleSwap(baseOpts, silentLogger);
+
+    expect(mockWatchOrder).toHaveBeenCalledWith(
+      "order-456",
+      expect.any(AbortSignal),
+      expect.objectContaining({ getOrder: expect.any(Function), log: silentLogger }),
+    );
+    const signal: AbortSignal = mockWatchOrder.mock.calls[0][1];
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("wires the watcher's getOrder to the SDK", async () => {
+    // Mocking the watcher would otherwise hide a dead wire: assert the dependency the
+    // command hands it actually reaches the SDK, signal and all.
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    await handleSwap(baseOpts, silentLogger);
+
+    const deps = mockWatchOrder.mock.calls[0][2];
+    const signal = AbortSignal.timeout(1000);
+    await deps.getOrder("order-456", { signal });
+
+    expect(mockGetOrder).toHaveBeenCalledWith("order-456", { signal });
+  });
+
+  it("--no-wait returns submitted without watching the order", async () => {
     const { handleSwap } = await import("../../src/commands/swap.js");
     const result = await handleSwap({ ...baseOpts, wait: false }, silentLogger);
 
@@ -243,6 +273,7 @@ describe("handleSwap", () => {
     expect(result.data.status).toBe("submitted");
     expect(result.data.txId).toBe("signed-tx-hex-abc");
 
+    expect(mockWatchOrder).not.toHaveBeenCalled();
     expect(mockGetOrder).not.toHaveBeenCalled();
   });
 
@@ -320,7 +351,7 @@ describe("handleSwap", () => {
 
     const tokenSwapOrder = { tokenSwap: { orderId: "order-789", tx: { to: "0xGatewayContract" } } };
     mockExecuteQuote.mockResolvedValue({ order: tokenSwapOrder, tx: "0xsettlementhash" });
-    mockGetOrder.mockResolvedValue({ id: "order-789", status: { failed: {} } });
+    mockWatchOrder.mockResolvedValue({ kind: "failed", order: { id: "order-789", status: { failed: {} } } });
 
     const { handleSwap } = await import("../../src/commands/swap.js");
     const { SwapError } = await import("../../src/errors.js");
@@ -460,43 +491,71 @@ describe("handleSwap", () => {
     expect(caught.message).not.toContain("bc1qsender");
   });
 
-  // ─── B1/B2/B3 — polling never reports a committed swap as failed ────────────
+  // ─── B1/B2/B3/B4 — mapping the order's outcome onto what the CLI says ───────
   //
   // Once executeQuote returns, the source funds are committed on-chain. The order status
   // is then the ONLY authority on whether the swap failed: an error while *reading* that
   // status says nothing about the swap. Reporting those reads as terminal failures
   // produced false "swap failed" alarms on swaps that had already succeeded — and, via
   // gateway-bot, false critical GitHub issues.
+  //
+  // That the watcher never confuses the two is proven against the real machinery in
+  // tests/util/order-watcher.test.ts. What is proven HERE is that the command believes
+  // it: a non-terminal outcome must come out as a non-failure, whatever went wrong
+  // behind it, and the order's `failed` must come out as a hard SwapError.
 
-  describe("polling never reports a committed swap as failed", () => {
-    it("a transient gateway 5xx while polling does not fail an already-settling swap", async () => {
-      // Incident (staging order cbf7296e-340a-438a-981c-75980fafc40c): get-order returned
-      // "bungee api error: status=504", yet the swap SUCCEEDED — 74,130 sats confirmed on
-      // Bitcoin in tx 48abaaf1…, block 957986. The CLI exited 1 and gateway-bot opened a
-      // false critical issue for a swap that worked.
-      mockGetOrder
-        .mockRejectedValueOnce(new Error("bungee api error: status=504 Gateway Timeout, message=error code: 504\n"))
-        .mockResolvedValue(confirmedOrder);
+  describe("outcome → result mapping", () => {
+    /** A concurrent leg's payout to the same reused BTC address, unconfirmed right now. */
+    const OTHER_LEGS_TX = { txid: "9c1d0b7e00000000000000000000000000000000000000000000000000000000", status: { confirmed: false } };
+    const OUR_PAYOUT_TXID = "48abaaf1000000000000000000000000000000000000000000000000000000ff";
+
+    it("settled → confirmed, with the delivered amount and the measured elapsed time", async () => {
+      mockWatchOrder.mockResolvedValue({ kind: "settled", order: confirmedOrder });
 
       const { handleSwap } = await import("../../src/commands/swap.js");
-      const result = await handleSwap({ ...baseOpts, timeout: 2 }, silentLogger, FAST);
+      const result = await handleSwap(baseOpts, silentLogger);
 
       expect(result.type).toBe("confirmed");
-      expect(mockGetOrder).toHaveBeenCalledTimes(2);
+      if (result.type !== "confirmed") return;
+      expect(result.data.dstAmount).toBe("4812300000");
+      expect(result.data.quotedDstAmount).toBe("4812300000");
+      expect(result.data.actualSlippageBps).toBe(0);
+      // Measurement only — reported, never obeyed.
+      expect(result.data.elapsedMs).toBeGreaterThanOrEqual(0);
     });
 
-    it("a generic fetch failure while polling reports in_flight, not failure", async () => {
-      // Incident (staging order a9a49f67-a2de-429f-bb44-2f32034a6f22): the SDK runtime threw
-      // its generic FetchError (underlying cause: a local Cloudflare 403) on every get-order.
-      // 44.6 USDC had already left the wallet; the order was `inProgress` and later settled
-      // fine. The CLI must not call that a failure — and must hand back the orderId + source
-      // tx so the in-flight funds can be followed up.
-      mockGetOrder.mockRejectedValue(
-        new Error("The request failed and the interceptors did not return an alternative response"),
-      );
+    it("failed → SwapError (the order's own verdict is the one terminal failure)", async () => {
+      mockWatchOrder.mockResolvedValue({ kind: "failed", order: { id: "order-456", status: { failed: {} } } });
 
       const { handleSwap } = await import("../../src/commands/swap.js");
-      const result = await handleSwap({ ...baseOpts, timeout: 0.3 }, silentLogger, FAST);
+      const { SwapError } = await import("../../src/errors.js");
+
+      await expect(handleSwap(baseOpts, silentLogger)).rejects.toThrow(SwapError);
+    });
+
+    it("refunded → SwapError, and the message carries the status for categorization", async () => {
+      mockWatchOrder.mockResolvedValue({ kind: "failed", order: { id: "order-456", status: { refunded: {} } } });
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const caught: any = await handleSwap(baseOpts, silentLogger).catch(e => e);
+
+      expect(caught.message).toContain("order-456 failed");
+      expect(caught.message).toContain("refunded");
+    });
+
+    it("inFlight after an unreadable status → in_flight, NOT a failure", async () => {
+      // Incident (staging order a9a49f67-a2de-429f-bb44-2f32034a6f22): every get-order threw
+      // the SDK's generic FetchError (underlying cause: a local Cloudflare 403). 44.6 USDC had
+      // already left the wallet; the order was `inProgress` and later settled fine. The CLI
+      // must not call that a failure — and must hand back the orderId + source tx so the
+      // in-flight funds can be followed up.
+      mockWatchOrder.mockResolvedValue({
+        kind: "inFlight",
+        lastError: "The request failed and the interceptors did not return an alternative response",
+      });
+
+      const { handleSwap } = await import("../../src/commands/swap.js");
+      const result = await handleSwap(baseOpts, silentLogger);
 
       expect(result.type).toBe("inFlight");
       if (result.type !== "inFlight") return;
@@ -504,18 +563,16 @@ describe("handleSwap", () => {
       expect(result.data.orderId).toBe("order-456");
       expect(result.data.txId).toBe("signed-tx-hex-abc");
       expect(result.data.lastError).toContain("interceptors did not return");
-      // Retried rather than bailing out on the first read error.
-      expect(mockGetOrder.mock.calls.length).toBeGreaterThan(1);
     });
 
-    it("an order still inProgress at --timeout reports in_flight, not failure", async () => {
-      // Previously the poll loop exhausted its retries and threw its internal "pending"
-      // sentinel, which surfaced as {"error":{"message":"pending"}} with exit 1 — a terminal
+    it("inFlight with a readable, still-settling order → in_flight with no lastError", async () => {
+      // Previously this exhausted the poll loop's retries and threw its internal "pending"
+      // sentinel, surfacing as {"error":{"message":"pending"}} with exit 1 — a terminal
       // failure for a swap that was simply still settling.
-      mockGetOrder.mockResolvedValue({ id: "order-456", status: { inProgress: {} } });
+      mockWatchOrder.mockResolvedValue({ kind: "inFlight" });
 
       const { handleSwap } = await import("../../src/commands/swap.js");
-      const result = await handleSwap({ ...baseOpts, timeout: 0.3 }, silentLogger, FAST);
+      const result = await handleSwap(baseOpts, silentLogger);
 
       expect(result.type).toBe("inFlight");
       if (result.type !== "inFlight") return;
@@ -523,127 +580,41 @@ describe("handleSwap", () => {
       expect(result.data.txId).toBe("signed-tx-hex-abc");
       // The status was readable throughout — nothing to report as a read error.
       expect(result.data.lastError).toBeUndefined();
-      expect(mockGetOrder.mock.calls.length).toBeGreaterThan(1);
     });
 
-    it("retrying read errors does not mask a genuine order failure", async () => {
-      // The order status stays the ONE authority on failure: surviving a transient read
-      // error must not make us swallow the `failed` status that follows it.
-      mockGetOrder
-        .mockRejectedValueOnce(new Error("bungee api error: status=504 Gateway Timeout"))
-        .mockResolvedValue({ id: "order-456", status: { failed: {} } });
-
-      const { handleSwap } = await import("../../src/commands/swap.js");
-      const { SwapError } = await import("../../src/errors.js");
-
-      await expect(
-        handleSwap({ ...baseOpts, timeout: 2 }, silentLogger, FAST),
-      ).rejects.toThrow(SwapError);
-    });
-
-    it("a stalled getOrder read is aborted, so the loop still ends at --timeout", async () => {
-      // B2: a stalled TCP connection — the server accepts the request and never answers. Like
-      // undici, the mock settles ONLY when its AbortSignal fires. Without a per-attempt signal
-      // the await never returns and --timeout is unenforceable; racing a timer instead would
-      // leak the socket. The read must be genuinely cancelled.
-      mockGetOrder.mockImplementation((_id: string, init?: { signal?: AbortSignal }) =>
-        new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => reject(init.signal!.reason));
-        }),
-      );
-
-      const { handleSwap } = await import("../../src/commands/swap.js");
-      const startedAt = Date.now();
-      const result = await handleSwap({ ...baseOpts, timeout: 0.3 }, silentLogger, FAST);
-      const elapsedMs = Date.now() - startedAt;
-
-      // Bounded by --timeout, and the unreadable status is in_flight — never a failure.
-      expect(result.type).toBe("inFlight");
-      expect(elapsedMs).toBeLessThan(3_000);
-      expect(mockGetOrder).toHaveBeenCalledWith("order-456", { signal: expect.any(AbortSignal) });
-      if (result.type !== "inFlight") return;
-      expect(result.data.lastError).toContain("timed out");
-    }, 10_000);
-
-    it("survives a clock that jumps past the deadline mid-iteration (no RangeError)", async () => {
-      // B3: the first attempt at B2 kept a `deadline` and derived the per-attempt budget from
-      // `deadline - Date.now()`, reading the clock separately from the loop guard. A stall
-      // between the two reads makes the window negative, and AbortSignal.timeout(negative)
-      // throws RangeError *synchronously* — outside the read's try — so a swap whose funds are
-      // already committed exits 1 as a hard failure. That is B1 reintroduced through the clock.
-      //
-      // There is no clock arithmetic left to break: the loop is driven by abort state alone, so
-      // it must survive a clock that lies. Date.now() may now only be *reported*, never obeyed.
-      const nowSpy = vi.spyOn(Date, "now");
-      try {
-        let call = 0;
-        nowSpy.mockImplementation(() => {
-          call++;
-          if (call === 1) return 1_000;  // startedAt
-          if (call === 2) return 1_100;  // still inside any plausible window
-          return 999_999_999;            // stalled: every later read is "past" any deadline
-        });
-        mockGetOrder.mockResolvedValue({ id: "order-456", status: { inProgress: {} } });
-
-        const { handleSwap } = await import("../../src/commands/swap.js");
-        const result = await handleSwap({ ...baseOpts, timeout: 0.3 }, silentLogger, FAST);
-
-        // Exits cleanly as in-flight rather than throwing RangeError — or "pending".
-        expect(result.type).toBe("inFlight");
-      } finally {
-        nowSpy.mockRestore();
-      }
-    });
-  });
-
-  // ─── B4 — the BTC payout on timeout comes from the order, never from the address ──
-  //
-  // The only sound source for this order's payout tx is the order's own
-  // `pendingBtcPayment`. Scanning the recipient address for an unconfirmed tx is not
-  // correlation: gateway-bot reuses ONE BTC address for every swap and runs offramp legs
-  // in parallel, so several of its own payouts to that address are unconfirmed at once.
-
-  describe("BTC payout on timeout is taken from the order, never guessed from the address", () => {
-    /** A concurrent leg's payout to the same reused address, unconfirmed right now. */
-    const OTHER_LEGS_TX = { txid: "9c1d0b7e00000000000000000000000000000000000000000000000000000000", status: { confirmed: false } };
-    const OUR_PAYOUT_TXID = "48abaaf1000000000000000000000000000000000000000000000000000000ff";
-
-    it("reports the txid the order says it broadcast, not the first unconfirmed tx to the address", async () => {
+    it("inFlight + payout txid → mempool_pending, reporting the txid the ORDER broadcast", async () => {
+      // The only sound source for this order's payout tx is the order's own
+      // `pendingBtcPayment`, which the watcher carries out as `payoutTxId`. Scanning the
+      // recipient address for an unconfirmed tx is not correlation: gateway-bot reuses ONE
+      // BTC address for every swap and runs offramp legs in parallel, so several of its own
+      // payouts to that address are unconfirmed at once — an address scan would report a
+      // concurrent leg's tx as this order's payout.
       const opts = await setupOfframp();
-
-      // The order tells us exactly which tx it broadcast for THIS order.
-      mockGetOrder.mockResolvedValue({
-        id: "order-btc-1",
-        status: { inProgress: { pendingBtcPayment: { txid: OUR_PAYOUT_TXID, amount: "74130" } } },
-      });
-      // Meanwhile another leg's payout to the same address is also unconfirmed. An address
-      // scan would pick this one and report someone else's tx as our payout.
+      mockWatchOrder.mockResolvedValue({ kind: "inFlight", payoutTxId: OUR_PAYOUT_TXID });
       mockGetAddressMempoolTxs.mockResolvedValue([OTHER_LEGS_TX]);
 
       const { handleSwap } = await import("../../src/commands/swap.js");
-      const result = await handleSwap({ ...opts, timeout: 0.3 }, silentLogger, FAST);
+      const result = await handleSwap(opts, silentLogger);
 
       expect(result.type).toBe("mempoolPending");
       if (result.type !== "mempoolPending") return;
       expect(result.data.mempoolTxId).toBe(OUR_PAYOUT_TXID);
       expect(result.data.orderId).toBe("order-btc-1");
-      // The address heuristic is gone, not merely gated.
+      // The address heuristic is gone, not merely gated: nothing in the swap path scans
+      // the destination address, and the watcher is handed no mempool client at all.
       expect(mockGetAddressMempoolTxs).not.toHaveBeenCalled();
     });
 
-    it("reports in_flight with no txid when no status was ever read", async () => {
+    it("inFlight with no payout txid → in_flight with no mempoolTxId, never a guessed one", async () => {
+      // No status was ever read, so we know nothing about a payout — including whether one
+      // exists. An order id that can be followed up beats a confident, wrong txid.
       const opts = await setupOfframp();
-
-      // Every read failed, so we know nothing about a payout — including whether one exists.
-      mockGetOrder.mockRejectedValue(
-        new Error("The request failed and the interceptors did not return an alternative response"),
-      );
+      mockWatchOrder.mockResolvedValue({ kind: "inFlight", lastError: "Cloudflare 403" });
       mockGetAddressMempoolTxs.mockResolvedValue([OTHER_LEGS_TX]);
 
       const { handleSwap } = await import("../../src/commands/swap.js");
-      const result = await handleSwap({ ...opts, timeout: 0.3 }, silentLogger, FAST);
+      const result = await handleSwap(opts, silentLogger);
 
-      // An order id that can be followed up beats a confident, wrong txid.
       expect(result.type).toBe("inFlight");
       if (result.type !== "inFlight") return;
       expect(result.data.orderId).toBe("order-btc-1");

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Logger } from "../../src/output.js";
 import type { RouteInfo } from "@gobob/bob-sdk";
 import type { PollTimings } from "../../src/commands/swap.js";
@@ -341,6 +341,125 @@ describe("handleSwap", () => {
     expect(caught.context.dstAsset).toEqual({ symbol: "USDC", chain: "base" });
   });
 
+  // ─── C1 / A4 — never retry a swap once the wallet has been asked to sign ────
+  //
+  // `executeQuote` is not idempotent: createOrder → sign + BROADCAST → registerTx.
+  // Re-running it after the broadcast sends the user's funds a SECOND time. The SDK
+  // fires its step callback immediately before it asks the wallet to sign, which is
+  // the signal these tests rely on. Reachable via `--retry` only (gateway-bot CI does
+  // not pass it), but `--retry` defaults to on for anyone running the CLI by hand.
+
+  it("does NOT retry executeQuote when a transient error is thrown AFTER the source tx was broadcast", async () => {
+    // Reproduced from the real incident: the solver returned 504 *after* the source funds
+    // had already left the wallet. "504 Gateway Timeout" matches /timeout/i in TRANSIENT,
+    // so the closure was re-entered → a second quote, a second order, a second broadcast.
+    // Six broadcasts (1 + retries: 5) from one 504.
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "send_transaction", totalSteps: 1 });
+      throw new Error("bungee api error: status=504 Gateway Timeout");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const { SwapError } = await import("../../src/errors.js");
+
+    const caught: any = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    // The funds-safety invariant: one broadcast, one attempt. Never two.
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+
+    expect(caught).toBeInstanceOf(SwapError);
+    // The operator must not be told "it failed, try again" while funds may be in flight.
+    expect(caught.message).toMatch(/do NOT re-run/i);
+    expect(caught.message).toContain("send_transaction");
+    // Original error text preserved as a substring so gateway-bot's categorization still matches.
+    expect(caught.message).toContain("504 Gateway Timeout");
+  });
+
+  it("does NOT retry after a BTC signature was requested, even on a transient error", async () => {
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "sign_bitcoin_transaction", totalSteps: 1 });
+      throw new Error("ECONNRESET");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const caught: any = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+    expect(caught.message).toMatch(/do NOT re-run/i);
+  });
+
+  it("does NOT retry after an ERC20 approve was signed (approve is a broadcast tx too)", async () => {
+    // An approve alone is not a double-send, but re-entering the closure while it is still
+    // pending races its own nonce — and the next step would broadcast the funds. The line
+    // is drawn at the FIRST wallet interaction of any kind.
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "approve", totalSteps: 2 });
+      throw new Error("rate limit exceeded");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const caught: any = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+    expect(caught.message).toContain("approve");
+  });
+
+  it("reports the FURTHEST step reached, not the first, when several steps fired", async () => {
+    // An EVM ERC20 swap fires approve → send_transaction. If the error names the first
+    // step, an operator reads "only the approve went out" and concludes it is safe to
+    // re-run — while the funds tx is already on-chain. That misreading is the exact
+    // double-send this fix exists to prevent, so the furthest step must win.
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "approve", totalSteps: 2 });
+      callback?.({ step: 2, type: "send_transaction", totalSteps: 2 });
+      throw new Error("registerTx failed: 503 Service Unavailable");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const caught: any = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+    expect(caught.message).toContain("send_transaction");
+    expect(caught.message).not.toContain("step: approve");
+  });
+
+  it("DOES still retry a transient error raised BEFORE anything was broadcast", async () => {
+    // The other half of the invariant: the fix must not disable retries wholesale.
+    // Nothing has been signed yet here, so re-quoting is free of side effects.
+    let quoteCalls = 0;
+    mockGetQuote.mockImplementation(async () => {
+      if (++quoteCalls === 1) throw new Error("429 Too Many Requests");
+      return onrampQuote;
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const result = await handleSwap({ ...baseOpts, retry: true }, silentLogger);
+
+    expect(result.type).toBe("confirmed");
+    expect(quoteCalls).toBe(2);
+    expect(mockExecuteQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the EVM owner, not the BTC sender, in the recovery hint on a BTC onramp", async () => {
+    // A4: `gateway-cli orders` rejects BTC addresses outright ("BTC address lookups are not
+    // supported"), and orders are indexed by the EVM-side owner anyway. Naming the BTC
+    // sender leaves the operator unable to check whether an order exists — at exactly the
+    // moment they are tempted to re-run, and double-send.
+    const { deriveAddress, resolveRecipient } = await import("../../src/chains/index.js");
+    vi.mocked(deriveAddress).mockResolvedValue("bc1qsender");
+    vi.mocked(resolveRecipient).mockResolvedValue("0xEvmOwner");
+    mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
+      callback?.({ step: 1, type: "sign_bitcoin_transaction", totalSteps: 1 });
+      throw new Error("ECONNRESET");
+    });
+
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    const caught: any = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
+
+    expect(caught.message).toContain("gateway-cli orders 0xEvmOwner");
+    expect(caught.message).not.toContain("bc1qsender");
+  });
+
   // ─── B1/B2/B3 — polling never reports a committed swap as failed ────────────
   //
   // Once executeQuote returns, the source funds are committed on-chain. The order status
@@ -460,9 +579,9 @@ describe("handleSwap", () => {
         let call = 0;
         nowSpy.mockImplementation(() => {
           call++;
-          if (call === 1) return 1_000;
-          if (call === 2) return 1_500;
-          return 999_999_999; // stalled: every later read is "past" any deadline
+          if (call === 1) return 1_000;  // startedAt
+          if (call === 2) return 1_100;  // still inside any plausible window
+          return 999_999_999;            // stalled: every later read is "past" any deadline
         });
         mockGetOrder.mockResolvedValue({ id: "order-456", status: { inProgress: {} } });
 

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -103,6 +103,7 @@ vi.mock("../../src/util/price-oracle.js", () => ({
 }));
 
 vi.mock("../../src/chains/index.js", () => ({
+  validateAddressFamily: vi.fn(),
   getChainFamily: vi.fn((chain: string) => chain === "bitcoin" ? "bitcoin" : "evm"),
   deriveAddress: vi.fn().mockResolvedValue("bc1qtest"),
   resolveSigner: vi.fn().mockResolvedValue({ address: "bc1qtest", signer: mockBtcSigner }),
@@ -111,7 +112,7 @@ vi.mock("../../src/chains/index.js", () => ({
     onramp: { orderId, bitcoinTxHex: txId },
   })),
   resolvePrivateKey: vi.fn((chain: string, privateKey?: string) => privateKey),
-  resolveRecipient: vi.fn().mockResolvedValue("0xEvmRecipient"),
+  resolveRecipient: vi.fn().mockResolvedValue("0x4444444444444444444444444444444444444444"),
 }));
 
 vi.mock("@gobob/bob-sdk", () => ({
@@ -177,7 +178,7 @@ const baseOpts = {
   src: "BTC",
   dst: "USDC:base",
   amount: "5000000",
-  recipient: "0xABC",
+  recipient: "0x1111111111111111111111111111111111111111",
   unsigned: false,
   wait: true,
   retry: true,
@@ -188,8 +189,8 @@ const baseOpts = {
 async function setupOfframp() {
   const { resolveSigner, deriveAddress, resolveRecipient } = await import("../../src/chains/index.js");
   const publicClient = { getTransactionCount: vi.fn().mockResolvedValue(0) } as any;
-  vi.mocked(resolveSigner).mockResolvedValue({ address: "0xSender", walletClient: {} as any, publicClient } as any);
-  vi.mocked(deriveAddress).mockResolvedValue("0xSender");
+  vi.mocked(resolveSigner).mockResolvedValue({ address: "0x2222222222222222222222222222222222222222", walletClient: {} as any, publicClient } as any);
+  vi.mocked(deriveAddress).mockResolvedValue("0x2222222222222222222222222222222222222222");
   vi.mocked(resolveRecipient).mockResolvedValue("bc1qshared");
 
   mockExecuteQuote.mockResolvedValue({
@@ -345,9 +346,9 @@ describe("handleSwap", () => {
     // EVM signed path uses { walletClient, publicClient }; the pending-nonce check
     // calls publicClient.getTransactionCount (latest >= pending → settled).
     const publicClient = { getTransactionCount: vi.fn().mockResolvedValue(0) } as any;
-    vi.mocked(resolveSigner).mockResolvedValue({ address: "0xSender", walletClient: {} as any, publicClient } as any);
-    vi.mocked(deriveAddress).mockResolvedValue("0xSender");
-    vi.mocked(resolveRecipient).mockResolvedValue("0xRecipient");
+    vi.mocked(resolveSigner).mockResolvedValue({ address: "0x2222222222222222222222222222222222222222", walletClient: {} as any, publicClient } as any);
+    vi.mocked(deriveAddress).mockResolvedValue("0x2222222222222222222222222222222222222222");
+    vi.mocked(resolveRecipient).mockResolvedValue("0x1111111111111111111111111111111111111111");
 
     const tokenSwapOrder = { tokenSwap: { orderId: "order-789", tx: { to: "0xGatewayContract" } } };
     mockExecuteQuote.mockResolvedValue({ order: tokenSwapOrder, tx: "0xsettlementhash" });
@@ -478,7 +479,7 @@ describe("handleSwap", () => {
     // moment they are tempted to re-run, and double-send.
     const { deriveAddress, resolveRecipient } = await import("../../src/chains/index.js");
     vi.mocked(deriveAddress).mockResolvedValue("bc1qsender");
-    vi.mocked(resolveRecipient).mockResolvedValue("0xEvmOwner");
+    vi.mocked(resolveRecipient).mockResolvedValue("0x3333333333333333333333333333333333333333");
     mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
       callback?.({ step: 1, type: "sign_bitcoin_transaction", totalSteps: 1 });
       throw new Error("ECONNRESET");
@@ -487,7 +488,7 @@ describe("handleSwap", () => {
     const { handleSwap } = await import("../../src/commands/swap.js");
     const caught: any = await handleSwap({ ...baseOpts, retry: true }, silentLogger).catch(e => e);
 
-    expect(caught.message).toContain("gateway-cli orders 0xEvmOwner");
+    expect(caught.message).toContain("gateway-cli orders 0x3333333333333333333333333333333333333333");
     expect(caught.message).not.toContain("bc1qsender");
   });
 

--- a/gateway-cli/tests/util/order-watcher.test.ts
+++ b/gateway-cli/tests/util/order-watcher.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi } from "vitest";
+import { watchOrder, type PollTimings } from "../../src/util/order-watcher.js";
+import type { Logger } from "../../src/output.js";
+
+// ─── The machinery under test ────────────────────────────────────────────────
+//
+// A swap is an async process whose state the GATEWAY owns: inProgress → success |
+// failed | refunded. `watchOrder` is the machinery for observing that state machine,
+// and these tests exercise it unmocked: real AbortSignal.timeout, real AbortSignal.any,
+// real request cancellation, real backoff. Nothing here is faked but the gateway.
+//
+// Once the source funds are committed, the order status is the ONLY authority on
+// whether the swap failed. Every test below is a case where a *read* went wrong and the
+// watcher must NOT turn that into a failure — each one corresponds to a real incident
+// in which the CLI exited 1 and gateway-bot opened a false critical issue for a swap
+// that had, in fact, worked.
+
+const silentLogger: Logger = { progress: () => {}, warn: () => {} };
+
+/**
+ * Timings compressed so the REAL machinery runs and still finishes in milliseconds.
+ * These are a legitimate parameter of the component under test — not a seam punched
+ * through some other component's signature. Fake timers cannot drive
+ * AbortSignal.timeout (it is not backed by the global timer), and faking the loop's
+ * clock is exactly the thing these tests exist to prove the loop no longer depends on.
+ */
+const FAST: PollTimings = { pollIntervalMs: 10, maxBackoffMs: 40, getOrderTimeoutMs: 50 };
+
+const ORDER_ID = "order-456";
+
+const successOrder = { id: ORDER_ID, status: { success: {} }, dstInfo: { amount: "4812300000" } } as any;
+const inProgressOrder = { id: ORDER_ID, status: { inProgress: {} } } as any;
+
+/** Watch with the real machinery, a real overall budget, and a stub gateway. */
+const watch = (getOrder: any, timeoutMs = 300, timings: PollTimings = FAST) =>
+  watchOrder(ORDER_ID, AbortSignal.timeout(timeoutMs), { getOrder, log: silentLogger }, timings);
+
+describe("watchOrder", () => {
+  // ─── Terminal states ───────────────────────────────────────────────────────
+
+  it("returns settled when the order reaches success", async () => {
+    const getOrder = vi.fn().mockResolvedValue(successOrder);
+
+    const outcome = await watch(getOrder, 2_000);
+
+    expect(outcome.kind).toBe("settled");
+    if (outcome.kind !== "settled") return;
+    expect(outcome.order.dstInfo?.amount).toBe("4812300000");
+    // Every read carries an abort signal, so no single read can outlive the budget.
+    expect(getOrder).toHaveBeenCalledWith(ORDER_ID, { signal: expect.any(AbortSignal) });
+  });
+
+  it("returns failed when the order declares `failed`", async () => {
+    const outcome = await watch(vi.fn().mockResolvedValue({ id: ORDER_ID, status: { failed: {} } }), 2_000);
+    expect(outcome.kind).toBe("failed");
+  });
+
+  it("returns failed when the order declares `refunded`", async () => {
+    const outcome = await watch(vi.fn().mockResolvedValue({ id: ORDER_ID, status: { refunded: {} } }), 2_000);
+    expect(outcome.kind).toBe("failed");
+  });
+
+  // ─── A failed READ is never a failed SWAP ──────────────────────────────────
+
+  it("a transient gateway 5xx while polling does not fail an already-settling swap", async () => {
+    // Incident (staging order cbf7296e-340a-438a-981c-75980fafc40c): get-order returned
+    // "bungee api error: status=504", yet the swap SUCCEEDED — 74,130 sats confirmed on
+    // Bitcoin in tx 48abaaf1…, block 957986. The CLI exited 1 and gateway-bot opened a
+    // false critical issue for a swap that worked.
+    const getOrder = vi.fn()
+      .mockRejectedValueOnce(new Error("bungee api error: status=504 Gateway Timeout, message=error code: 504\n"))
+      .mockResolvedValue(successOrder);
+
+    const outcome = await watch(getOrder, 2_000);
+
+    expect(outcome.kind).toBe("settled");
+    expect(getOrder).toHaveBeenCalledTimes(2);
+  });
+
+  it("a generic fetch failure while polling reports inFlight, not failure", async () => {
+    // Incident (staging order a9a49f67-a2de-429f-bb44-2f32034a6f22): the SDK runtime threw
+    // its generic FetchError (underlying cause: a local Cloudflare 403) on every get-order.
+    // 44.6 USDC had already left the wallet; the order was `inProgress` and later settled
+    // fine. An unreadable status is not a failed swap — it is a swap we cannot see.
+    const getOrder = vi.fn().mockRejectedValue(
+      new Error("The request failed and the interceptors did not return an alternative response"),
+    );
+
+    const outcome = await watch(getOrder);
+
+    expect(outcome.kind).toBe("inFlight");
+    if (outcome.kind !== "inFlight") return;
+    expect(outcome.lastError).toContain("interceptors did not return");
+    // Retried rather than bailing out on the first read error.
+    expect(getOrder.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("retrying read errors does not mask a genuine order failure", async () => {
+    // The order status stays the ONE authority on failure: surviving a transient read
+    // error must not make us swallow the `failed` status that follows it.
+    const getOrder = vi.fn()
+      .mockRejectedValueOnce(new Error("bungee api error: status=504 Gateway Timeout"))
+      .mockResolvedValue({ id: ORDER_ID, status: { failed: {} } });
+
+    const outcome = await watch(getOrder, 2_000);
+
+    expect(outcome.kind).toBe("failed");
+  });
+
+  it("backs off between consecutive read failures instead of hammering the API", async () => {
+    // A gateway that is failing reads is usually a gateway under strain — retrying at the
+    // plain poll interval hammers it. Consecutive failures back off exponentially from
+    // pollIntervalMs (10 → 20 → 40), capped at maxBackoffMs (40).
+    //
+    // The gaps must GROW: with the backoff removed every gap would sit at the 10ms poll
+    // interval, so the assertions below are written to fail in that case rather than to
+    // be satisfied by timer jitter.
+    const at: number[] = [];
+    const getOrder = vi.fn().mockImplementation(async () => {
+      at.push(Date.now());
+      throw new Error("bungee api error: status=504");
+    });
+
+    const outcome = await watch(getOrder, 300);
+
+    expect(outcome.kind).toBe("inFlight");
+    const gaps = at.slice(1).map((t, i) => t - at[i]!);
+    expect(gaps.length).toBeGreaterThanOrEqual(3);
+    // 1st retry waits ~10ms (the plain interval); by the 3rd it waits ~40ms — a delay a
+    // flat 10ms interval could never produce.
+    expect(gaps[0]!).toBeLessThan(20);
+    expect(gaps[2]!).toBeGreaterThanOrEqual(30);
+  });
+
+  // ─── The budget is a signal; nothing does clock arithmetic ─────────────────
+
+  it("an order still inProgress at the end of the budget is inFlight, not failed", async () => {
+    // Previously the poll loop exhausted its retries and threw its internal "pending"
+    // sentinel, which surfaced as {"error":{"message":"pending"}} with exit 1 — a terminal
+    // failure for a swap that was simply still settling.
+    const getOrder = vi.fn().mockResolvedValue(inProgressOrder);
+
+    const outcome = await watch(getOrder);
+
+    expect(outcome.kind).toBe("inFlight");
+    if (outcome.kind !== "inFlight") return;
+    // The status was readable throughout — nothing to report as a read error.
+    expect(outcome.lastError).toBeUndefined();
+    expect(outcome.payoutTxId).toBeUndefined();
+    expect(getOrder.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("a stalled getOrder read is aborted, so the watch still ends at the budget", async () => {
+    // A stalled TCP connection — the server accepts the request and never answers. Like
+    // undici, the stub settles ONLY when its AbortSignal fires. Without a per-read signal
+    // the await never returns and the budget is unenforceable; racing a timer instead
+    // would leak the socket. The read must be genuinely cancelled.
+    const getOrder = vi.fn().mockImplementation((_id: string, init?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal!.reason));
+      }),
+    );
+
+    const startedAt = Date.now();
+    const outcome = await watch(getOrder, 300);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(outcome.kind).toBe("inFlight");
+    expect(elapsedMs).toBeLessThan(3_000);
+    if (outcome.kind !== "inFlight") return;
+    expect(outcome.lastError).toContain("timed out");
+    // Every read was cancelled by its own budget, so the loop kept trying.
+    expect(getOrder.mock.calls.length).toBeGreaterThan(1);
+  }, 10_000);
+
+  it("the per-read budget cancels the request itself, it does not merely stop waiting", async () => {
+    // The signal handed to getOrder must actually abort: the SDK spreads initOverrides
+    // into fetch, so an aborted signal cancels the HTTP request and frees the socket.
+    let observed: AbortSignal | undefined;
+    const getOrder = vi.fn().mockImplementation((_id: string, init?: { signal?: AbortSignal }) => {
+      observed = init?.signal;
+      return new Promise((_r, reject) => init?.signal?.addEventListener("abort", () => reject(init.signal!.reason)));
+    });
+
+    await watchOrder(ORDER_ID, AbortSignal.timeout(300), { getOrder, log: silentLogger },
+      { ...FAST, getOrderTimeoutMs: 20 });
+
+    expect(observed?.aborted).toBe(true);
+  });
+
+  it("survives a clock that jumps past any plausible deadline (no RangeError)", async () => {
+    // An earlier fix kept a `deadline` and derived the per-read budget from
+    // `deadline - Date.now()`, reading the clock separately from the loop guard. A stall
+    // between the two reads makes the window negative, and AbortSignal.timeout(negative)
+    // throws RangeError *synchronously* — outside the read's try — so a swap whose funds
+    // are already committed exits 1 as a hard failure.
+    //
+    // There is no clock arithmetic left to break: the loop is driven by abort state
+    // alone, so it must survive a clock that lies. Date.now() may only be *reported*.
+    const nowSpy = vi.spyOn(Date, "now");
+    try {
+      let call = 0;
+      nowSpy.mockImplementation(() => {
+        call++;
+        if (call === 1) return 1_000;
+        if (call === 2) return 1_100;
+        return 999_999_999; // stalled: every later read is "past" any deadline
+      });
+
+      const outcome = await watch(vi.fn().mockResolvedValue(inProgressOrder));
+
+      expect(outcome.kind).toBe("inFlight");
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  // ─── The BTC payout comes from the ORDER, never from the address ───────────
+  //
+  // The only sound source for this order's payout tx is the order's own
+  // `pendingBtcPayment`. Scanning the recipient address for an unconfirmed tx is not
+  // correlation: gateway-bot reuses ONE BTC address for every swap and runs offramp legs
+  // in parallel, so several of its own payouts to that address are unconfirmed at once.
+  // The watcher is given no mempool client at all, so it *cannot* guess.
+
+  it("captures the payout txid the order says it broadcast", async () => {
+    const OUR_PAYOUT_TXID = "48abaaf1000000000000000000000000000000000000000000000000000000ff";
+    const getOrder = vi.fn().mockResolvedValue({
+      id: ORDER_ID,
+      status: { inProgress: { pendingBtcPayment: { txid: OUR_PAYOUT_TXID, amount: "74130" } } },
+    });
+
+    const outcome = await watch(getOrder);
+
+    expect(outcome.kind).toBe("inFlight");
+    if (outcome.kind !== "inFlight") return;
+    expect(outcome.payoutTxId).toBe(OUR_PAYOUT_TXID);
+  });
+
+  it("reports no payout txid when no status was ever read", async () => {
+    // Every read failed, so we know nothing about a payout — including whether one exists.
+    // An order id that can be followed up beats a confident, wrong txid.
+    const getOrder = vi.fn().mockRejectedValue(new Error("Cloudflare 403"));
+
+    const outcome = await watch(getOrder);
+
+    expect(outcome.kind).toBe("inFlight");
+    if (outcome.kind !== "inFlight") return;
+    expect(outcome.payoutTxId).toBeUndefined();
+    expect(outcome.lastError).toContain("403");
+  });
+
+  it("keeps the payout txid the order reported even if later reads fail", async () => {
+    // The gateway broadcast the payout and then went dark. The txid is still this
+    // order's payout — a read failure does not un-broadcast a transaction.
+    const OUR_PAYOUT_TXID = "48abaaf1000000000000000000000000000000000000000000000000000000ff";
+    const getOrder = vi.fn()
+      .mockResolvedValueOnce({
+        id: ORDER_ID,
+        status: { inProgress: { pendingBtcPayment: { txid: OUR_PAYOUT_TXID } } },
+      })
+      .mockRejectedValue(new Error("bungee api error: status=504"));
+
+    const outcome = await watch(getOrder);
+
+    expect(outcome.kind).toBe("inFlight");
+    if (outcome.kind !== "inFlight") return;
+    expect(outcome.payoutTxId).toBe(OUR_PAYOUT_TXID);
+    expect(outcome.lastError).toContain("504");
+  });
+
+  // ─── The caller's budget is the only deadline ──────────────────────────────
+
+  it("returns immediately when the caller's signal is already aborted", async () => {
+    const getOrder = vi.fn().mockResolvedValue(successOrder);
+
+    const outcome = await watchOrder(ORDER_ID, AbortSignal.abort(), { getOrder, log: silentLogger }, FAST);
+
+    expect(outcome.kind).toBe("inFlight");
+    expect(getOrder).not.toHaveBeenCalled();
+  });
+});

--- a/gateway-cli/tests/util/swap-context.test.ts
+++ b/gateway-cli/tests/util/swap-context.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { resolveOwnerAddress } from "../../src/util/swap-context.js";
+
+const EVM = "0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb";
+const BTC = "bc1q4xdatls497ea76fmuefu9we4ld4yu2vy8hedne";
+
+// `ownerAddress` is the EVM address that controls the order. The gateway rejects anything
+// else outright ("Invalid Ethereum address: Expected an EVM address but found a Bitcoin
+// address"), so the value must be an EVM address whatever route it arrived by.
+//
+// The subtlety: the family of `--sender` / `--recipient` cannot be pinned by the CLI schema,
+// because it depends on the swap's direction — a Bitcoin `--sender` is CORRECT on a BTC
+// onramp (it builds the PSBT). So the check can only live here, where the source chain is
+// known. That makes resolveOwnerAddress the sole place the invariant can be enforced, and it
+// must verify rather than assume.
+describe("resolveOwnerAddress", () => {
+  it("uses the recipient on a BTC→EVM onramp", () => {
+    expect(resolveOwnerAddress({
+      srcFamily: "bitcoin", dstFamily: "evm", recipient: EVM, senderAddress: BTC,
+    })).toBe(EVM);
+  });
+
+  it("accepts a Bitcoin sender on a BTC onramp — it is the PSBT's input, not the owner", () => {
+    // Guards the fix direction: family-refining `--sender` at the schema would break this.
+    expect(resolveOwnerAddress({
+      srcFamily: "bitcoin", dstFamily: "evm", recipient: EVM, senderAddress: BTC,
+    })).toBe(EVM);
+  });
+
+  it("uses the sender on an EVM→BTC offramp", () => {
+    expect(resolveOwnerAddress({
+      srcFamily: "evm", dstFamily: "bitcoin", recipient: BTC, senderAddress: EVM,
+    })).toBe(EVM);
+  });
+
+  it("prefers an explicit --owner", () => {
+    expect(resolveOwnerAddress({
+      explicit: EVM, srcFamily: "evm", dstFamily: "bitcoin", recipient: BTC, senderAddress: EVM,
+    })).toBe(EVM);
+  });
+
+  it("rejects a Bitcoin --sender on an EVM-source swap instead of sending it as the owner", () => {
+    // Reachable on the unsigned path, where no key is derived and no sender/key mismatch
+    // check runs: the BTC address would otherwise reach the gateway as `ownerAddress`.
+    expect(() => resolveOwnerAddress({
+      srcFamily: "evm", dstFamily: "bitcoin", recipient: BTC, senderAddress: BTC,
+    })).toThrow(/owner must be an EVM address.*--sender/s);
+  });
+
+  it("rejects a Bitcoin --recipient on an onramp instead of sending it as the owner", () => {
+    expect(() => resolveOwnerAddress({
+      srcFamily: "bitcoin", dstFamily: "evm", recipient: BTC,
+    })).toThrow(/owner must be an EVM address.*--recipient/s);
+  });
+
+  it("fails actionably when no EVM address can be determined at all", () => {
+    expect(() => resolveOwnerAddress({
+      srcFamily: "evm", dstFamily: "bitcoin", recipient: BTC,
+    })).toThrow(/Could not determine the EVM owner address/);
+  });
+});


### PR DESCRIPTION
## Why this PR exists

Three PRs — #1119, #1120, #1121 — each fixed one bug in `gateway-cli`. Two consecutive rounds of review then found a **new P1 inside each round's own fix**. That is not bad luck. The bugs share generators:

- **Root cause A** — `handleQuote` and `handleSwap` are two parallel implementations of the same pipeline (routes → source family → key → sender → inputs → recipient → owner → quote params). Every A-bug is a divergence between the two copies, or a value already computed being re-derived by hand at a call site.
- **Root cause B** — the poll loop conflates *"the swap failed"* with *"I could not read the swap's status"*, and hand-maintains a deadline with raw clock arithmetic in an async context.
- **Root cause C** — a non-idempotent operation (sign + broadcast) is wrapped in a retry.

Patching the instances is what produced the ping-pong. This PR removes the generators, so the whole class becomes unrepresentable. **#1119, #1120 and #1121 are superseded and should be closed in favour of this one.**

Three reviewable commits, one per root cause, plus a self-review follow-up.

---

## Root cause A — one swap context (`028f1ce`)

`quote` and `swap` now both consume a single `resolveSwapContext()`. The source is resolved ONLY through `parseAssetChain`; `ownerAddress` has exactly one definition and can never be a Bitcoin address; key derivation is expressed once, as a dependency ("who needs the sender, and when"), so a key nothing needs is never touched.

| Bug | Evidence |
|---|---|
| **A1 (P1)** `quote` sent the **Bitcoin** address as `ownerAddress` on every EVM→BTC offramp | Verified against staging: `INVALID_REQUEST: Invalid Ethereum address: Expected an EVM address but found a Bitcoin address`. `quote` derived the sender only for `--amount ALL`, so it was `undefined` and `ownerAddress` fell back to the recipient. `swap` derived it unconditionally — the divergence hid the bug. `ownerAddress` is also mandatory (omitting it → `MISSING_OWNER_ADDRESS`), so "don't send it" was never an option. |
| **A2 (P2)** `quote` re-parsed `--src` with an ad-hoc string heuristic | A bare symbol (`--src USDT`) was classified as EVM and a key was touched *before* the asset was validated: a malformed `EVM_PRIVATE_KEY` surfaced as `Failed to derive sender address` instead of `chain required for token "USDT"`. The same heuristic read the family case-sensitively (`--src Btc` → an EVM chain). |
| **A3 (P1)** deriving the EVM sender for *any* EVM source broke `--owner 0x…` with a malformed key | The derived sender is not used at all when `--owner` is given, yet the derivation failure aborted the quote. |
| **A4 (P1)** the point-of-no-return recovery message named `senderAddress` | On a BTC onramp that is a `bc1q…` address, and `handleOrders` rejects BTC addresses outright (`BTC address lookups are not supported`). Orders are indexed by the EVM-side owner anyway — so the one reconciliation step the message recommended was unexecutable exactly where it is needed most. It now uses `ctx.ownerAddress`; nothing re-derives the conditional at a call site. |

`resolveSwapInputs` (which re-parsed both assets internally) is replaced by `resolveAmount`, which takes the already-resolved source asset — so a swap's source is parsed once, in one place.

## Root cause B — signal-driven polling (`0b7ae23`)

**The clock was the bug.** There is no `deadline` variable, no `Date.now()` in any control-flow decision, no remaining-time subtraction and nothing to clamp. The timeout is expressed once, as a signal:

- one `AbortSignal.timeout(timeoutMs)` for the whole operation; the loop is driven by `while (!overall.aborted)`;
- each read is bounded by `AbortSignal.any([overall, AbortSignal.timeout(GET_ORDER_TIMEOUT_MS)])`, passed to `sdk.getOrder(id, { signal })`. The SDK runtime spreads `initOverrides` into the fetch init, so this genuinely **cancels** the request — not `Promise.race`, which leaks a socket per attempt;
- the backoff sleep ends early when the overall signal fires.

One `startedAt` survives, purely to report `elapsedMs`. It gates nothing.

| Bug | Evidence |
|---|---|
| **B1 (P1)** any error while *reading* order status was reported as a terminal swap failure | Order `cbf7296e-340a-438a-981c-75980fafc40c`: CLI exited 1 with `bungee api error: status=504 Gateway Timeout`. The swap **succeeded** — 74,130 sats confirmed on Bitcoin (`48abaaf1…`, block 957986).<br><br>Order `a9a49f67-a2de-429f-bb44-2f32034a6f22`: CLI exited 1 with `The request failed and the interceptors did not return an alternative response` (a local Cloudflare 403). 44.6 USDC had already left the wallet; the order was `inProgress` and later settled fine.<br><br>Mechanism: the retry predicate was `e.message === "pending"` — it matched only its own sentinel, so every `getOrder` error became terminal. A merely slow swap also exited 1, with `{"error":{"message":"pending"}}`. `gateway-bot` pipes this into `alert.ts`, so each one opened a false **critical** GitHub issue. |
| **B2 (P2)** `getOrder` had no per-attempt timeout | A stalled connection held the await open past `--timeout`, making the deadline contract unenforceable. |
| **B3 (P1)** clock arithmetic re-introduces B1 | `Math.min(GET_ORDER_TIMEOUT_MS, deadline - Date.now())` next to a separate `while (Date.now() < deadline)` guard reads the clock twice; a stall between them makes the delay negative and `AbortSignal.timeout` throws `RangeError` **synchronously**, outside the read's try-block. Reproduced verbatim: `RangeError: The value of "delay" is out of range … Received -999998699`. With no subtraction, this cannot exist. |
| **B4 (P2)** the BTC payout txid was the first unconfirmed tx to the *recipient address* | `gateway-bot` reuses ONE BTC address across all swaps and runs parallel legs, so two of its own offramps can have overlapping unconfirmed payouts and the CLI would confidently name the wrong txid. The txid now comes from the order's own `inProgress.pendingBtcPayment.txid`. The address scan is **deleted**, not gated — the correlation itself was unsound. With no payout observed we report in-flight rather than fabricate one. |

The order status is now the only authority on failure: terminal failure is raised from exactly one place — the order reporting `failed`/`refunded`. New non-failure exit state `in_flight` (exit 0) carries `orderId`, source `txId` and the last read error. **Additive**: the `--json` shapes `alert.ts` already parses (`SwapSuccessJson` / `SwapSubmittedJson` / `SwapMempoolPendingJson`) are unchanged.

## Root cause C — no retry past the point of no return (`2229d18`)

`withRetry(async () => { getQuote; executeQuote(...) })` wrapped a non-idempotent operation: `executeQuote` internally runs createOrder → approve → **sign and broadcast** → registerTx. If it throws *after* broadcasting (a `registerTx` 5xx, or anything matching the `TRANSIENT` list — which includes `/timeout/i`), the retry re-quotes, re-orders and broadcasts a **second transaction**. Reproduced: 6 broadcasts (1 + `retries: 5`) from a single `504 Gateway Timeout`.

No SDK change needed: `executeQuote` accepts a `callback` and fires `ResetApproval` / `Approve` / `SendTransaction` / `SignBitcoinTransaction` immediately BEFORE the corresponding `writeContract` / `sendBitcoin` / `signAllInputs`.

- A `RetryGuard` latches on the **first wallet interaction of any kind**, including `Approve` — an approve is itself a signed, broadcast tx, and re-entering the closure races its own nonce.
- The latch is created and consulted **inside `withRetry`**, *before* the transient predicate. A caller can arm it but cannot forget to consult it — "retried past an irreversible step" is unrepresentable rather than merely unlikely. Authority comes from the latch and the order status, never from parsing error text (the SDK discards the HTTP status; that is exactly why a `504` matched `/timeout/i` and re-sent).
- The latch is monotonic and the **last** reason wins, so the error names the **furthest** step reached. On an EVM ERC20 swap the steps are `approve` → `send_transaction`; naming `approve` when the funds tx is already on-chain would tell an operator it is safe to re-run — causing the very double-send this prevents.
- The original error text is preserved as a substring so `gateway-bot`'s `alert.ts` categorisation keeps matching.

### Reachability — correcting the brief I was given

I was told C1 was reachable via `--retry` only, and that `gateway-bot` CI does not pass it, so scheduled runs were not exposed. **That is wrong, and it is worth stating plainly.**

There is no `--retry` flag. `src/cli.ts` declares `.option("--no-retry", …)`, so commander defaults `retry` to **`true`**, and `swapSchema` re-affirms `retry: z.boolean().default(true)`. `retries = opts.retry ? 5 : 0` therefore evaluates to **5 by default**. Neither `gateway-bot-volume.yml` nor `gateway-bot-api-testing.yml` passes `--no-retry`.

So the scheduled volume bot — currently running **$1,500 per leg** — was exposed to the double-send on every transient error thrown after broadcast, not protected from it.

### Accepted cost, stated rather than hidden

The latch arms when the wallet is *asked* to sign, which is before viem prepares the transaction. A transient RPC failure during gas estimation or nonce fetch therefore also stops retrying. Over-warning costs one manual check; under-warning costs the funds. The message does **not** assert that funds *were* sent — it says a signature was requested and whether it reached the chain is unknown. SDK follow-up to narrow that window: #1122.

## Self-review follow-ups (`af57ec2`)

Found by running the ducklings review methodology on my own branch:

- **`--timeout` had no upper bound.** The poll timeout becomes an `AbortSignal.timeout(timeoutMs)` created *after* the source tx is broadcast, and `AbortSignal.timeout` throws `RangeError` synchronously above 2^32-1 ms — so `--timeout 99999999` would report an already-committed swap as a hard failure. That is B3's failure shape, just moved to the input. Now rejected at the boundary (max 24h), where nothing has been sent yet.
- **The README claimed transient errors are "automatically retried on quote and registration steps."** Retrying the registration step *is* the double-send. Corrected, and the point of no return / in-flight state / read-failure semantics are now documented.

---

## Tests

Every bug A1–A4, B1–B4, C1 has a test that **provably fails without its fix** — verified by reverting each source change individually and re-running, not merely by asserting the test passes. `pnpm install && pnpm build && pnpm test` → **135 tests, 18 files, all green**.

Highlights:

- B3's test reproduces the exact `RangeError … Received -999998699` when the deadline arithmetic is put back.
- B2's test models a stalled TCP connection (settles only on abort, like undici): without a per-attempt signal it never returns and the test times out — which is the bug.
- The B/B4 tests run the **real** `AbortSignal.timeout` / `AbortSignal.any` / abortable-sleep machinery on compressed timings, rather than faking the clock the loop is no longer allowed to depend on.
- C1 is covered from both sides: a transient error *after* broadcast must not retry, and a transient error *before* it still must.
- The tests cite the real staging order ids and on-chain txids in comments — that is the evidence, and it should stay.

## Behaviour changes worth confirming

- A keyless `quote` of an EVM→EVM tokenSwap that previously fell back to the recipient as `ownerAddress` now errors with an actionable message (`--owner` / `--sender` / `EVM_PRIVATE_KEY`). The recipient is not the order's owner, and letting it stand in is the same class of mistake as A1/A4.
- `--timeout` is now capped at 86400s (24h). The scheduled bot's longest is 5400s.

## Follow-up (other repo, not this PR)

`gateway-bot`'s `alert.ts` has no branch for `status: "in_flight"`, so it will log `Swap completed: … (in_flight)` and open no issue. That replaces a *false critical* with silence, which is an improvement, but the in-flight case deserves the same medium-severity warning `mempool_pending` gets. Worth a small `alert.ts` PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
