### PR TITLE
chore: bump @gobob/bob-sdk to 5.9.0 (HyperEVM)

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "5.8.1",
+    "version": "5.9.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "repository": {


### PR DESCRIPTION
Version bump only — a single line (`5.8.1` → `5.9.0`). Publishes HyperEVM support (chainId 999 in `supportedChainsMapping`, merged in #1113) to npm as `@gobob/bob-sdk@5.9.0`.

Minor bump: a new supported chain. After merge, tagging `5.9.0` triggers the SDK npm publish workflow.

Unblocks the gateway-cli release — the published SDK (5.8.1) has no `hyperevm`, so `getChainConfig("hyperevm")` throws and the CLI cannot touch HyperEVM. Follows #1125 (which made the SDK build again).

Replaces #1126 (that branch reformatted the whole file; this is the clean one-line diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)