### PR TITLE
fix(sdk): correct the get-max-spendable re-export (master build is broken)

### DIFF
--- a/sdk/src/gateway/generated-client/apis/index.ts
+++ b/sdk/src/gateway/generated-client/apis/index.ts
@@ -9,4 +9,7 @@ export * from './V3Api';
 // breaks `tsc`. This explicit re-export wins over the star exports and picks V2's copy (the
 // two are structurally identical). Delete this line the next time `pnpm codegen` regenerates
 // the client from the current spec.
-export type { type GetMaxSpendableV2Request as GetMaxSpendableV3Request } from './V2Api';
+// Resolve the ambiguity so `tsc` picks V2's copy for the shared name...
+export type { GetMaxSpendableV2Request } from './V2Api';
+// ...and expose V3's identical copy under its own name, matching the spec's v3 operationId.
+export type { GetMaxSpendableV2Request as GetMaxSpendableV3Request } from './V3Api';


### PR DESCRIPTION
## Master is broken

`@gobob/bob-sdk` does not build on `master`. The `5.9.0` publish (tag `5.9.0`) **failed** at `pnpm build`:

```
error TS2308: Module './V2Api' has already exported a member named 'GetMaxSpendableV2Request'.
error TS2207: The 'type' modifier cannot be used on a named export when 'export type' is used on its export statement.
```

## Cause

A follow-up commit on #1125 (`aa805285 "fix: type it"`) rewrote the disambiguation line to:

```ts
export type { type GetMaxSpendableV2Request as GetMaxSpendableV3Request } from './V2Api';
```

Broken two ways:
- the inner `type` modifier inside `export type { ... }` is invalid → **TS2207**;
- aliasing the shared name to `GetMaxSpendableV3Request` means nothing re-exports the ambiguous `GetMaxSpendableV2Request` anymore, so the two `export *` conflict again → **TS2308** returns.

CI on #1125 must have passed on an earlier commit; this last one wasn't re-gated before merge.

## Fix

Two valid re-exports — keeping the v3-specific name the earlier edit was reaching for, with correct syntax:

```ts
export type { GetMaxSpendableV2Request } from './V2Api';                        // resolve ambiguity (V2 wins)
export type { GetMaxSpendableV2Request as GetMaxSpendableV3Request } from './V3Api';  // v3's own name
```

Still a stopgap until the client is regenerated from the current spec (the two copies are structurally identical).

## Verification (ran the exact CI steps this time)

- `pnpm install --frozen-lockfile` + `pnpm build` → clean
- `pnpm test` → 77 passed, 11 pre-existing skips
- both `GetMaxSpendableV2Request` and `GetMaxSpendableV3Request` present in the built `.d.ts`

After merge I'll re-point tag `5.9.0` at the fixed commit to re-run the publish (5.9.0 was never published — the build failed before that step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)