### PR TITLE
chore: release gateway-cli 0.4.0 (HyperEVM) against bob-sdk 5.9.0

### DIFF
--- a/gateway-cli/package.json
+++ b/gateway-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/gateway-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CLI for bridging Bitcoin to/from EVM chains via BOB Gateway",
   "repository": {
     "type": "git",
@@ -20,11 +20,11 @@
     "cli:dev": "tsx bin/gateway-cli.ts"
   },
   "dependencies": {
-    "@gobob/bob-sdk": "^5.8.0",
+    "@gobob/bob-sdk": "^5.9.0",
     "@gobob/tokenlist": "github:bob-collective/tokenlist#5765810a897f2663f098939806d9f4285b9e8027",
     "commander": "^13.1.0",
     "p-retry": "^7.1.1",
-    "viem": "^2.31.3",
+    "viem": "2.49.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/gateway-cli/pnpm-lock.yaml
+++ b/gateway-cli/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@gobob/bob-sdk':
-        specifier: ^5.8.0
-        version: 5.8.0(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        specifier: ^5.9.0
+        version: 5.9.0(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
       '@gobob/tokenlist':
         specifier: github:bob-collective/tokenlist#5765810a897f2663f098939806d9f4285b9e8027
         version: https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027(typescript@5.9.3)(zod@4.3.6)
@@ -25,8 +25,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1
       viem:
-        specifier: ^2.31.3
-        version: 2.47.5(typescript@5.9.3)(zod@4.3.6)
+        specifier: 2.49.0
+        version: 2.49.0(typescript@5.9.3)(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -248,8 +248,8 @@ packages:
   '@gobob/bob-sdk@3.1.7-alpha0':
     resolution: {integrity: sha512-1qdKAYEigbqNt9x/0jYKeeC/d0u1lh6GluHaBIxp2Pt6p2+4fUVFnDdtGo5pMcgft7Bvo8/tdmlFBTzb3BEc5g==}
 
-  '@gobob/bob-sdk@5.8.0':
-    resolution: {integrity: sha512-s5304Pl5AcoPXeaxmv2srm341CIhEftzy3OSy0AVFZjrK9J9bL+lJaXfP3PplCVpw5fWIPayO+31S0mTUK8XFg==}
+  '@gobob/bob-sdk@5.9.0':
+    resolution: {integrity: sha512-sbmaTHM7rVwjysflfVa7dKeqVl763t3DeweNfQJHzottVuKo2bh5xdiqMENZDAx4XjJ1myF9DK/TKRGXoq2qAQ==}
 
   '@gobob/sats-wagmi@0.3.23':
     resolution: {integrity: sha512-7YAcQXo20v/SKNBv4Jhv9SYJJ9fzXUSC1ntUKwR0hjdCV9Kj0ivIRmGKvZwb8fqwgNYEaL4R5PbrMWnvFNTRgQ==}
@@ -976,8 +976,8 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  ox@0.14.5:
-    resolution: {integrity: sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==}
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -1196,8 +1196,8 @@ packages:
   varuint-bitcoin@1.1.2:
     resolution: {integrity: sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==}
 
-  viem@2.47.5:
-    resolution: {integrity: sha512-nVrJEQ8GL4JoVIrMBF3wwpTUZun0cpojfnOZ+96GtDWhqxZkVdy6vOEgu+jwfXqfTA/+wrR+YsN9TBQmhDUk0g==}
+  viem@2.49.0:
+    resolution: {integrity: sha512-vaasyOBFiCWYtw9JD8iRoaHPppk14kQH140qgVmrxkDEgv4qTX9Hwi6F+wF+s3Y7SStV5OtnN2ulJev+NQ7KDw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -1463,7 +1463,7 @@ snapshots:
       bitcoinjs-lib: 6.1.7
       ethers: 6.16.0
       global: 4.4.0
-      viem: 2.47.5(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.49.0(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -1471,7 +1471,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@gobob/bob-sdk@5.8.0(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
+  '@gobob/bob-sdk@5.9.0(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.2.0
       '@eslint/eslintrc': 3.3.5
@@ -1485,7 +1485,7 @@ snapshots:
       bitcoinjs-lib: 6.1.7
       global: 4.4.0
       globals: 17.4.0
-      viem: 2.47.5(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.49.0(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - '@tanstack/react-query'
       - bufferutil
@@ -1525,7 +1525,7 @@ snapshots:
   '@gobob/tokenlist@https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       '@scure/base': 1.2.6
-      viem: 2.47.5(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.49.0(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -1721,7 +1721,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -2265,7 +2265,7 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  ox@0.14.5(typescript@5.9.3)(zod@4.3.6):
+  ox@0.14.20(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2500,7 +2500,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  viem@2.47.5(typescript@5.9.3)(zod@4.3.6):
+  viem@2.49.0(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -2508,7 +2508,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.14.5(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.20(typescript@5.9.3)(zod@4.3.6)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.3


### PR DESCRIPTION
Ships HyperEVM support in `@gobob/gateway-cli`. Depends on `@gobob/bob-sdk@5.9.0` (just published).

## Changes (3 lines + lockfile)

- `@gobob/bob-sdk` `^5.8.0` → `^5.9.0` — 5.9.0 is the first published SDK with `hyperevm` in `supportedChainsMapping`. The CLI builds its `CHAIN_IDS` and viem chain configs from that mapping, so without it `getChainConfig("hyperevm")` throws and every HyperEVM path fails. Lockfile regenerated to resolve 5.9.0.
- `viem` `^2.31.3` → `2.49.0` — 5.9.0 pins viem exactly `2.49.0`. Left on `^2.31.3`, the CLI resolves a second viem (2.47.5), and the two `Chain` types are nominally incompatible: `createPublicClient({ chain: getChainConfig(...) })` fails to typecheck (`TS2322: Type 'Chain' is not assignable to type 'Chain | undefined'`). Pinning dedupes to one viem. Unpinning properly is tracked in #1115 (SDK module resolution).
- `version` `0.3.0` → `0.4.0` — minor; new supported chain.

## Verification

- `pnpm build` clean, `pnpm test` → 158 passed
- `getChainConfig("hyperevm")` → `999` against the **published** 5.9.0 (not the workspace copy)

After merge, tag `cli-0.4.0` triggers the CLI npm publish workflow. Then the gateway-bot bumps to 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)