### PR TITLE
docs: add OpenChainBench RPC latency benchmark reference

### DIFF
--- a/docs/docs/docs/tools/node-providers.md
+++ b/docs/docs/docs/tools/node-providers.md
@@ -24,3 +24,7 @@ Follow [Conduit's guide](https://docs.conduit.xyz/guides/run-a-node/op-stack-nod
 
 - [BOB Mainnet](https://drpc.org/chainlist/bob?utm_source=docs&utm_medium=bob)
 - [BOB Sepolia](https://drpc.org/chainlist/bob?utm_source=docs&utm_medium=bob#bob-testnet) (Testnet)
+
+---
+
+For live latency comparisons across these providers, see [OpenChainBench](https://openchainbench.com/benchmarks/bob-rpc) — an open benchmark that continuously measures free public RPC endpoints for BOB.


### PR DESCRIPTION
## What is OpenChainBench?

[OpenChainBench](https://openchainbench.com) is an open, live benchmark that continuously measures latency across free public RPC endpoints for dozens of EVM chains. Results are updated in real time using actual JSON-RPC probe requests.

## Why add this?

The Node Providers page already lists Conduit, Tenderly, and dRPC as options for BOB. This adds a reference to OpenChainBench where developers can compare live latency across these providers before choosing one.

## Change

Added one line at the bottom of the Node Providers page with a link to the BOB bench page on OpenChainBench.