### PR TITLE
chore: recompile openapi-docs-sync lock, drop stale FAQ answer

### DIFF
--- a/.github/workflows/openapi-docs-sync.lock.yml
+++ b/.github/workflows/openapi-docs-sync.lock.yml
@@ -22,7 +22,7 @@
 #
 # Review merged OpenAPI spec changes and open a PR with relevant docs updates.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6317a60aa4497d3d3c1fb756f42f8e792ea776ba149bacd47e0a754c147d857b","compiler_version":"v0.62.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7617f26a540ec3603955dc66a14818742179c59ccd40a21a691defc59eb1ff00","compiler_version":"v0.62.4","strict":true,"agent_id":"claude"}
 
 name: "OpenAPI Docs Sync"
 "on":

--- a/gateway-docs/content/docs/gateway/faq.mdx
+++ b/gateway-docs/content/docs/gateway/faq.mdx
@@ -14,9 +14,6 @@ Gateway falls back to sending wrapped BTC directly to the user's EVM address, so
 ### Do I need Bitcoin wallet support?
 Yes, your frontend needs Bitcoin wallet integration. See the [wallet guide](/gateway/wallets) for implementation details.
 
-### Can I chain multiple protocols?
-Yes! Custom strategies can interact with multiple protocols in sequence. For example: stake WBTC → get staked BTC → deposit in lending → send receipt tokens to user.
-
 ### Security considerations?
 - Use SafeERC20 for token transfers
 - Consider reentrancy protection


### PR DESCRIPTION
Two loose ends from #1137.

## Recompile the agentic workflow lock

#1137 moved the OpenAPI spec to `gateway-docs/openapi.json` and updated the trigger path in both `openapi-docs-sync.md` and its generated `.lock.yml` by hand. That left the lock file's `frontmatter_hash` stale, so the next regeneration could have reverted the trigger.

`gh aw compile` refreshes it — one line changed, and the compiler version (`v0.62.4`) matches what the lock file already recorded, so nothing else moves:

```diff
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6317a60a…"
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7617f26a…"
```

Trigger path verified unchanged afterwards:

```yaml
  push:
    branches:
    - master
    paths:
    - gateway-docs/openapi.json
```

## Drop a stale FAQ answer

The FAQ's *"Can I chain multiple protocols?"* answered:

> Yes! Custom strategies can interact with multiple protocols in sequence…

That describes the custom strategies mechanism whose page #1137 removed, because it documented `strategyMessage` / `strategyAddress` as `getQuote` parameters that V3 rejects. Leaving the answer keeps the same inaccuracy in a second place.

It's dropped rather than reworded — what V3 offers instead isn't something the docs currently establish, and guessing would reintroduce the original problem. Happy to write a correct answer if the V3 mechanism is confirmed.

## Deliberately left alone

- `migration.mdx`, `integration.mdx`, `api-reference/overview.mdx` — these state that `strategy*` params were **removed** in V3. Correct, and load-bearing for anyone upgrading.
- `refunds.mdx` — describes fallback when an on-chain DeFi call fails. Runtime behaviour, still accurate.
- `technical.mdx` — lists "Custom strategy: executes smart contract logic" as an intent-execution mode. Describes what the protocol does, not the removed API surface.
- `faq.mdx` **"Security considerations?"** — generic Solidity advice (SafeERC20, reentrancy, access control) that made most sense next to the strategies page. Now somewhat context-free, but it isn't wrong, and deleting security guidance felt beyond the scope of this cleanup. Flagging rather than removing.

## Verification

`next build` clean at 106 pages, ESLint and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)