### PR TITLE
fix(gateway-cli): warn on missing ERC-20 allowance for --unsigned offramps

### DIFF
--- a/gateway-cli/src/chains/evm.ts
+++ b/gateway-cli/src/chains/evm.ts
@@ -137,7 +137,7 @@ const ZERO_ADDR = "0x0000000000000000000000000000000000000000" as `0x${string}`;
  * Check if a token address represents the native token.
  * Native tokens have no contract address (represented by zero address or undefined).
  */
-function isNativeToken(tokenAddress?: string): boolean {
+export function isNativeToken(tokenAddress?: string): boolean {
   if (!tokenAddress) return true;
   // Non-EVM addresses (e.g. Tron base58 tokens from Tron routes) are never the
   // EVM native token. Guard here — isAddressEqual throws on non-EVM input, which
@@ -263,6 +263,24 @@ export async function getEvmBalances(
   }
 
   return { address, native, tokens: tokenBals };
+}
+
+/**
+ * Read an ERC20 allowance (owner → spender) in atomic units.
+ *
+ * Returns 0n for the native token: it has no allowance concept, and callers
+ * checking whether a Gateway contract can pull `srcAsset` should treat native as
+ * "no approval needed" and skip the check rather than query a non-contract address.
+ */
+export async function getErc20Allowance(chain: string, token: string, owner: string, spender: string): Promise<bigint> {
+  if (isNativeToken(token)) return 0n;
+  const client = await getClient(chain);
+  return client.readContract({
+    address: token as `0x${string}`,
+    abi: erc20Abi,
+    functionName: "allowance",
+    args: [owner as `0x${string}`, spender as `0x${string}`],
+  });
 }
 
 // ─── Signer ─────────────────────────────────────────────────────────────────

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -8,7 +8,7 @@ import { watchOrder } from "../util/order-watcher.js";
 import { sleep } from "../util/sleep.js";
 import { loadConfig, getSdk, getApi } from "../config.js";
 import { resolveSigner } from "../chains/index.js";
-import { CHAIN_IDS } from "../chains/evm.js";
+import { CHAIN_IDS, getErc20Allowance, isNativeToken } from "../chains/evm.js";
 import type { Logger, SwapSuccessJson, SwapSubmittedJson, SwapMempoolPendingJson, SwapInFlightJson } from "../output.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -110,6 +110,32 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
       if (!psbtHex) throw new Error("Gateway did not return a PSBT for this onramp order.");
       return { type: "unsigned", orderId: orderData.orderId, psbtBase64: Buffer.from(psbtHex, "hex").toString("base64") };
     }
+
+    // EVM offramp / tokenSwap: the returned calldata targets a Gateway contract that
+    // pulls the source ERC20 from the caller via `transferFrom`. The signed path lets
+    // the SDK issue the approval for you; an --unsigned caller must approve the spender
+    // (tx.to) themselves first. Without it the very first transfer reverts — and because
+    // legacy tokens like WBTC revert with empty returndata, the broadcast tx fails with a
+    // bare `execution reverted` (0x) that is easily mistaken for a gas/RPC problem (#1100).
+    // Warn (don't block: the caller may approve in a separate/batched tx) when the current
+    // allowance is short. A read failure must not sink the primary deliverable — the calldata.
+    const spender = orderData.tx?.to;
+    if (spender && senderAddress && !isNativeToken(srcAsset.address)) {
+      try {
+        const allowance = await getErc20Allowance(evmChain, srcAsset.address, senderAddress, spender);
+        if (allowance < BigInt(atomicUnits)) {
+          log.warn(
+            `Insufficient ${srcAsset.symbol} allowance for the Gateway contract — this transaction will revert if broadcast as-is.\n` +
+            `  Current allowance: ${allowance} (need ${atomicUnits}, atomic units)\n` +
+            `  Approve first, e.g.: ${srcAsset.address}.approve(${spender}, ${atomicUnits}) from ${senderAddress}\n` +
+            `  (Legacy tokens such as WBTC revert with empty data when allowance is short, which looks like a gas/RPC error.)`,
+          );
+        }
+      } catch (e) {
+        log.warn(`Could not verify ${srcAsset.symbol} allowance for the Gateway contract (${e instanceof Error ? e.message : String(e)}). Ensure ${spender} is approved to spend ${atomicUnits} before broadcasting.`);
+      }
+    }
+
     return { type: "unsigned", orderId: orderData.orderId, txInfo: orderData.tx };
   }
 

--- a/gateway-cli/tests/chains/evm.test.ts
+++ b/gateway-cli/tests/chains/evm.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockGetBalance = vi.fn();
 const mockEstimateFeesPerGas = vi.fn();
 const mockMulticall = vi.fn();
+const mockReadContract = vi.fn();
 
 vi.mock("viem", async (importOriginal) => {
   const actual = await importOriginal<typeof import("viem")>();
@@ -14,6 +15,7 @@ vi.mock("viem", async (importOriginal) => {
       getBalance: mockGetBalance,
       estimateFeesPerGas: mockEstimateFeesPerGas,
       multicall: mockMulticall,
+      readContract: mockReadContract,
     })),
     createWalletClient: vi.fn(() => ({
       account: { address: "0xTestAddress" },
@@ -60,7 +62,7 @@ vi.mock("../../src/util/rpc-resolver.js", () => ({
 
 // ─── Import after mocks ─────────────────────────────────────────────────────
 
-import { getEvmBalances, NATIVE_GAS_BUFFER, getTokenMetadata } from "../../src/chains/evm.js";
+import { getEvmBalances, NATIVE_GAS_BUFFER, getTokenMetadata, getErc20Allowance } from "../../src/chains/evm.js";
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
@@ -183,5 +185,33 @@ describe("getEvmBalances", () => {
     });
 
     expect(result.tokens![0].allSpendable).toBe("0");
+  });
+});
+
+describe("getErc20Allowance", () => {
+  beforeEach(() => {
+    mockReadContract.mockReset();
+  });
+
+  const OWNER = "0x2935C2621F4035Dbbf7BC370384B68e76a37C283";
+  const SPENDER = "0x2e77b55EE57FB33e5366987b25dDF6bE94F0892C";
+  const WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+
+  it("returns the on-chain allowance for an ERC20 token", async () => {
+    mockReadContract.mockResolvedValue(53464n);
+
+    const allowance = await getErc20Allowance("ethereum", WBTC, OWNER, SPENDER);
+
+    expect(allowance).toBe(53464n);
+    expect(mockReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({ address: WBTC, functionName: "allowance", args: [OWNER, SPENDER] }),
+    );
+  });
+
+  it("short-circuits to 0 for the native token without an RPC call", async () => {
+    const allowance = await getErc20Allowance("ethereum", "0x0000000000000000000000000000000000000000", OWNER, SPENDER);
+
+    expect(allowance).toBe(0n);
+    expect(mockReadContract).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the silent-revert trap reported in #1100. An `--unsigned` EVM offramp/tokenSwap returns calldata for a Gateway contract that pulls the source token via `transferFrom`, but the CLI never surfaced that the caller must first `approve()` the spender. With a legacy token like WBTC, `transferFrom` reverts with **empty `0x` returndata**, which is indistinguishable from a gas/RPC failure — exactly the dead end the reporter hit before self-diagnosing the missing allowance.

The **signed** path is unaffected: the SDK's `executeQuote` issues the approval itself. Only the manual `--unsigned` flow lacked any signal.

## Changes

- **`gateway-cli/src/chains/evm.ts`** — new `getErc20Allowance(chain, token, owner, spender)` helper (returns `0n` for the native token, no RPC call); export `isNativeToken`.
- **`gateway-cli/src/commands/swap.ts`** — in the `--unsigned` EVM branch, before returning calldata, read the sender's allowance to the Gateway contract (`tx.to`) and **warn** when it's short, including current vs. required amounts and the exact `approve(...)` to make. Native tokens are skipped; an allowance-read failure degrades to a soft warning so the calldata is still delivered.
- **`gateway-cli/tests/chains/evm.test.ts`** — coverage for the ERC-20 read and the native short-circuit.

## Design notes

- **Warns, does not block.** `--unsigned` is an advanced flow where the caller may legitimately batch or pre-stage the approval; a hard error would break those. Warnings go to stderr and are suppressed under `--json`, so machine output is unchanged.
- This addresses the **client-side** half of #1100. The backend asks in that issue — surfacing a concrete revert reason on the API/contract side — are out of scope for the CLI and tracked separately.

## Testing

`pnpm run test` → 160 passing (2 new).

> Note: `pnpm run build` (tsc) currently reports 12 **pre-existing** errors from an `@gobob/bob-sdk` version drift in `node_modules` (missing V3 types), present on `master` before this change and unrelated to it. Tests run clean via vitest/tsx.

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)