### PR TITLE
fix(sdk): wait for approval to be visible before sending

### DIFF
--- a/gateway-cli/package.json
+++ b/gateway-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/gateway-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for bridging Bitcoin to/from EVM chains via BOB Gateway",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "cli:dev": "tsx bin/gateway-cli.ts"
   },
   "dependencies": {
-    "@gobob/bob-sdk": "^5.9.0",
+    "@gobob/bob-sdk": "^5.9.1",
     "@gobob/tokenlist": "github:bob-collective/tokenlist#5765810a897f2663f098939806d9f4285b9e8027",
     "commander": "^13.1.0",
     "p-retry": "^7.1.1",

--- a/gateway-cli/pnpm-lock.yaml
+++ b/gateway-cli/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@gobob/bob-sdk':
-        specifier: ^5.9.0
-        version: 5.9.0(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        specifier: ^5.9.1
+        version: 5.9.1(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
       '@gobob/tokenlist':
         specifier: github:bob-collective/tokenlist#5765810a897f2663f098939806d9f4285b9e8027
         version: https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027(typescript@5.9.3)(zod@4.3.6)
@@ -248,8 +248,8 @@ packages:
   '@gobob/bob-sdk@3.1.7-alpha0':
     resolution: {integrity: sha512-1qdKAYEigbqNt9x/0jYKeeC/d0u1lh6GluHaBIxp2Pt6p2+4fUVFnDdtGo5pMcgft7Bvo8/tdmlFBTzb3BEc5g==}
 
-  '@gobob/bob-sdk@5.9.0':
-    resolution: {integrity: sha512-sbmaTHM7rVwjysflfVa7dKeqVl763t3DeweNfQJHzottVuKo2bh5xdiqMENZDAx4XjJ1myF9DK/TKRGXoq2qAQ==}
+  '@gobob/bob-sdk@5.9.1':
+    resolution: {integrity: sha512-FpTDflxKO+r9aIE/VgCwU11o/kYJAJNWRRJcd4HBydXlzljAP8XTqNZwzL6PwpRB14W/Lmdy1K6h3lyPSU/nmw==}
 
   '@gobob/sats-wagmi@0.3.23':
     resolution: {integrity: sha512-7YAcQXo20v/SKNBv4Jhv9SYJJ9fzXUSC1ntUKwR0hjdCV9Kj0ivIRmGKvZwb8fqwgNYEaL4R5PbrMWnvFNTRgQ==}
@@ -259,7 +259,7 @@ packages:
       react-dom: '>=18'
 
   '@gobob/tokenlist@https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027':
-    resolution: {gitHosted: true, integrity: sha512-yS4vAV6+luoSJkLQglKT+/lCr+EfLpXV4CMRfeSkJOWT6C5pudJtGlGvO9dS5Km49+O5ZNK2573fTcDmgx/jvw==, tarball: https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027}
+    resolution: {integrity: sha512-yS4vAV6+luoSJkLQglKT+/lCr+EfLpXV4CMRfeSkJOWT6C5pudJtGlGvO9dS5Km49+O5ZNK2573fTcDmgx/jvw==, tarball: https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027}
     version: 1.0.0
 
   '@jridgewell/sourcemap-codec@1.5.5':
@@ -370,79 +370,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1471,7 +1458,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@gobob/bob-sdk@5.9.0(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
+  '@gobob/bob-sdk@5.9.1(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.2.0
       '@eslint/eslintrc': 3.3.5


### PR DESCRIPTION
## Problem

`executeQuote` approves, awaits the approve receipt, then immediately sends the swap tx. `waitForTransactionReceipt` can resolve **before** the approval is reflected in `latest` state — Base serves flashblock preconfirmations, and load-balanced RPCs can answer the follow-up `eth_call` / `eth_estimateGas` from a node that has not applied the block yet.

viem estimates gas during `sendTransaction`, so the estimate reverts and the swap tx is **never broadcast**, even though the approval succeeded on-chain:

```
Execution reverted with reason: ERC20: transfer amount exceeds allowance.
Request Arguments:
  from:   0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb
  to:     0x0000000000001fF3684f28c67538d4D072C22734
Details: execution reverted: ERC20: transfer amount exceeds allowance
Version: viem@2.49.0
```

Observed in the gateway-bot API test workflow, leg `USDC@base → BTC` ([run 31794363730](https://github.com/bob-collective/gateway-bot/actions/runs/31794363730/job/94748230262)):

| Time (UTC) | Base block | Fact |
|---|---|---|
| 11:01:21 | 49957967 | `allowance(bot, 0x…22734)` = **0** |
| 11:01:21.7 | — | CLI throws `ERC20: transfer amount exceeds allowance` |
| 11:01:23 | 49957968 | approve tx `0x9f40d9c4…` (nonce 208) mined → allowance = 24975524 |

The approved amount equals exactly what the swap calldata pulls (`0x17d18a4`), and the wallet nonce is `209` — nonce 208 (the approve) was the last one used, confirming the offramp tx was never sent. A `cast call --trace` of the calldata also confirms the puller and the approved spender are the same address, so this is purely a state-visibility race, not a wrong-spender or amount bug.

## Fix

Add `waitForAllowance` (`sdk/src/gateway/utils/allowance.ts`), which polls `allowance` until it covers the required amount, and call it after the approve receipt in the offramp, tokenSwap and `executeStrategy` paths.

- Checks before sleeping → common case costs one extra `eth_call` and no delay.
- Tolerates transient RPC read failures.
- On exhaustion (default 10 × 500ms) throws with the observed allowance, spender, required amount and approve tx hash. Failing there is preferable to a revert during the send, because nothing has been signed yet.

The USDT reset-to-0 step is left unchanged — same class of race, but not the observed failure.

## Notes

`estimateGasWithBuffer` does not protect against this: it swallows the revert and returns `undefined`, after which viem re-estimates during the send and throws the same error.

## Test plan

- `sdk/test/allowance.test.ts` (new): immediate return, polls through stale reads, survives a transient RPC error, throws with the observed allowance after N attempts.
- `sdk/test/gateway.test.ts`: `mockOftReadContract` now models post-approve state (`allowanceAfterApproval`, default `maxUint256`); two new offramp tests assert the re-check happens before `sendTransaction`, and that a permanently-stale allowance rejects without sending.
- `pnpm run test` → 83 passed | 11 skipped. `pnpm run lint` and `pnpm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)