### PR TITLE
fix(sdk): announce the send step only after gas estimation

### DIFF
--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -409,9 +409,14 @@ export class GatewayApiClient {
                 await publicClient.waitForTransactionReceipt({ hash: approveTxHash, retryCount: RETRY_COUNT });
             }
 
-            callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
             const offrampData = order.offramp.tx.data as Hex;
             const offrampValue = BigInt(order.offramp.tx.value || 0);
+            // Estimate before announcing the step. `SendTransaction` means "the wallet is
+            // about to be asked to sign", and callers latch on it to mark the operation
+            // unsafe to re-run. Gas estimation touches no wallet, yet it is the call here
+            // most likely to fail (it reverts on stale RPC state, e.g. an approve that has
+            // just landed but is not visible yet), so announcing first reports a failure
+            // that signed nothing as one that may already have broadcast.
             const offrampGas =
                 walletClient.account.type === 'local'
                     ? await estimateGasWithBuffer(publicClient, walletClient.account, {
@@ -421,6 +426,7 @@ export class GatewayApiClient {
                       })
                     : undefined;
 
+            callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
             const transactionHash = await walletClient.sendTransaction({
                 account: signerAccount(walletClient),
                 data: offrampData,
@@ -555,10 +561,10 @@ export class GatewayApiClient {
                 }
             }
 
-            callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
             const tokenSwapTo = order.tokenSwap.tx.to as Address;
             const tokenSwapData = order.tokenSwap.tx.data as Hex;
             const tokenSwapValue = BigInt(order.tokenSwap.tx.value || 0);
+            // Estimate before announcing the step - see the offramp path above.
             const tokenSwapGas =
                 walletClient.account.type === 'local'
                     ? await estimateGasWithBuffer(publicClient, walletClient.account, {
@@ -568,6 +574,7 @@ export class GatewayApiClient {
                       })
                     : undefined;
 
+            callback?.({ step: totalSteps, type: ExecuteQuoteStepType.SendTransaction, totalSteps });
             const transactionHash = await walletClient.sendTransaction({
                 account: signerAccount(walletClient),
                 data: tokenSwapData,


### PR DESCRIPTION
## Problem

`ExecuteQuoteStepType.SendTransaction` is the caller's signal that the wallet is about to be asked to sign. `gateway-cli` latches on it (`guard.pointOfNoReturn(step.type)`) to mark the swap as past its point of no return, which disables retries and reports the failure as:

```
Swap aborted after the wallet was asked to sign (step: send_transaction). A transaction
may already have been broadcast — do NOT re-run this swap or you may send twice.
```

The offramp and tokenSwap paths fired that callback *before* `estimateGasWithBuffer`. A revert during gas estimation — where nothing has been signed and nothing can have been broadcast — was therefore reported as a possible double-send, and the retry was suppressed.

## Evidence

Seen in the gateway-bot token-test workflow ([run 31779909172](https://github.com/bob-collective/gateway-bot/actions/runs/31779909172)) and the API-testing workflow ([run 31794363730](https://github.com/bob-collective/gateway-bot/actions/runs/31794363730)). Every offramp failed at gas estimation with an allowance revert, and the wallet still holds the unspent approval for the exact offramp amount, confirming the swap tx was never sent:

| Token (Base) | Offramp amount | Live allowance | Reported error |
|---|---|---|---|
| LBTC `0xecAc9C…` | 15536 | 15536 | `Execution reverted for an unknown reason` |
| tBTC `0x236aA5…` | 156589047514442 | 156589047514442 | `ERC20: insufficient allowance` |
| USDC `0x833589…` | 24975524 | 24975524 | `ERC20: transfer amount exceeds allowance` |

## Change

Move the `SendTransaction` callback to just before `walletClient.sendTransaction` in both the offramp and tokenSwap paths, so the step is announced only when a wallet interaction is genuinely next.

This is the mis-reporting half of the failure. The allowance revert itself is fixed separately in #1146.

## Test

- `npx tsc --noEmit` — clean
- `npx vitest run test/gateway.test.ts` — 41 passed
- `npx prettier --check src/gateway/client.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)