### PR TITLE
chore: bump tokenlist in gateway-cli

### DIFF
--- a/gateway-cli/package.json
+++ b/gateway-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/gateway-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI for bridging Bitcoin to/from EVM chains via BOB Gateway",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@gobob/bob-sdk": "^5.9.1",
-    "@gobob/tokenlist": "github:bob-collective/tokenlist#5765810a897f2663f098939806d9f4285b9e8027",
+    "@gobob/tokenlist": "github:bob-collective/tokenlist#f307495b07ab7ff3d21d77e1917a8574e32d5468",
     "commander": "^13.1.0",
     "p-retry": "^7.1.1",
     "viem": "2.49.0",

--- a/gateway-cli/pnpm-lock.yaml
+++ b/gateway-cli/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^5.9.1
         version: 5.9.1(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
       '@gobob/tokenlist':
-        specifier: github:bob-collective/tokenlist#5765810a897f2663f098939806d9f4285b9e8027
-        version: https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027(typescript@5.9.3)(zod@4.3.6)
+        specifier: github:bob-collective/tokenlist#f307495b07ab7ff3d21d77e1917a8574e32d5468
+        version: https://codeload.github.com/bob-collective/tokenlist/tar.gz/f307495b07ab7ff3d21d77e1917a8574e32d5468(typescript@5.9.3)(zod@4.3.6)
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -258,8 +258,8 @@ packages:
       react: '>=18'
       react-dom: '>=18'
 
-  '@gobob/tokenlist@https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027':
-    resolution: {integrity: sha512-yS4vAV6+luoSJkLQglKT+/lCr+EfLpXV4CMRfeSkJOWT6C5pudJtGlGvO9dS5Km49+O5ZNK2573fTcDmgx/jvw==, tarball: https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027}
+  '@gobob/tokenlist@https://codeload.github.com/bob-collective/tokenlist/tar.gz/f307495b07ab7ff3d21d77e1917a8574e32d5468':
+    resolution: {tarball: https://codeload.github.com/bob-collective/tokenlist/tar.gz/f307495b07ab7ff3d21d77e1917a8574e32d5468}
     version: 1.0.0
 
   '@jridgewell/sourcemap-codec@1.5.5':
@@ -1509,7 +1509,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@gobob/tokenlist@https://codeload.github.com/bob-collective/tokenlist/tar.gz/5765810a897f2663f098939806d9f4285b9e8027(typescript@5.9.3)(zod@4.3.6)':
+  '@gobob/tokenlist@https://codeload.github.com/bob-collective/tokenlist/tar.gz/f307495b07ab7ff3d21d77e1917a8574e32d5468(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       '@scure/base': 1.2.6
       viem: 2.49.0(typescript@5.9.3)(zod@4.3.6)


### PR DESCRIPTION
## Summary

Bumps `@gobob/tokenlist` in `gateway-cli` from `5765810a` to [`f307495b`](https://github.com/bob-collective/tokenlist/commit/f307495b07ab7ff3d21d77e1917a8574e32d5468) (*chore: udjust rlusd logo size (#42)*), and bumps the CLI package version to `0.4.2`.

`pnpm-lock.yaml` is regenerated to match the new specifier.

## Note

The regenerated lockfile entry for `@gobob/tokenlist` carries only `tarball` and no `integrity` hash. This is not specific to the new commit — pnpm 10.10 produces the same entry for the *old* commit on a clean store, so it is a resolver behaviour change rather than something introduced here. Flagging in case the repo wants to pin pnpm or move the dependency off a GitHub tarball.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run test` — 20 files, 158 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)