### PR TITLE
docs(gateway): update FAQ, refunds and deep dive to current protocol

### DIFF
--- a/gateway-docs/content/docs/gateway/faq.mdx
+++ b/gateway-docs/content/docs/gateway/faq.mdx
@@ -5,11 +5,12 @@ icon: CircleQuestionMark
 ---
 ## Frequently Asked Questions
 
-### Who pays the gas fees?
-The Relayer estimates gas costs upfront and deducts them from the transaction. Users don't need ETH on BOB to use Gateway.
+### What happens if my swap fails?
+No user is ever left with funds spent and nothing delivered.
 
-### What happens if my DeFi action fails?
-Gateway falls back to sending wrapped BTC directly to the user's EVM address, so the user still receives value. Always test thoroughly to avoid fallbacks. See [Refunds](/gateway/refunds) for details.
+On a BTC-to-X swap, the destination payout is one atomic transaction, so there is no partial fill to unwind. If it can't land at the quoted terms — prices drifted while the Bitcoin deposit confirmed, or the destination swap or bridge won't go through — the solver re-quotes and retries with backoff for about an hour, then settles the order as a refund: BTC back to the Bitcoin `refundAddress` if the order was created with one, otherwise USDT to the order owner on Ethereum.
+
+On an X-to-BTC swap, the user's USDT stays escrowed in the offramp contract until an SPV proof of the Bitcoin payout is verified on-chain. If the payout never happens, the escrow becomes reclaimable after a security delay — users can self-serve in the BOB Gateway UI, or you can submit the `refundTx` from the order status on their behalf. See [Refunds](/gateway/refunds) for details.
 
 ### Do I need Bitcoin wallet support?
 Yes, your frontend needs Bitcoin wallet integration. See the [wallet guide](/gateway/wallets) for implementation details.

--- a/gateway-docs/content/docs/gateway/faq.mdx
+++ b/gateway-docs/content/docs/gateway/faq.mdx
@@ -10,7 +10,7 @@ No user is ever left with funds spent and nothing delivered.
 
 On a BTC-to-X swap, the destination payout is one atomic transaction, so there is no partial fill to unwind. If it can't land at the quoted terms — prices drifted while the Bitcoin deposit confirmed, or the destination swap or bridge won't go through — the solver re-quotes and retries with backoff for about an hour, then settles the order as a refund: BTC back to the Bitcoin `refundAddress` if the order was created with one, otherwise USDT to the order owner on Ethereum.
 
-On an X-to-BTC swap, the user's USDT stays escrowed in the offramp contract until an SPV proof of the Bitcoin payout is verified on-chain. If the payout never happens, the escrow becomes reclaimable after a security delay — users can self-serve in the BOB Gateway UI, or you can submit the `refundTx` from the order status on their behalf. See [Refunds](/gateway/refunds) for details.
+On an X-to-BTC swap, the user's USDT stays escrowed in the offramp registry until an SPV proof of the Bitcoin payout is verified on-chain. If the payout never happens, Gateway refunds the escrow to the user once the on-chain refund delay has elapsed. Either way the funds can only go to the user or to a solver that proved it paid them. See [Refunds](/gateway/refunds) for details.
 
 ### Do I need Bitcoin wallet support?
 Yes, your frontend needs Bitcoin wallet integration. See the [wallet guide](/gateway/wallets) for implementation details.
@@ -36,7 +36,7 @@ The quote response includes an `estimatedTimeInSecs` field with the expected dur
 For X-to-BTC transactions, the Bitcoin payout can be bumped to speed up confirmation if network fees increase. See [Refunds](/gateway/refunds).
 
 ### Can I cancel a transaction?
-For X-to-BTC orders, you can reclaim locked funds if an order gets stuck. This is irreversible — once unlocked, the order cannot be resumed. See [Refunds](/gateway/refunds).
+No. Once an order is created it either settles or is refunded — there is no cancel, and neither users nor integrators can trigger a refund themselves. Gateway settles refunds in both directions automatically; for X-to-BTC orders that happens after the escrow's on-chain refund delay. See [Refunds](/gateway/refunds).
 
 ### What chains are supported?
 Gateway supports Bitcoin and a growing set of EVM and non-EVM chains. See [Supported Routes](/gateway/supported-routes) for the current, live list.

--- a/gateway-docs/content/docs/gateway/integration.mdx
+++ b/gateway-docs/content/docs/gateway/integration.mdx
@@ -356,14 +356,9 @@ orders.forEach(order => {
       const { txid, amount } = order.status.inProgress.pendingBtcPayment;
       console.log(`Pending BTC payout: ${amount} sats (txid: ${txid})`);
     }
-    if (order.status.inProgress.refundTx) {
-      console.log('Refund transaction available');
-    }
+    // Note: `refundTx` is always null — Gateway settles refunds itself
   } else if ('failed' in order.status) {
     console.log('Status: failed');
-    if (order.status.failed.refundTx) {
-      console.log('Refund transaction available');
-    }
   } else if ('success' in order.status) {
     console.log('Status: success');
     // Settled token transfers (with on-chain txHash, and V3 `usd`) are on the status payload
@@ -445,36 +440,25 @@ Gateway no longer exposes a `bumpFeeTx` EVM transaction — it manages fee bumps
 
 </Accordion>
 
-<Accordion icon="unlock" title="Refund Stuck Orders">
+<Accordion icon="unlock" title="Show Refunded Orders">
 
-If an order gets stuck or needs to be cancelled, the order will include a `refundTx` to unlock the locked assets:
+Gateway settles every refund itself, in both directions — there is no refund transaction for you or your users to submit. What you can do is surface the outcome, which arrives as the `refunded` status:
 
 ```typescript
 const { orders } = await gatewaySDK.getOrders({ userAddress: userEvmAddress });
 
-// Find order with refund transaction available
-const orderNeedingRefund = orders.find(order =>
-  ('inProgress' in order.status && order.status.inProgress.refundTx)
-  || ('failed' in order.status && order.status.failed.refundTx)
-);
+for (const order of orders) {
+  if (!('refunded' in order.status)) continue;
 
-if (orderNeedingRefund) {
-  const refundTx = 'failed' in orderNeedingRefund.status
-    ? orderNeedingRefund.status.failed.refundTx!
-    : (orderNeedingRefund.status as { inProgress: { refundTx: any } }).inProgress.refundTx!;
-  // Submit the refund transaction
-  const hash = await walletClient.sendTransaction({
-    to: refundTx.to,
-    data: refundTx.data,
-    value: refundTx.value,
-  });
-
-  await publicClient.waitForTransactionReceipt({ hash });
+  for (const t of order.status.refunded.refundedTokens) {
+    // A BTC refund reports `chain: 'bitcoin'` and a Bitcoin txid in `txHash`
+    console.log(`Refunded ${t.amount} ${t.token} on ${t.chain} (tx ${t.txHash})`);
+  }
 }
 ```
 
 <Callout type="warn">
-This action is irreversible. Once refunded, the order cannot be resumed.
+`status.inProgress.refundTx` and `status.failed.refundTx` are **always `null`** — the fields are retained only so the response shape is unchanged for existing integrators. X-to-BTC refunds are owner-operated on the offramp registry and cannot be triggered by a user or an integrator. See [Refunds](/gateway/refunds).
 </Callout>
 
 </Accordion>

--- a/gateway-docs/content/docs/gateway/refunds.mdx
+++ b/gateway-docs/content/docs/gateway/refunds.mdx
@@ -13,28 +13,30 @@ Users can always check their order — including refund status — on the [Gatew
 
 | Scenario | What the user receives | Who acts |
 |---|---|---|
-| BTC to X: swap can't fill at quoted terms | USDT on Ethereum | BOB, automatic |
-| BTC to X: DeFi action fails | Wrapped BTC to their EVM address | BOB, automatic |
+| BTC to X: swap can't fill at quoted terms | BTC to their refund address, or USDT on Ethereum | BOB, automatic |
+| BTC to X: destination swap or bridge can't land | BTC to their refund address, or USDT on Ethereum | BOB, automatic |
 | X to BTC: payout delayed | BTC (gateway bumps the fee) | BOB, automatic |
-| X to BTC: payout can't complete (very rare) | Their locked wrapped BTC back | User withdraws — self-serve in BOB Gateway UI, or via `refundTx` for integrators |
+| X to BTC: payout can't complete (very rare) | Their locked USDT back | User withdraws — self-serve in BOB Gateway UI, or via `refundTx` for integrators |
 
 ## BTC to X refunds
 
 There are two cases where a BTC-to-X swap returns funds instead of the expected output:
 
-1. **The swap can't fill at the quoted terms.** While waiting for the Bitcoin transaction to confirm, prices can drift until the destination route no longer accepts the submitted amount. When this happens, Gateway refunds the user **in USDT on Ethereum**, automatically — no action needed from the user or the integrator.
+1. **The swap can't fill at the quoted terms.** While waiting for the Bitcoin transaction to confirm, prices can drift until the destination route no longer accepts the submitted amount.
 
-2. **A DeFi action fails.** When a swap includes a strategy or DeFi action — staking, lending, a multicall — and that on-chain action reverts, Gateway falls back to delivering wrapped BTC directly to the user's EVM address rather than failing the whole swap. The user still receives value; they just receive wrapped BTC instead of the intended position.
+2. **The destination swap or bridge can't land.** When a route swaps or bridges onwards through a third-party provider, that on-chain call can revert. The payout and the onward call are one atomic transaction, so the whole release reverts with it and the user is never left holding a partial result.
 
-<Callout type="idea">
-Always test strategies thoroughly on testnet. A fallback means the user received wrapped BTC rather than the position they intended to open.
+Both cases resolve the same way, automatically, with no action needed from the user or the integrator. The solver simulates the destination call before releasing, re-quotes, and retries with backoff for about an hour. If the release still can't land, Gateway settles the order as a refund: **BTC back to the Bitcoin `refundAddress`** when the order was created with one, and otherwise **USDT on Ethereum** to the order owner.
+
+<Callout>
+Pass a `refundAddress` when you request a quote if you want failed BTC-to-X swaps returned in BTC rather than USDT on Ethereum.
 </Callout>
 
 ## X to BTC refunds
 
 X-to-BTC refunds are a very rare edge case: the token swap settles before the Bitcoin payout is made, so a refund only comes into play if the payout never happens (for example, a solver going offline). Often a slow payout isn't a refund case at all — it just needs a Bitcoin fee bump, which the gateway handles internally.
 
-If the payout genuinely can't complete, the user's locked wrapped BTC becomes reclaimable. A security delay applies before funds can be withdrawn — this ensures a Bitcoin payment that was already made can't be refunded twice. After the delay:
+If the payout genuinely can't complete, the USDT escrowed when the order was created becomes reclaimable. A security delay applies before funds can be withdrawn — this ensures a Bitcoin payment that was already made can't be refunded twice. After the delay:
 
 **For users on the BOB Gateway UI** — the order appears in the activity section (sidebar) with a withdraw option. One click, sign the transaction, funds returned. No integrator involvement needed.
 

--- a/gateway-docs/content/docs/gateway/refunds.mdx
+++ b/gateway-docs/content/docs/gateway/refunds.mdx
@@ -5,7 +5,7 @@ icon: RotateCcw
 ---
 ## Overview
 
-Gateway is non-custodial. Swaps are atomic and secured by an on-chain Bitcoin Light Client, so a solver can never take a user's funds without delivering the other side of the swap. If a swap can't be completed, the user gets their funds back. BTC-to-X refunds are processed by BOB automatically; the only case requiring user action — an X-to-BTC order where the Bitcoin payout never happened — is a very rare edge case.
+Gateway is non-custodial: its contracts never hold user funds between transactions, apart from the X-to-BTC escrow described below. If a swap can't be completed, the user gets their funds back, and **Gateway settles every refund itself** — there is no refund transaction for a user or an integrator to submit.
 
 Users can always check their order — including refund status — on the [Gateway Explorer](/gateway/integration#link-users-to-the-gateway-explorer) order page, so you don't need to build refund status UI.
 
@@ -13,10 +13,10 @@ Users can always check their order — including refund status — on the [Gatew
 
 | Scenario | What the user receives | Who acts |
 |---|---|---|
-| BTC to X: swap can't fill at quoted terms | BTC to their refund address, or USDT on Ethereum | BOB, automatic |
-| BTC to X: destination swap or bridge can't land | BTC to their refund address, or USDT on Ethereum | BOB, automatic |
-| X to BTC: payout delayed | BTC (gateway bumps the fee) | BOB, automatic |
-| X to BTC: payout can't complete (very rare) | Their locked USDT back | User withdraws — self-serve in BOB Gateway UI, or via `refundTx` for integrators |
+| BTC to X: swap can't fill at quoted terms | BTC to their refund address, or USDT on Ethereum | Gateway, automatic |
+| BTC to X: destination swap or bridge can't land | BTC to their refund address, or USDT on Ethereum | Gateway, automatic |
+| X to BTC: payout delayed | BTC (Gateway bumps the fee) | Gateway, automatic |
+| X to BTC: payout can't complete (very rare) | Their escrowed USDT back | Gateway, after the on-chain refund delay |
 
 ## BTC to X refunds
 
@@ -26,49 +26,56 @@ There are two cases where a BTC-to-X swap returns funds instead of the expected 
 
 2. **The destination swap or bridge can't land.** When a route swaps or bridges onwards through a third-party provider, that on-chain call can revert. The payout and the onward call are one atomic transaction, so the whole release reverts with it and the user is never left holding a partial result.
 
-Both cases resolve the same way, automatically, with no action needed from the user or the integrator. The solver simulates the destination call before releasing, re-quotes, and retries with backoff for about an hour. If the release still can't land, Gateway settles the order as a refund: **BTC back to the Bitcoin `refundAddress`** when the order was created with one, and otherwise **USDT on Ethereum** to the order owner.
+Both cases resolve the same way, automatically, with no action needed from the user or the integrator. The solver simulates the destination call before releasing, then re-quotes and retries the release on an exponential backoff — starting at 15 seconds and doubling — for up to an hour. If the release still can't land, Gateway settles the order as a refund, and the channel is decided by whether the order was created with a Bitcoin `refundAddress`:
+
+- **With a `refundAddress`** — the order is committed to a Bitcoin refund on-chain, then paid from the solver's Bitcoin wallet to that address. The Bitcoin fee needed to get the refund transaction confirmed is deducted from the amount sent, so the user bears the cost of moving their own coins back.
+- **Without one** — USDT on Ethereum to the order owner.
+
+A refunded order earns no fee. Every fee withheld from the fill — solver, protocol and affiliate — is returned to the user along with the deposit.
 
 <Callout>
 Pass a `refundAddress` when you request a quote if you want failed BTC-to-X swaps returned in BTC rather than USDT on Ethereum.
 </Callout>
 
+### Refunds after a partial recovery
+
+If the destination call was already released and the onward bridge sent funds back to the solver instead of delivering them, the refund is sized against what actually came back, converted at the rate the order was originally quoted at, plus every withheld fee. In practice the user bears only the gas the failed bridge attempt consumed.
+
+A handful of cases can't be settled automatically and are held for manual handling rather than paid out incorrectly: a deposit too small to cover the Bitcoin fee for its own refund, a refund that would be below Bitcoin's dust threshold, or a refund address or order owner flagged by screening.
+
 ## X to BTC refunds
 
-X-to-BTC refunds are a very rare edge case: the token swap settles before the Bitcoin payout is made, so a refund only comes into play if the payout never happens (for example, a solver going offline). Often a slow payout isn't a refund case at all — it just needs a Bitcoin fee bump, which the gateway handles internally.
+X-to-BTC refunds are a very rare edge case. The user's USDT is escrowed in the offramp registry when the order is created, and the token side settles before the Bitcoin payout is made — so a refund only comes into play if the payout never happens (for example, a solver going offline). Often a slow payout isn't a refund case at all — it just needs a Bitcoin fee bump, which Gateway handles internally.
 
-If the payout genuinely can't complete, the USDT escrowed when the order was created becomes reclaimable. A security delay applies before funds can be withdrawn — this ensures a Bitcoin payment that was already made can't be refunded twice. After the delay:
+The escrow can leave the contract in exactly two ways:
 
-**For users on the BOB Gateway UI** — the order appears in the activity section (sidebar) with a withdraw option. One click, sign the transaction, funds returned. No integrator involvement needed.
+1. **The solver proves it paid.** `finalizeOfframpOrder` releases the escrow only against an SPV proof of the Bitcoin payout, verified on-chain by the Bitcoin Light Client. See the [Deep Dive](/gateway/technical#x-to-btc).
+2. **Gateway refunds the order.** After the on-chain `refundDelay` has elapsed, the registry owner can call `refundOrder` to return the full escrowed amount to the user. The delay is configurable on-chain between 12 hours and 7 days, and exists so a Bitcoin payment that was already made can't be refunded on top of it.
 
-**For integrators** — your users' orders expose the same reclaim as a `refundTx` in the order status (see below). You can submit it on the user's behalf, surface a withdraw button in your own UI, or simply direct users to the BOB Gateway app where they can self-serve.
+Nothing else can move those funds — in particular, neither a solver nor the relayer can take them.
 
 <Callout type="warn">
-Reclaiming is irreversible. Once an order is refunded/unlocked, it cannot be resumed.
+As of offramp registry V7, `refundOrder` is owner-only: **users and integrators cannot trigger an X-to-BTC refund themselves.** Earlier registry versions let the order owner call it directly, and the API used to hand out a `refundTx` for that purpose; both are gone. If an X-to-BTC order looks stuck, contact us on [Discord](https://discord.gg/gobob) rather than trying to submit a refund.
 </Callout>
 
 <Callout>
-Because users cannot currently submit Bitcoin proofs themselves, an order may be temporarily "stuck" if the relayer is offline. Funds remain safe and become reclaimable — they cannot be taken by the relayer or a solver.
+Because users cannot submit Bitcoin proofs themselves, an order may be temporarily "stuck" if the relayer is offline. Funds remain safe — the escrow can only be released against a valid proof, and it stays refundable to the user after the refund delay.
 </Callout>
 
 ## Do integrators need to build refund handling?
 
-Mostly no. BTC-to-X refunds are fully automatic, and for the rare X-to-BTC case, users can self-serve in the BOB Gateway UI — or you can handle it via `refundTx`. Optionally, surface refund status in your app using the API fields below — for example to show "refunded" in an order history.
+No. Refunds in both directions are settled by Gateway, and there is nothing for you to submit. Optionally, surface refund status in your app using the API fields below — for example to show "refunded" in an order history.
 
 ## Refund status in the API
 
-A completed refund shows up as the `refunded` order status, which lists the `refundedTokens` actually returned (each with `chain`, `token`, `amount`, and the settlement `txHash`). While an order is still in progress or has failed, a `refundTx` may be available to trigger the reclaim:
+A completed refund shows up as the `refunded` order status, which lists the `refundedTokens` actually returned — each with `chain`, `token`, `amount`, and the settlement `txHash`:
 
-- `status.inProgress.refundTx` — refund available on an in-progress order
-- `status.failed.refundTx` — refund available on a failed order
 - `status.refunded.refundedTokens` — the completed refund
+- A BTC refund appears here as a Bitcoin entry, where `txHash` is the Bitcoin txid rather than an EVM transaction hash
 
-## Issuing a refund manually
-
-When a `refundTx` is present, it can be submitted as a normal EVM transaction to reclaim the locked assets. Step-by-step code:
-
-<Card title="Refund stuck orders" icon="unlock" href="/gateway/integration#x-to-btc-order-features" horizontal>
-  Detect a refundable order and submit its refundTx
-</Card>
+<Callout type="warn">
+`status.inProgress.refundTx` and `status.failed.refundTx` are **always `null`**. The fields remain in the response purely so the shape is unchanged for existing integrators — do not build refund flows on them.
+</Callout>
 
 ## Next Steps
 

--- a/gateway-docs/content/docs/gateway/refunds.mdx
+++ b/gateway-docs/content/docs/gateway/refunds.mdx
@@ -47,15 +47,15 @@ A handful of cases can't be settled automatically and are held for manual handli
 
 X-to-BTC refunds are a very rare edge case. The user's USDT is escrowed in the offramp registry when the order is created, and the token side settles before the Bitcoin payout is made — so a refund only comes into play if the payout never happens (for example, a solver going offline). Often a slow payout isn't a refund case at all — it just needs a Bitcoin fee bump, which Gateway handles internally.
 
-The escrow can leave the contract in exactly two ways:
+The escrow has only two possible destinations, and the contract fixes both: the user, or a solver that has proven on-chain that it already paid the user.
 
 1. **The solver proves it paid.** `finalizeOfframpOrder` releases the escrow only against an SPV proof of the Bitcoin payout, verified on-chain by the Bitcoin Light Client. See the [Deep Dive](/gateway/technical#x-to-btc).
-2. **Gateway refunds the order.** After the on-chain `refundDelay` has elapsed, the registry owner can call `refundOrder` to return the full escrowed amount to the user. The delay is configurable on-chain between 12 hours and 7 days, and exists so a Bitcoin payment that was already made can't be refunded on top of it.
+2. **Gateway refunds the order.** Once the on-chain `refundDelay` has elapsed, `refundOrder` returns the full escrowed amount to the user. The delay is configurable on-chain between 12 hours and 7 days, and exists so a Bitcoin payment that was already made can't be refunded on top of it.
 
-Nothing else can move those funds — in particular, neither a solver nor the relayer can take them.
+No other party can move those funds, and there is no route that pays them anywhere else — the registry owner controls the timing of a refund, not its destination.
 
-<Callout type="warn">
-As of offramp registry V7, `refundOrder` is owner-only: **users and integrators cannot trigger an X-to-BTC refund themselves.** Earlier registry versions let the order owner call it directly, and the API used to hand out a `refundTx` for that purpose; both are gone. If an X-to-BTC order looks stuck, contact us on [Discord](https://discord.gg/gobob) rather than trying to submit a refund.
+<Callout>
+`refundOrder` is owner-only, so users and integrators don't trigger X-to-BTC refunds themselves. If an order looks stuck, contact us on [Discord](https://discord.gg/gobob).
 </Callout>
 
 <Callout>

--- a/gateway-docs/content/docs/gateway/technical.mdx
+++ b/gateway-docs/content/docs/gateway/technical.mdx
@@ -1,158 +1,192 @@
 ---
 title: "Deep Dive"
-description: "Technical overview of BOB Gateway's architecture and cross-chain verification"
+description: "How BOB Gateway settles native BTC swaps — solver inventory, atomic release, and SPV-verified payouts"
 icon: Lightbulb
 ---
 ## Overview
 
-BOB Gateway is an intent-based bridge that enables Bitcoin users to access DeFi protocols with a single Bitcoin transaction. The protocol coordinates peer-to-peer swaps between users and Solvers secured by an on-chain Bitcoin Light Client.
+BOB Gateway is an intents protocol for native BTC swaps. A user states what they want — BTC for a token, or a token for BTC — and a solver fills it from its own inventory. The solver holds BTC in a Bitcoin wallet and **USDT on Ethereum as the reserve asset**; every other token and chain is reached by swapping or bridging that USDT through third-party providers (Velora, Bungee, LayerZero OFT).
 
-## BTC to X (Bitcoin → BOB)
+Two things follow from that design, and they shape everything below:
+
+- **Nothing is pooled or locked in a vault.** The solver's own EOA is the custodian of the USDT, and its own Bitcoin wallet holds the BTC. Gateway's contracts never hold funds between transactions, except for the X-to-BTC escrow described below.
+- **The two directions have different settlement mechanics.** X-to-BTC releases escrowed USDT only against an SPV proof verified by an on-chain Bitcoin Light Client. BTC-to-X settles on Bitcoin confirmations, with an automatic refund if the payout can't be delivered.
+
+<Callout>
+Custom strategies (`strategyTarget` / `strategyMessage`) and gas refills were removed. The API rejects them on every version — see [Migration](/gateway/migration).
+</Callout>
+
+## BTC to X
 
 <Steps>
-  <Step>
-
-### Liquidity
-
-    Solvers hold wrapped Bitcoin on BOB or destination chain.
-  </Step>
-  
   <Step>
 
 ### Quote
 
-    User requests to swap BTC for wrapped BTC or execute a DeFi action (stake, lend, swap). The API provides quotes with routing information, fees, and expected outputs.
+    Your app calls `get-quote`. The solver prices the route against live markets and returns the guaranteed minimum output, an `estimatedTimeInSecs`, and a full `feeBreakdown` — solver pricing, protocol fee, affiliate fees, the destination gas priced in USDT (`executionFee`), and any bridge fee. The quote is signed by the API and valid for one minute; that signature travels back in `create-order`, so an order can only be created on terms Gateway actually issued.
   </Step>
-  
+
   <Step>
 
-### Order Creation
+### Order creation
 
-    User creates an order with the Relayer to reserve liquidity. The Relayer provides transaction details including the Solver's Bitcoin address and order parameters.
+    `create-order` returns an `orderId` and a **unique Bitcoin deposit address belonging to the solver's wallet**. If you passed the user's `sender` address, the response also carries a ready-to-sign PSBT (`psbtHex`) with coin selection already done.
   </Step>
-  
+
   <Step>
 
-### Bitcoin Transaction
+### Bitcoin payment
 
-    User sends BTC to the given Bitcoin address. The order details are tracked by the Relayer using the transaction ID (txid).
+    The user signs and broadcasts one Bitcoin transaction. Your app reports it with `register-tx`, which links the transaction to the order. Nothing on the destination chain has happened yet — the user has spent only their BTC and the Bitcoin miner fee.
   </Step>
-  
+
   <Step>
 
-### Trustless Verification
+### Screening and simulation
 
-    The Relayer verifies the Bitcoin transaction:
-    - The transaction exists in a Bitcoin block
-    - The block meets the required proof-of-work difficulty
-    - The transaction was sent to the correct Solver address with the correct amount
+    Before anything is released, the deposit's UTXO sources and the payout recipients are screened with TRM Labs (up to 3 hops), and the destination call is pre-executed in a simulator so a route that would revert is caught before funds move.
   </Step>
-  
+
   <Step>
 
-### Intent Execution
+### Atomic release
 
-    After verification, Gateway releases the Solver's wrapped Bitcoin to execute the user's intent:
-    - **Direct transfer**: Sends wrapped BTC to user's address
-    - **Staking**: Converts to BTC LST/LRT and sends to user
-    - **Custom strategy**: Executes smart contract logic
-    
-    Output tokens are sent to the user's address on the destination chain.
+    Once the deposit is confirmed — cross-checked across independent Bitcoin explorer sources so a single API can't fake it — the solver sends **one** Ethereum transaction calling `releaseFundsAndCallStrategy` on `GatewayOnrampV8`:
+
+    - USDT is pulled from the solver's EOA with `safeTransferFrom`
+    - for an Ethereum destination it goes straight to the recipient; otherwise it's handed to a Gateway strategy contract that swaps or bridges onwards (a multicall wrapping Velora or Bungee, or a LayerZero OFT send)
+    - the destination gas is withheld from the fill (`tokenWithheldForGasAmount`) to reimburse the solver, so the user never needs the destination gas token
+    - affiliate and protocol fees are paid in the same transaction when the destination is Ethereum, and in a follow-up `payFees` call otherwise
+
+    The whole release is all-or-nothing. The contract even reverts if the strategy fails to consume the payout it was handed, so tokens can't be stranded mid-flow.
+  </Step>
+
+  <Step>
+
+### If it can't land
+
+    A release that fails — prices drifted past the quoted minimum, the onward swap reverts — is re-quoted and retried with backoff for about an hour, then settled as a refund: BTC to the order's `refundAddress` if one was given, otherwise USDT to the order owner on Ethereum. See [Refunds](/gateway/refunds).
   </Step>
 </Steps>
 
-### Architecture Diagram
+<Callout type="warn">
+This direction is not SPV-verified: the user's BTC lands in the solver's own wallet, and the solver then releases USDT. What protects the user is the signed quote and the automatic refund path — not an on-chain proof. The on-chain Bitcoin Light Client secures the other direction, where the solver is the one who must prove it paid.
+</Callout>
 
-The BTC-to-X process involves trustless coordination between Bitcoin, the Relayer, and BOB:
+### Architecture diagram
 
 ```mermaid
 sequenceDiagram
     participant User
+    participant API as Gateway API
     participant Bitcoin
-    participant Relayer
-    participant LightClient
-    participant Gateway
     participant Solver
+    participant Onramp as GatewayOnrampV8
+    participant Strategy as Strategy / bridge
 
-    Solver->>Gateway: Lock wrapped BTC
-    User->>Relayer: Request quote
-    Relayer->>User: Return quote
-    User->>Relayer: Create order
-    User->>Bitcoin: Send BTC to Solver address
-    Bitcoin->>Solver: BTC received
-    Relayer->>LightClient: Submit Merkle proof
-    LightClient->>LightClient: Verify proof
-    LightClient->>Gateway: Grant withdrawal permission
-    Gateway->>User: Execute intent & send tokens
+    User->>API: get-quote
+    API->>User: signed quote (1 min validity)
+    User->>API: create-order
+    API->>User: orderId + deposit address (+ PSBT)
+    User->>Bitcoin: broadcast BTC deposit
+    User->>API: register-tx
+    Solver->>Bitcoin: watch deposit until confirmed
+    Solver->>Solver: TRM screening + simulate destination call
+    Solver->>Onramp: releaseFundsAndCallStrategy
+    Onramp->>Strategy: handleGatewayMessage (non-Ethereum destinations)
+    Strategy->>User: output token on destination chain
 ```
 
-## X to BTC (BOB → Bitcoin)
+## X to BTC
 
 <Steps>
   <Step>
 
-### Registration
+### Quote and order creation
 
-    Solvers register their address and fund it with native Bitcoin (BTC) to fulfill X-to-BTC orders.
+    `get-quote` returns the minimum sats the user will receive, plus the solver fee, the Bitcoin miner fee for the payout (`inclusionFee`), and protocol and affiliate fees. `create-order` returns an EVM transaction that calls `createOrder` on `GatewayOfframpRegistryV6`, **escrowing the user's USDT in the contract** together with their Bitcoin output script, the minimum sat output, the affiliate fee list, and a creation deadline.
+
+    Users starting from a different chain or token don't create the order themselves: their token is swapped and bridged to USDT on Ethereum through a third-party provider, and the arriving message is executed by a Gateway composer contract that creates the order on their behalf.
   </Step>
-  
+
   <Step>
 
-### User Creates Order
+### Bitcoin payout
 
-    User locks wrapped Bitcoin in the `OfframpRegistry` smart contract and specifies their Bitcoin address for receiving BTC.
+    The solver waits until the order creation is reorg-safe, screens the destination address, then sends BTC to the user's script with an `OP_RETURN` output committing to `keccak256(orderId, registryAddress)` — that's what ties an on-chain Bitcoin payment to this specific order and this specific registry.
+
+    The payout txid is persisted before broadcast, so a crash degrades to "recorded but maybe unsent" rather than "sent but forgotten". The solver also refuses to pay within a 12-hour safety margin of the order's refund deadline, where the user could reclaim their USDT before the proof lands.
   </Step>
-  
+
   <Step>
 
-### Solver Accepts & Fulfills
+### SPV-verified settlement
 
-    Solvers monitors open orders, accepts those that meets their fee threshold and broadcasts a Bitcoin transaction to the user's specified address.
+    After confirmation, the solver submits the proof to `finalizeOfframpOrder`: the Bitcoin transaction, its Merkle proof, the coinbase transaction and its proof, and a chain of block headers. The `LightRelay` light client checks the headers' accumulated proof-of-work against the registry's on-chain `txProofDifficultyFactor`, and the registry then verifies that the paid output is at least `satOutputMinimum` and that the `OP_RETURN` hash matches the order.
+
+    Only then does the escrow move: protocol fee, affiliate fees, and the remainder to the solver. A `spentTxHashes` mapping means one Bitcoin transaction can never settle two orders.
   </Step>
-  
+
   <Step>
 
-### Proof & Settlement
+### Self-serve refund
 
-    After Bitcoin confirmation, the Relayer submits a Merkle proof of the Bitcoin transaction to the `OfframpRegistry`. The contract verifies the proof and transfers the user's locked wrapped Bitcoin to the Solver as reimbursement.
-  </Step>
-  
-  <Step>
-
-### Fallback Options
-
-    If the order isn't fulfilled within a reasonable time:
-    - User can bump transaction fees to incentivize Solvers
-    - User can unlock their funds after a claim delay period
+    The order owner can call `refundOrder` once the on-chain `refundDelay` has passed (configurable between 12 hours and 7 days), returning the full escrowed amount. This is the user's unilateral exit — it needs no solver and no relayer.
   </Step>
 </Steps>
 
-### Architecture Diagram
+<Callout>
+This is where the trustlessness lives: the solver cannot touch the escrowed USDT without proving on-chain that it paid the user's Bitcoin address, and the user can always walk away with their funds after the refund delay.
+</Callout>
+
+### Architecture diagram
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant OfframpRegistry
+    participant Registry as GatewayOfframpRegistryV6
     participant Solver
     participant Bitcoin
-    participant Relayer
-    participant LightClient
+    participant LightRelay
 
-    Solver->>Solver: Fund Solver with BTC
-    User->>OfframpRegistry: Lock wrapped BTC
-    Solver->>Solver: Monitor orders
-    Solver->>Bitcoin: Send BTC + OP_RETURN
+    User->>Registry: createOrder (escrow USDT, BTC script, min sats)
+    Solver->>Registry: read order once reorg-safe
+    Solver->>Bitcoin: send BTC + OP_RETURN commitment
     Bitcoin->>User: BTC received
-    Solver->>Relayer: Notify completion
-    Relayer->>LightClient: Submit Merkle proof
-    LightClient->>LightClient: Verify proof
-    LightClient->>OfframpRegistry: Confirm transaction
-    OfframpRegistry->>Solver: Release wrapped BTC
+    Solver->>Registry: finalizeOfframpOrder (tx + Merkle + headers)
+    Registry->>LightRelay: validate proof-of-work and Merkle proof
+    LightRelay->>Registry: proof accepted
+    Registry->>Solver: release escrow (minus protocol + affiliate fees)
+    Note over User,Registry: If no payout: user calls refundOrder after refundDelay
 ```
 
 <Callout type="warn">
-Users' funds cannot be stolen by the relayer, but orders may be "stuck" if the relayer is offline since users cannot currently submit proofs themselves.
+Users cannot currently submit Bitcoin proofs themselves, so an order can sit unsettled if proof submission stalls. Funds stay safe either way — the escrow can only be released against a valid proof, and it becomes reclaimable by the owner after the refund delay.
 </Callout>
+
+## Controls
+
+Every order passes a fixed set of controls before funds move, in both directions:
+
+| Control | What it does |
+|---|---|
+| Address screening | TRM Labs, up to 3 hops, on every inbound and outbound flow — BTC senders, USDT recipients, Bitcoin payout addresses, affiliate recipients |
+| Simulation | The destination call is pre-executed in a sandbox and every address that touches funds inside it is screened |
+| Rate limiting | Volume-based, per-account and global |
+| Geo-IP blocking | Restricted jurisdictions are refused — see the [FAQ](/gateway/faq) for the current list |
+| Circuit breaker | The solver can be shut down at the infrastructure level on anomaly detection |
+
+## Contracts
+
+| Contract | Role |
+|---|---|
+| `GatewayOnrampV8` | Releases the solver's USDT for a BTC deposit, directly or through a strategy, and settles fees |
+| `GatewayOfframpRegistryV6` | Escrows USDT, verifies the Bitcoin payout proof, releases to the solver, and handles owner refunds |
+| `LightRelay` | On-chain Bitcoin light client — validates block headers and their accumulated proof-of-work |
+| Strategy contracts | Gateway-owned multicall and LayerZero targets that swap or bridge the payout onwards |
+| Composer contracts | Execute an inbound bridge message to create an X-to-BTC order for users arriving from another chain |
+
+Both Gateway contracts have been audited by Pashov and Common Prefix — see the [audit reports](https://docs.gobob.xyz/docs/reference/audits#bob-gateway).
 
 ## Next Steps
 
@@ -160,10 +194,13 @@ Users' funds cannot be stolen by the relayer, but orders may be "stuck" if the r
   <Card title="Integration Guide" icon="code" href="/gateway/integration">
     Start integrating Gateway into your app
   </Card>
+  <Card title="Refunds" icon="arrow-rotate-left" href="/gateway/refunds">
+    What happens when a swap can't be completed
+  </Card>
+  <Card title="Fees" icon="money-check-dollar" href="/gateway/fees">
+    The full fee breakdown, quote-first
+  </Card>
   <Card title="API Reference" icon="book" href="/api-reference/overview">
     Explore the complete API
-  </Card>
-  <Card title="Technical Docs" icon="file-lines" href="https://docs.gobob.xyz/docs/gateway/overview">
-    Read the full technical documentation
   </Card>
 </Cards>

--- a/gateway-docs/content/docs/gateway/technical.mdx
+++ b/gateway-docs/content/docs/gateway/technical.mdx
@@ -65,7 +65,12 @@ Custom strategies (`strategyTarget` / `strategyMessage`) and gas refills were re
 
 ### If it can't land
 
-    A release that fails — prices drifted past the quoted minimum, the onward swap reverts — is re-quoted and retried with backoff for about an hour, then settled as a refund: BTC to the order's `refundAddress` if one was given, otherwise USDT to the order owner on Ethereum. See [Refunds](/gateway/refunds).
+    A release that fails — prices drifted past the quoted minimum, the onward swap reverts — is re-quoted and retried on an exponential backoff (15s, doubling) for up to an hour, then settled as a refund by the same contract that would have released it:
+
+    - with a `refundAddress`, `commitBitcoinRefund` reserves the order's terminal state on-chain and the BTC is then sent from the solver's Bitcoin wallet, net of the fee needed to confirm that transaction
+    - without one, `refundOrder` pays USDT to the order owner on Ethereum
+
+    Either way the order earns no fee: `refundOrder` marks the fee obligation settled so `payFees` can never pay out on a refunded order, and every withheld fee goes back to the user. See [Refunds](/gateway/refunds).
   </Step>
 </Steps>
 
@@ -104,7 +109,7 @@ sequenceDiagram
 
 ### Quote and order creation
 
-    `get-quote` returns the minimum sats the user will receive, plus the solver fee, the Bitcoin miner fee for the payout (`inclusionFee`), and protocol and affiliate fees. `create-order` returns an EVM transaction that calls `createOrder` on `GatewayOfframpRegistryV6`, **escrowing the user's USDT in the contract** together with their Bitcoin output script, the minimum sat output, the affiliate fee list, and a creation deadline.
+    `get-quote` returns the minimum sats the user will receive, plus the solver fee, the Bitcoin miner fee for the payout (`inclusionFee`), and protocol and affiliate fees. `create-order` returns an EVM transaction that calls `createOrder` on `GatewayOfframpRegistryV7`, **escrowing the user's USDT in the contract** together with their Bitcoin output script, the minimum sat output, the affiliate fee list, and a creation deadline. The call also carries an EIP-712 solver signature over those terms: the registry recovers it against its configured `orderSigner` and consumes the digest, so an order can only be created on terms a solver actually approved, and the same approval can't be replayed.
 
     Users starting from a different chain or token don't create the order themselves: their token is swapped and bridged to USDT on Ethereum through a third-party provider, and the arriving message is executed by a Gateway composer contract that creates the order on their behalf.
   </Step>
@@ -115,7 +120,7 @@ sequenceDiagram
 
     The solver waits until the order creation is reorg-safe, screens the destination address, then sends BTC to the user's script with an `OP_RETURN` output committing to `keccak256(orderId, registryAddress)` — that's what ties an on-chain Bitcoin payment to this specific order and this specific registry.
 
-    The payout txid is persisted before broadcast, so a crash degrades to "recorded but maybe unsent" rather than "sent but forgotten". The solver also refuses to pay within a 12-hour safety margin of the order's refund deadline, where the user could reclaim their USDT before the proof lands.
+    The payout txid is persisted before broadcast, so a crash degrades to "recorded but maybe unsent" rather than "sent but forgotten".
   </Step>
 
   <Step>
@@ -129,14 +134,18 @@ sequenceDiagram
 
   <Step>
 
-### Self-serve refund
+### Refund
 
-    The order owner can call `refundOrder` once the on-chain `refundDelay` has passed (configurable between 12 hours and 7 days), returning the full escrowed amount. This is the user's unilateral exit — it needs no solver and no relayer.
+    If the payout never lands, the escrow is returned by `refundOrder`, which pays the full escrowed amount to the user once the on-chain `refundDelay` has passed (configurable between 12 hours and 7 days). As of V7 this is `onlyOwner`: it is operated by BOB, not callable by the user or a solver. See [Refunds](/gateway/refunds).
   </Step>
 </Steps>
 
 <Callout>
-This is where the trustlessness lives: the solver cannot touch the escrowed USDT without proving on-chain that it paid the user's Bitcoin address, and the user can always walk away with their funds after the refund delay.
+This is where the SPV guarantee lives: the solver cannot touch the escrowed USDT without proving on-chain that it paid the user's Bitcoin address. Escrowed funds have exactly two exits — to the solver against a valid proof, or back to the user via `refundOrder` — so no party can divert them elsewhere.
+</Callout>
+
+<Callout type="warn">
+The refund is no longer a user-side exit. Registry V6 and earlier let the order owner call `refundOrder` themselves; V7 gates it on the contract owner, so recovering a stuck order depends on BOB acting after the refund delay. The escrow still cannot be paid to anyone but the user or a solver that proved it paid.
 </Callout>
 
 ### Architecture diagram
@@ -144,7 +153,7 @@ This is where the trustlessness lives: the solver cannot touch the escrowed USDT
 ```mermaid
 sequenceDiagram
     participant User
-    participant Registry as GatewayOfframpRegistryV6
+    participant Registry as GatewayOfframpRegistryV7
     participant Solver
     participant Bitcoin
     participant LightRelay
@@ -157,11 +166,11 @@ sequenceDiagram
     Registry->>LightRelay: validate proof-of-work and Merkle proof
     LightRelay->>Registry: proof accepted
     Registry->>Solver: release escrow (minus protocol + affiliate fees)
-    Note over User,Registry: If no payout: user calls refundOrder after refundDelay
+    Note over User,Registry: If no payout: BOB calls refundOrder after refundDelay, paying the user
 ```
 
 <Callout type="warn">
-Users cannot currently submit Bitcoin proofs themselves, so an order can sit unsettled if proof submission stalls. Funds stay safe either way — the escrow can only be released against a valid proof, and it becomes reclaimable by the owner after the refund delay.
+Users cannot submit Bitcoin proofs themselves, so an order can sit unsettled if proof submission stalls. Funds stay safe either way — the escrow can only be released against a valid proof, and it stays refundable to the user after the refund delay.
 </Callout>
 
 ## Controls
@@ -180,8 +189,8 @@ Every order passes a fixed set of controls before funds move, in both directions
 
 | Contract | Role |
 |---|---|
-| `GatewayOnrampV8` | Releases the solver's USDT for a BTC deposit, directly or through a strategy, and settles fees |
-| `GatewayOfframpRegistryV6` | Escrows USDT, verifies the Bitcoin payout proof, releases to the solver, and handles owner refunds |
+| `GatewayOnrampV8` | Releases the solver's USDT for a BTC deposit, directly or through a strategy, settles fees, and settles refunds in USDT or by committing to a Bitcoin refund |
+| `GatewayOfframpRegistryV7` | Escrows USDT against a solver signature, verifies the Bitcoin payout proof, releases to the solver, and handles owner-operated refunds |
 | `LightRelay` | On-chain Bitcoin light client — validates block headers and their accumulated proof-of-work |
 | Strategy contracts | Gateway-owned multicall and LayerZero targets that swap or bridge the payout onwards |
 | Composer contracts | Execute an inbound bridge message to create an X-to-BTC order for users arriving from another chain |

--- a/gateway-docs/content/docs/gateway/technical.mdx
+++ b/gateway-docs/content/docs/gateway/technical.mdx
@@ -141,11 +141,7 @@ sequenceDiagram
 </Steps>
 
 <Callout>
-This is where the SPV guarantee lives: the solver cannot touch the escrowed USDT without proving on-chain that it paid the user's Bitcoin address. Escrowed funds have exactly two exits — to the solver against a valid proof, or back to the user via `refundOrder` — so no party can divert them elsewhere.
-</Callout>
-
-<Callout type="warn">
-The refund is no longer a user-side exit. Registry V6 and earlier let the order owner call `refundOrder` themselves; V7 gates it on the contract owner, so recovering a stuck order depends on BOB acting after the refund delay. The escrow still cannot be paid to anyone but the user or a solver that proved it paid.
+This is where the SPV guarantee lives: the solver cannot touch the escrowed USDT without proving on-chain that it paid the user's Bitcoin address. Escrowed funds have exactly two exits — to the solver against a valid proof, or back to the user via `refundOrder` — so the owner key controls when a refund settles, not where it goes.
 </Callout>
 
 ### Architecture diagram

--- a/sdk/src/gateway/README.md
+++ b/sdk/src/gateway/README.md
@@ -68,7 +68,8 @@ passed), `tx` is absent — complete the BTC payment externally using
 
 `getOrders` order objects carry status detail: `inProgress`, `failed`, `success`,
 `refunded` (with token-settlement info), plus `pendingBtcPayment` (`{ txid, amount }`)
-for in-flight X→BTC orders and `refundTx` for stuck ones.
+for in-flight X→BTC orders. `refundTx` is always `null` — the gateway settles refunds
+itself, and the field is retained only to keep the response shape stable.
 
 ## Wallet clients (`walletClient` / `publicClient`)
 


### PR DESCRIPTION
The FAQ, Refunds, Deep Dive and Integration pages described the pre-intents protocol. Checked each claim against the `bob-gateway` codebase and rewrote what no longer holds.

Two commits, because the gateway moved while this PR was open — the second one is the substantive part.

---

## Commit 2: refunds are operator-settled, not user-callable

Two `bob-gateway` changes landed after the first commit and invalidated the refund guidance on four pages.

**`51f40696` dropped the user-callable refund tx.** `refundTx` is now hardcoded `None` on v1, v2 *and* v3 order status; `order_recovery.rs` and `OfframpWrapper::refund_tx`/`refund_delay` are deleted. The field survives only so the response shape is unchanged for existing integrators — there's a test asserting it serializes as `null`.

**`70ce78dd`/`dedee564` moved production to `GatewayOfframpRegistryV7`,** whose `refundOrder` is `onlyOwner` (`contracts/src/GatewayOfframpRegistryV7.sol:180`). V6 required `_msgSender() == order.owner`, so users had a unilateral exit. They no longer do, and nothing in the solver or API calls the offramp `refundOrder` automatically — it's an operator action.

So the pages promising that users "self-serve in the BOB Gateway UI — one click, sign the transaction" and that integrators can "submit the `refundTx` on their behalf" described a path that no longer exists at either layer.

### Refunds

- X-to-BTC section rewritten: operator-settled after the on-chain `refundDelay`, framed as the escrow's only two exits (SPV-proven release to the solver, or `refundOrder` back to the user).
- Dropped "Issuing a refund manually" and every self-serve/UI-withdraw claim.
- Added BTC-to-X detail from `onramp/refund.rs`: the Bitcoin inclusion fee is deducted from the refund (the user bears the cost of moving their own coins back), every withheld fee — solver, protocol, affiliate — is returned, and a post-release refund is sized pro-rata at the quoted rate against what the bridge actually recovered.
- Documented that `refundTx` is always `null`.

### Deep Dive

- `GatewayOfframpRegistryV6` → V7 in prose, diagram and contracts table.
- Documented the EIP-712 solver signature `createOrder` now recovers against `orderSigner` and consumes.
- "Self-serve refund" → owner-operated, with the trust claim split: the SPV guarantee still holds against the solver, but the user-side exit is gone and that's now called out explicitly.
- Covered `commitBitcoinRefund` alongside `refundOrder` on the onramp side.
- Dropped the 12-hour payout safety margin — removed from the code by the same commit that made refunds owner-callable, since BOB now controls both sides of that race.

### FAQ

Fixed the two answers that promised self-serve reclaim ("What happens if my swap fails?" and "Can I cancel a transaction?").

### Integration

The "Refund Stuck Orders" accordion's code would now find nothing and submit nothing. Replaced with reading the `refunded` status, including that a BTC refund reports `chain: 'bitcoin'` with a Bitcoin txid in `txHash` rather than an EVM hash. Also corrected the same claim in `sdk/src/gateway/README.md`.

---

## Commit 1: FAQ, refunds and deep dive to current protocol

- **FAQ** — removed "Who pays the gas fees?" (the Relayer no longer estimates gas; it only submits SPV proofs — gas is priced in USDT by the solver and withheld from the fill, already documented on Fees) and "What happens if my DeFi action fails?" (custom strategies were removed; the API rejects `strategyTarget`/`strategyMessage` on every version). Replaced with a single "What happens if my swap fails?".
- **Refunds** — BTC-to-X failures refund BTC to the order's `refundAddress` or USDT on Ethereum; there is no wrapped-BTC fallback. X-to-BTC orders escrow USDT, not wrapped BTC.
- **Deep Dive** — rewritten end to end. The old page had solvers holding wrapped BTC, the Relayer issuing quotes and creating orders, and a Bitcoin Light Client verifying the BTC-to-X direction. Now: API-signed quote (1-minute validity, echoed back on `create-order`), deposit address from the solver's own Bitcoin wallet, TRM screening plus destination-call simulation, then one atomic `releaseFundsAndCallStrategy` on `GatewayOnrampV8`. Added controls and contracts tables and replaced both mermaid diagrams.

### One call worth reviewing

The page states plainly that **only X-to-BTC is SPV-verified**. BTC-to-X settles on Bitcoin confirmations — the deposit lands in the solver's own wallet — and the user's protection is the signed quote plus the automatic refund path. That matches the contracts (`GatewayOnrampV8` has no relay reference; only the offramp registry validates proofs), but it's a more conservative claim than the marketing pages make. Reword if you'd rather frame it differently.

---

## Two things I did not change

1. **The audit claim is probably stale.** `technical.mdx` and `faq.mdx` both say the Gateway contracts "have been audited by Pashov and Common Prefix." `bob-gateway/audits/` tops out at onramp v4 and offramp v1, plus a 2025-08-27 offramp-solver report — nothing covering `GatewayOnrampV8` or `GatewayOfframpRegistryV7`, which are what's live. Left alone because audit status is a legal/marketing statement and unpublished reports wouldn't appear in that folder. Needs a decision from someone who knows the real position.
2. **`refundDelay`'s deployed value** is set from `REFUND_DELAY` at deploy time, so the docs give the contract's 12h–7d bounds rather than a specific figure. Happy to state the live value if someone confirms it.

## Also still untouched

`overview.mdx` step 2 says a solver "locks the output asset in a smart contract... before the user sends any Bitcoin" — there is no such lock; the solver EOA stays custodian until release. Step 4 and the Non-Custodial accordion apply Light Client verification to the flow as a whole. Follow-up.

## Verification

`npm run build` and `npm run lint` pass in `gateway-docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
