### PR TITLE
refactor(sdk): simplify quote execution errors

### DIFF
--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -51,6 +51,7 @@ const RETRY_COUNT = 8; // Number of times to retry fetching transaction receipt 
 
 const INSUFFICIENT_FUNDS_MESSAGE =
     'Insufficient native funds for source and destination gas fees, please add more native funds to your account';
+const EXECUTE_QUOTE_ERROR_MESSAGE = 'Failed to execute Gateway quote after order creation';
 
 // ContractFunctionExecutionError also wraps plain reverts, so only translate when
 // InsufficientFundsError is actually in the cause chain.
@@ -71,7 +72,9 @@ async function simulateApproval<T>(orderId: string, simulate: () => Promise<{ re
     try {
         return (await simulate()).request;
     } catch (error) {
-        throw new ExecuteQuoteError(orderId, { cause: error, message: getApprovalErrorMessage(error) });
+        throw new ExecuteQuoteError(getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE, orderId, {
+            cause: error,
+        });
     }
 }
 
@@ -320,15 +323,16 @@ export class GatewayApiClient {
                         opReturn: order.onramp.opReturnData || undefined,
                         // isSignet: this.isSignet,
                     });
-                    if (!bitcoinTxHex) throw new Error('Failed to get signed transaction');
                 } catch (error) {
-                    throw new ExecuteQuoteError(orderId, { cause: error });
+                    throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
                 }
             } else if (btcSigner.signAllInputs) {
                 if (!order.onramp.psbtHex) {
-                    throw new ExecuteQuoteError(orderId, {
-                        message: 'PSBT not available: sender address is required when using signAllInputs',
-                    });
+                    throw new ExecuteQuoteError(
+                        'PSBT not available: sender address is required when using signAllInputs',
+                        orderId,
+                        {}
+                    );
                 }
                 const psbtHex = order.onramp.psbtHex;
                 callback?.({
@@ -339,14 +343,15 @@ export class GatewayApiClient {
                 });
                 try {
                     bitcoinTxHex = await btcSigner.signAllInputs(psbtHex);
-                    if (!bitcoinTxHex) throw new Error('Failed to get signed transaction');
                 } catch (error) {
-                    throw new ExecuteQuoteError(orderId, { cause: error });
+                    throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
                 }
             } else {
-                throw new ExecuteQuoteError(orderId, {
-                    message: 'btcSigner must implement either sendBitcoin or signAllInputs method',
-                });
+                throw new ExecuteQuoteError(
+                    'btcSigner must implement either sendBitcoin or signAllInputs method',
+                    orderId,
+                    {}
+                );
             }
 
             let tx: RegisterTxSuccess;
@@ -371,7 +376,7 @@ export class GatewayApiClient {
                     tx = response;
                 }
             } catch (error) {
-                throw new ExecuteQuoteError(orderId, { cause: error });
+                throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
             }
 
             if (typeof tx === 'string') {
@@ -428,7 +433,7 @@ export class GatewayApiClient {
                             args: [accountAddress, spenderAddress],
                         });
                     } catch (error) {
-                        throw new ExecuteQuoteError(orderId, { cause: error });
+                        throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
                     }
                 }
             }
@@ -464,7 +469,11 @@ export class GatewayApiClient {
                         const resetTxHash = await walletClient.writeContract(resetRequest);
                         await publicClient.waitForTransactionReceipt({ hash: resetTxHash, retryCount: RETRY_COUNT });
                     } catch (error) {
-                        throw new ExecuteQuoteError(orderId, { cause: error, message: getApprovalErrorMessage(error) });
+                        throw new ExecuteQuoteError(
+                            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE,
+                            orderId,
+                            { cause: error }
+                        );
                     }
                 }
 
@@ -488,7 +497,11 @@ export class GatewayApiClient {
                     const approveTxHash = await walletClient.writeContract(approveRequest);
                     await publicClient.waitForTransactionReceipt({ hash: approveTxHash, retryCount: RETRY_COUNT });
                 } catch (error) {
-                    throw new ExecuteQuoteError(orderId, { cause: error, message: getApprovalErrorMessage(error) });
+                    throw new ExecuteQuoteError(
+                        getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE,
+                        orderId,
+                        { cause: error }
+                    );
                 }
             }
 
@@ -519,7 +532,7 @@ export class GatewayApiClient {
 
                 transactionHash = hash;
             } catch (error) {
-                throw new ExecuteQuoteError(orderId, { cause: error });
+                throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
             }
 
             try {
@@ -624,7 +637,11 @@ export class GatewayApiClient {
                             retryCount: RETRY_COUNT,
                         });
                     } catch (error) {
-                        throw new ExecuteQuoteError(orderId, { cause: error, message: getApprovalErrorMessage(error) });
+                        throw new ExecuteQuoteError(
+                            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE,
+                            orderId,
+                            { cause: error }
+                        );
                     }
                 }
 
@@ -653,7 +670,11 @@ export class GatewayApiClient {
 
                     await publicClient.waitForTransactionReceipt({ hash: txHash, retryCount: RETRY_COUNT });
                 } catch (error) {
-                    throw new ExecuteQuoteError(orderId, { cause: error, message: getApprovalErrorMessage(error) });
+                    throw new ExecuteQuoteError(
+                        getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE,
+                        orderId,
+                        { cause: error }
+                    );
                 }
             }
 
@@ -685,7 +706,7 @@ export class GatewayApiClient {
 
                 transactionHash = hash;
             } catch (error) {
-                throw new ExecuteQuoteError(orderId, { cause: error });
+                throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
             }
 
             try {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -72,11 +72,7 @@ async function simulateApproval<T>(orderId: string, simulate: () => Promise<{ re
     try {
         return (await simulate()).request;
     } catch (error) {
-        throw new ExecuteQuoteError(
-            { cause: error },
-            orderId,
-            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
-        );
+        throw new ExecuteQuoteError(orderId, getApprovalErrorMessage(error), { cause: error });
     }
 }
 
@@ -326,12 +322,11 @@ export class GatewayApiClient {
                         // isSignet: this.isSignet,
                     });
                 } catch (error) {
-                    throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
+                    throw new ExecuteQuoteError(orderId, EXECUTE_QUOTE_ERROR_MESSAGE, { cause: error });
                 }
             } else if (btcSigner.signAllInputs) {
                 if (!order.onramp.psbtHex) {
                     throw new ExecuteQuoteError(
-                        {},
                         orderId,
                         'PSBT not available: sender address is required when using signAllInputs'
                     );
@@ -346,11 +341,10 @@ export class GatewayApiClient {
                 try {
                     bitcoinTxHex = await btcSigner.signAllInputs(psbtHex);
                 } catch (error) {
-                    throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
+                    throw new ExecuteQuoteError(orderId, EXECUTE_QUOTE_ERROR_MESSAGE, { cause: error });
                 }
             } else {
                 throw new ExecuteQuoteError(
-                    {},
                     orderId,
                     'btcSigner must implement either sendBitcoin or signAllInputs method'
                 );
@@ -378,7 +372,7 @@ export class GatewayApiClient {
                     tx = response;
                 }
             } catch (error) {
-                throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
+                throw new ExecuteQuoteError(orderId, EXECUTE_QUOTE_ERROR_MESSAGE, { cause: error });
             }
 
             if (typeof tx === 'string') {
@@ -435,7 +429,7 @@ export class GatewayApiClient {
                             args: [accountAddress, spenderAddress],
                         });
                     } catch (error) {
-                        throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
+                        throw new ExecuteQuoteError(orderId, EXECUTE_QUOTE_ERROR_MESSAGE, { cause: error });
                     }
                 }
             }
@@ -471,11 +465,7 @@ export class GatewayApiClient {
                         const resetTxHash = await walletClient.writeContract(resetRequest);
                         await publicClient.waitForTransactionReceipt({ hash: resetTxHash, retryCount: RETRY_COUNT });
                     } catch (error) {
-                        throw new ExecuteQuoteError(
-                            { cause: error },
-                            orderId,
-                            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
-                        );
+                        throw new ExecuteQuoteError(orderId, getApprovalErrorMessage(error), { cause: error });
                     }
                 }
 
@@ -499,11 +489,7 @@ export class GatewayApiClient {
                     const approveTxHash = await walletClient.writeContract(approveRequest);
                     await publicClient.waitForTransactionReceipt({ hash: approveTxHash, retryCount: RETRY_COUNT });
                 } catch (error) {
-                    throw new ExecuteQuoteError(
-                        { cause: error },
-                        orderId,
-                        getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
-                    );
+                    throw new ExecuteQuoteError(orderId, getApprovalErrorMessage(error), { cause: error });
                 }
             }
 
@@ -534,7 +520,7 @@ export class GatewayApiClient {
 
                 transactionHash = hash;
             } catch (error) {
-                throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
+                throw new ExecuteQuoteError(orderId, EXECUTE_QUOTE_ERROR_MESSAGE, { cause: error });
             }
 
             try {
@@ -639,11 +625,7 @@ export class GatewayApiClient {
                             retryCount: RETRY_COUNT,
                         });
                     } catch (error) {
-                        throw new ExecuteQuoteError(
-                            { cause: error },
-                            orderId,
-                            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
-                        );
+                        throw new ExecuteQuoteError(orderId, getApprovalErrorMessage(error), { cause: error });
                     }
                 }
 
@@ -672,11 +654,7 @@ export class GatewayApiClient {
 
                     await publicClient.waitForTransactionReceipt({ hash: txHash, retryCount: RETRY_COUNT });
                 } catch (error) {
-                    throw new ExecuteQuoteError(
-                        { cause: error },
-                        orderId,
-                        getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
-                    );
+                    throw new ExecuteQuoteError(orderId, getApprovalErrorMessage(error), { cause: error });
                 }
             }
 
@@ -708,7 +686,7 @@ export class GatewayApiClient {
 
                 transactionHash = hash;
             } catch (error) {
-                throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
+                throw new ExecuteQuoteError(orderId, EXECUTE_QUOTE_ERROR_MESSAGE, { cause: error });
             }
 
             try {

--- a/sdk/src/gateway/client.ts
+++ b/sdk/src/gateway/client.ts
@@ -72,9 +72,11 @@ async function simulateApproval<T>(orderId: string, simulate: () => Promise<{ re
     try {
         return (await simulate()).request;
     } catch (error) {
-        throw new ExecuteQuoteError(getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE, orderId, {
-            cause: error,
-        });
+        throw new ExecuteQuoteError(
+            { cause: error },
+            orderId,
+            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
+        );
     }
 }
 
@@ -324,14 +326,14 @@ export class GatewayApiClient {
                         // isSignet: this.isSignet,
                     });
                 } catch (error) {
-                    throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
+                    throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
                 }
             } else if (btcSigner.signAllInputs) {
                 if (!order.onramp.psbtHex) {
                     throw new ExecuteQuoteError(
-                        'PSBT not available: sender address is required when using signAllInputs',
+                        {},
                         orderId,
-                        {}
+                        'PSBT not available: sender address is required when using signAllInputs'
                     );
                 }
                 const psbtHex = order.onramp.psbtHex;
@@ -344,13 +346,13 @@ export class GatewayApiClient {
                 try {
                     bitcoinTxHex = await btcSigner.signAllInputs(psbtHex);
                 } catch (error) {
-                    throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
+                    throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
                 }
             } else {
                 throw new ExecuteQuoteError(
-                    'btcSigner must implement either sendBitcoin or signAllInputs method',
+                    {},
                     orderId,
-                    {}
+                    'btcSigner must implement either sendBitcoin or signAllInputs method'
                 );
             }
 
@@ -376,7 +378,7 @@ export class GatewayApiClient {
                     tx = response;
                 }
             } catch (error) {
-                throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
+                throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
             }
 
             if (typeof tx === 'string') {
@@ -433,7 +435,7 @@ export class GatewayApiClient {
                             args: [accountAddress, spenderAddress],
                         });
                     } catch (error) {
-                        throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
+                        throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
                     }
                 }
             }
@@ -470,9 +472,9 @@ export class GatewayApiClient {
                         await publicClient.waitForTransactionReceipt({ hash: resetTxHash, retryCount: RETRY_COUNT });
                     } catch (error) {
                         throw new ExecuteQuoteError(
-                            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE,
+                            { cause: error },
                             orderId,
-                            { cause: error }
+                            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
                         );
                     }
                 }
@@ -498,9 +500,9 @@ export class GatewayApiClient {
                     await publicClient.waitForTransactionReceipt({ hash: approveTxHash, retryCount: RETRY_COUNT });
                 } catch (error) {
                     throw new ExecuteQuoteError(
-                        getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE,
+                        { cause: error },
                         orderId,
-                        { cause: error }
+                        getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
                     );
                 }
             }
@@ -532,7 +534,7 @@ export class GatewayApiClient {
 
                 transactionHash = hash;
             } catch (error) {
-                throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
+                throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
             }
 
             try {
@@ -638,9 +640,9 @@ export class GatewayApiClient {
                         });
                     } catch (error) {
                         throw new ExecuteQuoteError(
-                            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE,
+                            { cause: error },
                             orderId,
-                            { cause: error }
+                            getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
                         );
                     }
                 }
@@ -671,9 +673,9 @@ export class GatewayApiClient {
                     await publicClient.waitForTransactionReceipt({ hash: txHash, retryCount: RETRY_COUNT });
                 } catch (error) {
                     throw new ExecuteQuoteError(
-                        getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE,
+                        { cause: error },
                         orderId,
-                        { cause: error }
+                        getApprovalErrorMessage(error) ?? EXECUTE_QUOTE_ERROR_MESSAGE
                     );
                 }
             }
@@ -706,7 +708,7 @@ export class GatewayApiClient {
 
                 transactionHash = hash;
             } catch (error) {
-                throw new ExecuteQuoteError(EXECUTE_QUOTE_ERROR_MESSAGE, orderId, { cause: error });
+                throw new ExecuteQuoteError({ cause: error }, orderId, EXECUTE_QUOTE_ERROR_MESSAGE);
             }
 
             try {

--- a/sdk/src/gateway/types/execute.ts
+++ b/sdk/src/gateway/types/execute.ts
@@ -19,7 +19,7 @@ export class ExecuteQuoteError extends Error {
 
     public readonly name = 'ExecuteQuoteError';
 
-    constructor(message: string, orderId: string, options: ErrorOptions) {
+    constructor(options: ErrorOptions, orderId: string, message: string) {
         super(message, options);
         this.orderId = orderId;
     }

--- a/sdk/src/gateway/types/execute.ts
+++ b/sdk/src/gateway/types/execute.ts
@@ -17,9 +17,10 @@ export interface ExecuteQuoteStep {
 export class ExecuteQuoteError extends Error {
     readonly orderId: string;
 
+    public readonly name = 'ExecuteQuoteError';
+
     constructor(message: string, orderId: string, options: ErrorOptions) {
         super(message, options);
-        this.name = 'ExecuteQuoteError';
         this.orderId = orderId;
     }
 }

--- a/sdk/src/gateway/types/execute.ts
+++ b/sdk/src/gateway/types/execute.ts
@@ -17,9 +17,13 @@ export interface ExecuteQuoteStep {
 export class ExecuteQuoteError extends Error {
     readonly orderId: string;
 
-    public readonly name = 'ExecuteQuoteError';
+    readonly name = 'ExecuteQuoteError';
 
-    constructor(options: ErrorOptions, orderId: string, message: string) {
+    constructor(
+        orderId: string,
+        message = 'Failed to execute Gateway quote after order creation',
+        options?: ErrorOptions
+    ) {
         super(message, options);
         this.orderId = orderId;
     }

--- a/sdk/src/gateway/types/execute.ts
+++ b/sdk/src/gateway/types/execute.ts
@@ -13,18 +13,12 @@ export interface ExecuteQuoteStep {
     orderId?: string;
 }
 
-const EXECUTE_QUOTE_ERROR_MESSAGE = 'Failed to execute Gateway quote after order creation';
-
-type ExecuteQuoteErrorOptions = { message: string } | { cause: unknown; message?: string };
-
 /** Thrown by {@link GatewayApiClient.executeQuote} after order creation; `cause`, when present, is the exact caught value. */
 export class ExecuteQuoteError extends Error {
     readonly orderId: string;
 
-    constructor(orderId: string, options: ExecuteQuoteErrorOptions) {
-        const cause = 'cause' in options ? options.cause : undefined;
-
-        super(options.message ?? EXECUTE_QUOTE_ERROR_MESSAGE, 'cause' in options ? { cause } : undefined);
+    constructor(message: string, orderId: string, options: ErrorOptions) {
+        super(message, options);
         this.name = 'ExecuteQuoteError';
         this.orderId = orderId;
     }

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -737,7 +737,7 @@ describe('Gateway Tests', () => {
         expect(registerTxScope.isDone()).toBe(false);
     });
 
-    it('should throw error when btcSigner returns empty transaction', async () => {
+    it('should register an empty transaction returned by btcSigner', async () => {
         const gatewaySDK = new GatewaySDK();
 
         const mockQuote: GatewayQuoteOneOf = {
@@ -813,6 +813,12 @@ describe('Gateway Tests', () => {
                 },
             });
 
+        nock(`${MAINNET_GATEWAY_BASE_URL}`)
+            .patch('/v3/register-tx', {
+                onramp: { bitcoin_tx_hex: '', order_id: mockOrderId },
+            })
+            .reply(200, JSON.stringify('tx-hash-empty'));
+
         const mockBtcSigner: BitcoinSigner = {
             signAllInputs: async () => '',
         };
@@ -823,22 +829,17 @@ describe('Gateway Tests', () => {
 
         const mockPublicClient = {} as PublicClient<Transport>;
 
-        const error = await gatewaySDK
-            .executeQuote({
-                quote: mockQuote,
-                walletClient: mockWalletClient,
-                publicClient: mockPublicClient,
-                btcSigner: mockBtcSigner,
-            })
-            .catch((thrown: unknown) => thrown);
+        const result = await gatewaySDK.executeQuote({
+            quote: mockQuote,
+            walletClient: mockWalletClient,
+            publicClient: mockPublicClient,
+            btcSigner: mockBtcSigner,
+        });
 
-        expect(error).toBeInstanceOf(ExecuteQuoteError);
-        assert(error instanceof ExecuteQuoteError);
-        expect(error.orderId).toBe(mockOrderId);
-        expect(error.message).toBe('Failed to execute Gateway quote after order creation');
-        expect(error.cause).toBeInstanceOf(Error);
-        assert(error.cause instanceof Error);
-        expect(error.cause.message).toBe('Failed to get signed transaction');
+        expect(result).toEqual({
+            order: expect.objectContaining({ onramp: expect.objectContaining({ orderId: mockOrderId }) }),
+            tx: 'tx-hash-empty',
+        });
     });
 
     it('should execute offramp quote with token approval', async () => {
@@ -3388,7 +3389,9 @@ describe('Gateway Tests', () => {
     describe('ExecuteQuoteError', () => {
         it('is a real class instance carrying orderId and the original error as cause', () => {
             const original = new Error('boom');
-            const error = new ExecuteQuoteError('order-abc', { cause: original });
+            const error = new ExecuteQuoteError('Failed to execute Gateway quote after order creation', 'order-abc', {
+                cause: original,
+            });
 
             expect(error).toBeInstanceOf(Error);
             expect(error).toBeInstanceOf(ExecuteQuoteError);
@@ -3402,23 +3405,22 @@ describe('Gateway Tests', () => {
             const frozen = Object.freeze(new Error('frozen'));
             const rpcRejection = { code: 4001, message: 'User rejected the transaction' };
 
-            expect(() => new ExecuteQuoteError('order-frozen', { cause: frozen })).not.toThrow();
-            expect(new ExecuteQuoteError('order-frozen', { cause: frozen }).cause).toBe(frozen);
-            expect(new ExecuteQuoteError('order-frozen', { cause: frozen }).message).toBe(
-                'Failed to execute Gateway quote after order creation'
-            );
+            const message = 'Failed to execute Gateway quote after order creation';
 
-            expect(() => new ExecuteQuoteError('order-rpc', { cause: rpcRejection })).not.toThrow();
-            expect(new ExecuteQuoteError('order-rpc', { cause: rpcRejection }).cause).toBe(rpcRejection);
-            expect(new ExecuteQuoteError('order-rpc', { cause: rpcRejection }).message).toBe(
-                'Failed to execute Gateway quote after order creation'
-            );
+            expect(() => new ExecuteQuoteError(message, 'order-frozen', { cause: frozen })).not.toThrow();
+            expect(new ExecuteQuoteError(message, 'order-frozen', { cause: frozen }).cause).toBe(frozen);
+            expect(new ExecuteQuoteError(message, 'order-frozen', { cause: frozen }).message).toBe(message);
+
+            expect(() => new ExecuteQuoteError(message, 'order-rpc', { cause: rpcRejection })).not.toThrow();
+            expect(new ExecuteQuoteError(message, 'order-rpc', { cause: rpcRejection }).cause).toBe(rpcRejection);
+            expect(new ExecuteQuoteError(message, 'order-rpc', { cause: rpcRejection }).message).toBe(message);
         });
 
         it('uses an explicit message and omits cause for validation-only failures', () => {
-            const error = new ExecuteQuoteError('order-validation', { message: 'btcSigner missing' });
+            const error = new ExecuteQuoteError('btcSigner missing', 'order-validation', {});
 
             expect(error.message).toBe('btcSigner missing');
+            expect(error.orderId).toBe('order-validation');
             expect(Object.hasOwn(error, 'cause')).toBe(false);
         });
     });

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -3389,11 +3389,7 @@ describe('Gateway Tests', () => {
     describe('ExecuteQuoteError', () => {
         it('is a real class instance carrying orderId and the original error as cause', () => {
             const original = new Error('boom');
-            const error = new ExecuteQuoteError(
-                { cause: original },
-                'order-abc',
-                'Failed to execute Gateway quote after order creation'
-            );
+            const error = new ExecuteQuoteError('order-abc', undefined, { cause: original });
 
             expect(error).toBeInstanceOf(Error);
             expect(error).toBeInstanceOf(ExecuteQuoteError);
@@ -3409,17 +3405,17 @@ describe('Gateway Tests', () => {
 
             const message = 'Failed to execute Gateway quote after order creation';
 
-            expect(() => new ExecuteQuoteError({ cause: frozen }, 'order-frozen', message)).not.toThrow();
-            expect(new ExecuteQuoteError({ cause: frozen }, 'order-frozen', message).cause).toBe(frozen);
-            expect(new ExecuteQuoteError({ cause: frozen }, 'order-frozen', message).message).toBe(message);
+            expect(() => new ExecuteQuoteError('order-frozen', message, { cause: frozen })).not.toThrow();
+            expect(new ExecuteQuoteError('order-frozen', message, { cause: frozen }).cause).toBe(frozen);
+            expect(new ExecuteQuoteError('order-frozen', message, { cause: frozen }).message).toBe(message);
 
-            expect(() => new ExecuteQuoteError({ cause: rpcRejection }, 'order-rpc', message)).not.toThrow();
-            expect(new ExecuteQuoteError({ cause: rpcRejection }, 'order-rpc', message).cause).toBe(rpcRejection);
-            expect(new ExecuteQuoteError({ cause: rpcRejection }, 'order-rpc', message).message).toBe(message);
+            expect(() => new ExecuteQuoteError('order-rpc', message, { cause: rpcRejection })).not.toThrow();
+            expect(new ExecuteQuoteError('order-rpc', message, { cause: rpcRejection }).cause).toBe(rpcRejection);
+            expect(new ExecuteQuoteError('order-rpc', message, { cause: rpcRejection }).message).toBe(message);
         });
 
         it('uses an explicit message and omits cause for validation-only failures', () => {
-            const error = new ExecuteQuoteError({}, 'order-validation', 'btcSigner missing');
+            const error = new ExecuteQuoteError('order-validation', 'btcSigner missing');
 
             expect(error.message).toBe('btcSigner missing');
             expect(error.orderId).toBe('order-validation');

--- a/sdk/test/gateway.test.ts
+++ b/sdk/test/gateway.test.ts
@@ -3389,9 +3389,11 @@ describe('Gateway Tests', () => {
     describe('ExecuteQuoteError', () => {
         it('is a real class instance carrying orderId and the original error as cause', () => {
             const original = new Error('boom');
-            const error = new ExecuteQuoteError('Failed to execute Gateway quote after order creation', 'order-abc', {
-                cause: original,
-            });
+            const error = new ExecuteQuoteError(
+                { cause: original },
+                'order-abc',
+                'Failed to execute Gateway quote after order creation'
+            );
 
             expect(error).toBeInstanceOf(Error);
             expect(error).toBeInstanceOf(ExecuteQuoteError);
@@ -3407,17 +3409,17 @@ describe('Gateway Tests', () => {
 
             const message = 'Failed to execute Gateway quote after order creation';
 
-            expect(() => new ExecuteQuoteError(message, 'order-frozen', { cause: frozen })).not.toThrow();
-            expect(new ExecuteQuoteError(message, 'order-frozen', { cause: frozen }).cause).toBe(frozen);
-            expect(new ExecuteQuoteError(message, 'order-frozen', { cause: frozen }).message).toBe(message);
+            expect(() => new ExecuteQuoteError({ cause: frozen }, 'order-frozen', message)).not.toThrow();
+            expect(new ExecuteQuoteError({ cause: frozen }, 'order-frozen', message).cause).toBe(frozen);
+            expect(new ExecuteQuoteError({ cause: frozen }, 'order-frozen', message).message).toBe(message);
 
-            expect(() => new ExecuteQuoteError(message, 'order-rpc', { cause: rpcRejection })).not.toThrow();
-            expect(new ExecuteQuoteError(message, 'order-rpc', { cause: rpcRejection }).cause).toBe(rpcRejection);
-            expect(new ExecuteQuoteError(message, 'order-rpc', { cause: rpcRejection }).message).toBe(message);
+            expect(() => new ExecuteQuoteError({ cause: rpcRejection }, 'order-rpc', message)).not.toThrow();
+            expect(new ExecuteQuoteError({ cause: rpcRejection }, 'order-rpc', message).cause).toBe(rpcRejection);
+            expect(new ExecuteQuoteError({ cause: rpcRejection }, 'order-rpc', message).message).toBe(message);
         });
 
         it('uses an explicit message and omits cause for validation-only failures', () => {
-            const error = new ExecuteQuoteError('btcSigner missing', 'order-validation', {});
+            const error = new ExecuteQuoteError({}, 'order-validation', 'btcSigner missing');
 
             expect(error.message).toBe('btcSigner missing');
             expect(error.orderId).toBe('order-validation');


### PR DESCRIPTION
## Summary

- align ExecuteQuoteError constructor with Error message/options arguments
- migrate executeQuote callers while preserving messages, causes, and order IDs
- pass empty signer results to Gateway registration and cover behavior

## Test plan

- pnpm run build
- pnpm run lint
- pnpm run format:check
- pnpm run test (93 passed, 11 skipped)

Stacked on #1149.