### PR TITLE
feat(cli): add swap refund address

### DIFF
--- a/gateway-cli/README.md
+++ b/gateway-cli/README.md
@@ -175,6 +175,7 @@ All config via environment variables. No config files.
 
 ```
 --private-key <key>      Signing key (or use env vars)
+--refund-address <addr>  Valid Bitcoin refund address (Bitcoin source swaps only)
 --unsigned               Output unsigned PSBT/tx without signing
 --no-wait                Exit after submitting without polling
 --no-retry               Fail immediately on transient errors (retry is on by default)

--- a/gateway-cli/src/cli.ts
+++ b/gateway-cli/src/cli.ts
@@ -106,6 +106,7 @@ program
   .option("--btc-fee-rate <sat/vbyte>", "Bitcoin fee rate (default: mempool.space)")
   .option("--fee-token <address>", "ERC20 token used to pay gas (paymaster)")
   .option("--fee-reserve <amount>", "Amount of fee token to reserve for gas, in atomic units (e.g. wei)")
+  .option("--refund-address <address>", "Bitcoin refund address (Bitcoin source swaps only)")
   .option("--private-key <key>", "Private key (WIF for BTC, hex for EVM). WARNING: visible in process listings — prefer env vars")
   .option("--no-wait", "Exit after submitting without polling")
   .option("--unsigned", "Output unsigned PSBT/tx data without signing", false)

--- a/gateway-cli/src/schemas.ts
+++ b/gateway-cli/src/schemas.ts
@@ -41,6 +41,7 @@ export const quoteSchema = z.object({
  * Extends quoteSchema with additional swap-specific fields.
  */
 export const swapSchema = quoteSchema.and(z.object({
+  refundAddress: z.string().optional(),
   privateKey: z.string().optional(),
   wait: z.boolean().default(true),
   unsigned: z.boolean().default(false),

--- a/gateway-cli/src/util/swap-context.ts
+++ b/gateway-cli/src/util/swap-context.ts
@@ -20,6 +20,7 @@ export interface SwapContextOptions {
   slippage?: number;
   feeToken?: string;
   feeReserve?: string;
+  refundAddress?: string;
   privateKey?: string;
 }
 
@@ -78,6 +79,16 @@ export interface SwapContext {
   key?: string;
   /** Quote parameters, identical for `quote` and `swap` by construction. */
   quoteParams: GetQuoteParams;
+}
+
+/** Validate and return a Bitcoin-source refund address. */
+export function resolveRefundAddress(refundAddress: string | undefined, fromChain: string): string | undefined {
+  if (refundAddress === undefined) return undefined;
+  if (getChainFamily(fromChain) !== "bitcoin") {
+    throw new Error("--refund-address may only be specified when the source chain is Bitcoin.");
+  }
+  validateAddressFamily(fromChain, refundAddress, "--refund-address");
+  return refundAddress;
 }
 
 // ─── Owner address ───────────────────────────────────────────────────────────
@@ -160,6 +171,7 @@ export async function resolveSwapContext(
 
   const srcFamily = getChainFamily(srcAsset.chain);
   const dstFamily = getChainFamily(dstAsset.chain);
+  const refundAddress = resolveRefundAddress(opts.refundAddress, srcAsset.chain);
   const variant: SwapVariant = srcFamily === "bitcoin" ? "onramp" : dstFamily === "bitcoin" ? "offramp" : "tokenSwap";
   const evmChain = srcFamily === "bitcoin" ? dstAsset.chain : srcAsset.chain;
 
@@ -239,6 +251,7 @@ export async function resolveSwapContext(
       toUserAddress: recipient,
       fromUserAddress: senderAddress,
       ownerAddress,
+      refundAddress,
       amount: atomicUnits,
       maxSlippage: slippageBps,
     },

--- a/gateway-cli/tests/commands/swap-schema.test.ts
+++ b/gateway-cli/tests/commands/swap-schema.test.ts
@@ -20,3 +20,11 @@ describe("swapSchema --timeout", () => {
     expect(() => AbortSignal.timeout(86_400 * 1000)).not.toThrow();
   });
 });
+
+describe("swapSchema --refund-address", () => {
+  it("preserves refundAddress", () => {
+    expect(swapSchema.parse({ ...base, refundAddress: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq" })).toMatchObject({
+      refundAddress: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+    });
+  });
+});

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -234,6 +234,28 @@ describe("handleSwap", () => {
     expect(mockExecuteQuote).toHaveBeenCalledOnce();
   });
 
+  it("forwards --refund-address to getQuote", async () => {
+    const { handleSwap } = await import("../../src/commands/swap.js");
+    await handleSwap({ ...baseOpts, refundAddress: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq" }, silentLogger);
+
+    expect(mockGetQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ refundAddress: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq" }),
+    );
+  });
+
+  it("rejects --refund-address for an EVM source before getQuote", async () => {
+    const { handleSwap } = await import("../../src/commands/swap.js");
+
+    await expect(handleSwap({
+      ...baseOpts,
+      src: "USDT:ethereum",
+      dst: "BTC",
+      owner: "0x2222222222222222222222222222222222222222",
+      refundAddress: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+    }, silentLogger)).rejects.toThrow(/only be specified.*source chain is Bitcoin/);
+    expect(mockGetQuote).not.toHaveBeenCalled();
+  });
+
   it("hands the watcher the order id and ONE signal carrying the whole --timeout budget", async () => {
     // The command's entire contribution to the wait: name the order, and express the
     // budget once, as a signal. There is no deadline to keep, nothing to clamp, and no

--- a/gateway-cli/tests/util/swap-context.test.ts
+++ b/gateway-cli/tests/util/swap-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveOwnerAddress } from "../../src/util/swap-context.js";
+import { resolveOwnerAddress, resolveRefundAddress } from "../../src/util/swap-context.js";
 
 const EVM = "0xAF91558Ba2B1994530c9cfCcbda5AE9cD2b456bb";
 const BTC = "bc1q4xdatls497ea76fmuefu9we4ld4yu2vy8hedne";
@@ -57,5 +57,23 @@ describe("resolveOwnerAddress", () => {
     expect(() => resolveOwnerAddress({
       srcFamily: "evm", dstFamily: "bitcoin", recipient: BTC,
     })).toThrow(/Could not determine the EVM owner address/);
+  });
+});
+
+describe("resolveRefundAddress", () => {
+  it("accepts a valid Bitcoin address for a Bitcoin source", () => {
+    expect(resolveRefundAddress(BTC, "bitcoin")).toBe(BTC);
+  });
+
+  it("rejects an invalid Bitcoin address for a Bitcoin source", () => {
+    expect(() => resolveRefundAddress("bc1qinvalid", "bitcoin")).toThrow(/valid Bitcoin address/);
+  });
+
+  it("rejects a refund address for an EVM source", () => {
+    expect(() => resolveRefundAddress(BTC, "ethereum")).toThrow(/only be specified.*source chain is Bitcoin/);
+  });
+
+  it("returns undefined for an EVM source when omitted", () => {
+    expect(resolveRefundAddress(undefined, "ethereum")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- add --refund-address to gateway-cli swap
- forward refundAddress to SDK getQuote for signed and unsigned flows
- accept valid Bitcoin refund addresses only for Bitcoin-source swaps
- reject refund addresses for EVM-source swaps before quote requests
- document new swap flag

## Testing

- pnpm run test (165 tests)
- pnpm run build
- git diff --check