### PR TITLE
fix(sdk): preserve swap owner address

### DIFF
--- a/gateway-docs/openapi.json
+++ b/gateway-docs/openapi.json
@@ -1236,7 +1236,7 @@
           {
             "name": "refundAddress",
             "in": "query",
-            "description": "Optional refund bitcoin address to be used in a bitcoin onramp request.",
+            "description": "Optional refund bitcoin address to be used in a bitcoin onramp request.\nMust be valid on Bitcoin mainnet. Ignored for non-onramp routes.",
             "required": false,
             "schema": {
               "type": "string"
@@ -3643,7 +3643,7 @@
       },
       "GatewayTokenSwapQuoteV3": {
         "type": "object",
-        "description": "V3 token-swap quote: the V2 shape plus a resolved `affiliate`. The quote *is*\nthe create-order body, so carrying the affiliate here is what stops it being\ndropped on the round-trip — the aggregator (Bungee/Velora) charges it on the\nsource chain. Mirrors how onramp/offramp embed affiliates in their quotes.",
+        "description": "V3 token-swap quote: the V2 shape plus a resolved `affiliate` and\n`ownerAddress`. The quote *is* the create-order body, so both must round-trip\n— the aggregator charges the affiliate on the source chain, and Bungee\nrefunds `ownerAddress` on a source-chain failure.",
         "required": [
           "srcChain",
           "dstChain",
@@ -3684,6 +3684,13 @@
           },
           "outputAmount": {
             "$ref": "#/components/schemas/GatewayTokenAmountV2"
+          },
+          "ownerAddress": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "V3 EVM owner / source-chain refund address (`0x…`). Echoed so create-order\nnames the same Bungee refund target as get-quote. Absent on quotes produced\nbefore this field existed; create-order then refunds the sender."
           },
           "priceImpact": {
             "type": [

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gobob/bob-sdk",
-    "version": "5.11.1",
+    "version": "5.12.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "repository": {

--- a/sdk/src/gateway/generated-client/models/GatewayTokenSwapQuoteV3.ts
+++ b/sdk/src/gateway/generated-client/models/GatewayTokenSwapQuoteV3.ts
@@ -29,10 +29,10 @@ import {
 } from './GatewayTokenAmountV2';
 
 /**
- * V3 token-swap quote: the V2 shape plus a resolved `affiliate`. The quote *is*
- * the create-order body, so carrying the affiliate here is what stops it being
- * dropped on the round-trip — the aggregator (Bungee/Velora) charges it on the
- * source chain. Mirrors how onramp/offramp embed affiliates in their quotes.
+ * V3 token-swap quote: the V2 shape plus a resolved `affiliate` and
+ * `ownerAddress`. The quote *is* the create-order body, so both must round-trip
+ * — the aggregator charges the affiliate on the source chain, and Bungee
+ * refunds `ownerAddress` on a source-chain failure.
  * @export
  * @interface GatewayTokenSwapQuoteV3
  */
@@ -73,6 +73,14 @@ export interface GatewayTokenSwapQuoteV3 {
      * @memberof GatewayTokenSwapQuoteV3
      */
     outputAmount: GatewayTokenAmountV2;
+    /**
+     * V3 EVM owner / source-chain refund address (`0x…`). Echoed so create-order
+     * names the same Bungee refund target as get-quote. Absent on quotes produced
+     * before this field existed; create-order then refunds the sender.
+     * @type {string}
+     * @memberof GatewayTokenSwapQuoteV3
+     */
+    ownerAddress?: string | null;
     /**
      * Price impact as a fraction, e.g. `"-0.05"` means 5% loss. Absent if no price feed is
      * available.
@@ -151,6 +159,7 @@ export function GatewayTokenSwapQuoteV3FromJSONTyped(json: any, ignoreDiscrimina
         'fees': GatewayTokenAmountV2FromJSON(json['fees']),
         'inputAmount': GatewayTokenAmountV2FromJSON(json['inputAmount']),
         'outputAmount': GatewayTokenAmountV2FromJSON(json['outputAmount']),
+        'ownerAddress': json['ownerAddress'] == null ? undefined : json['ownerAddress'],
         'priceImpact': json['priceImpact'] == null ? undefined : json['priceImpact'],
         'priceImpactUsd': json['priceImpactUsd'] == null ? undefined : json['priceImpactUsd'],
         'recipient': json['recipient'],
@@ -178,6 +187,7 @@ export function GatewayTokenSwapQuoteV3ToJSONTyped(value?: GatewayTokenSwapQuote
         'fees': GatewayTokenAmountV2ToJSON(value['fees']),
         'inputAmount': GatewayTokenAmountV2ToJSON(value['inputAmount']),
         'outputAmount': GatewayTokenAmountV2ToJSON(value['outputAmount']),
+        'ownerAddress': value['ownerAddress'],
         'priceImpact': value['priceImpact'],
         'priceImpactUsd': value['priceImpactUsd'],
         'recipient': value['recipient'],


### PR DESCRIPTION
## Summary

- add optional ownerAddress to V3 token-swap quote schema and generated SDK model
- preserve Bungee source-chain refund target through JSON round-trip
- clarify Bitcoin mainnet requirement for onramp refundAddress

## Validation

- pnpm run lint
- pnpm run build
- pnpm run test -- --run: 84 passed, 11 failed because ordinals service returned HTTP 503; gateway tests passed 59/59
- jq empty gateway-docs/openapi.json
- git diff --check