### PR TITLE
chore(gateway-cli): bump bob-sdk to 5.14.1, register onramp orders only

### DIFF
--- a/gateway-cli/README.md
+++ b/gateway-cli/README.md
@@ -120,7 +120,8 @@ gateway-cli routes --src-chain bitcoin        # routes from BTC
 ```bash
 gateway-cli status <order-id>                 # check order status
 gateway-cli orders <address>                  # list orders for address
-gateway-cli register <order-id> <txid>        # manually register a tx (recovery)
+gateway-cli register <order-id> <bitcoin-tx>  # manually register a Bitcoin tx for an
+                                              # onramp order (recovery; raw hex or txid)
 ```
 
 ## Amount format
@@ -232,7 +233,11 @@ git push origin cli-v0.3.0-rc0
   however transient the error looks — re-running `executeQuote` would broadcast a second
   transaction and send the funds twice. Such a failure is reported as terminal, tells you not
   to re-run, and points at `gateway-cli orders <owner-address>` to check whether an order exists.
-- **Registration failure**: if a signed tx fails to register, the error includes the order ID and a recovery command: `gateway-cli register <order-id> <txid>`.
+- **Registration failure (BTC onramp only)**: registration applies to Bitcoin-originated orders,
+  where handing the signed transaction to the gateway *is* the broadcast. If it fails, retry with
+  `gateway-cli register <order-id> <bitcoin-tx>`. EVM-source orders (offramp, tokenSwap) are not
+  registered at all as of `@gobob/bob-sdk` 5.14.1 — the gateway detects those transactions
+  on-chain — and `register` rejects them.
 - **Status read failures while polling**: a swap's funds are committed once it is submitted, so
   the order status is the only authority on whether it failed. Errors while *reading* that status
   (gateway 5xx, network failures) are retried until `--timeout`, never reported as swap failures.

--- a/gateway-cli/package.json
+++ b/gateway-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobob/gateway-cli",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "CLI for bridging Bitcoin to/from EVM chains via BOB Gateway",
   "repository": {
     "type": "git",
@@ -20,11 +20,11 @@
     "cli:dev": "tsx bin/gateway-cli.ts"
   },
   "dependencies": {
-    "@gobob/bob-sdk": "^5.9.1",
+    "@gobob/bob-sdk": "^5.14.1",
     "@gobob/tokenlist": "github:bob-collective/tokenlist#f307495b07ab7ff3d21d77e1917a8574e32d5468",
     "commander": "^13.1.0",
     "p-retry": "^7.1.1",
-    "viem": "2.49.0",
+    "viem": "2.55.19",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/gateway-cli/pnpm-lock.yaml
+++ b/gateway-cli/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@gobob/bob-sdk':
-        specifier: ^5.9.1
-        version: 5.9.1(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        specifier: ^5.14.1
+        version: 5.14.1(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
       '@gobob/tokenlist':
         specifier: github:bob-collective/tokenlist#f307495b07ab7ff3d21d77e1917a8574e32d5468
         version: https://codeload.github.com/bob-collective/tokenlist/tar.gz/f307495b07ab7ff3d21d77e1917a8574e32d5468(typescript@5.9.3)(zod@4.3.6)
@@ -25,8 +25,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1
       viem:
-        specifier: 2.49.0
-        version: 2.49.0(typescript@5.9.3)(zod@4.3.6)
+        specifier: 2.55.19
+        version: 2.55.19(typescript@5.9.3)(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -248,8 +248,8 @@ packages:
   '@gobob/bob-sdk@3.1.7-alpha0':
     resolution: {integrity: sha512-1qdKAYEigbqNt9x/0jYKeeC/d0u1lh6GluHaBIxp2Pt6p2+4fUVFnDdtGo5pMcgft7Bvo8/tdmlFBTzb3BEc5g==}
 
-  '@gobob/bob-sdk@5.9.1':
-    resolution: {integrity: sha512-FpTDflxKO+r9aIE/VgCwU11o/kYJAJNWRRJcd4HBydXlzljAP8XTqNZwzL6PwpRB14W/Lmdy1K6h3lyPSU/nmw==}
+  '@gobob/bob-sdk@5.14.1':
+    resolution: {integrity: sha512-veMR2V2q7rdXP+onzLAav9+9nYDONa8e8Rm8O4H5JdR8cL0cEfP7ZmB9bWbAZiLCCFEZaOmCTzlhSX/C+8Ra7w==}
 
   '@gobob/sats-wagmi@0.3.23':
     resolution: {integrity: sha512-7YAcQXo20v/SKNBv4Jhv9SYJJ9fzXUSC1ntUKwR0hjdCV9Kj0ivIRmGKvZwb8fqwgNYEaL4R5PbrMWnvFNTRgQ==}
@@ -963,8 +963,8 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  ox@0.14.20:
-    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+  ox@0.14.34:
+    resolution: {integrity: sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -1183,8 +1183,8 @@ packages:
   varuint-bitcoin@1.1.2:
     resolution: {integrity: sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==}
 
-  viem@2.49.0:
-    resolution: {integrity: sha512-vaasyOBFiCWYtw9JD8iRoaHPppk14kQH140qgVmrxkDEgv4qTX9Hwi6F+wF+s3Y7SStV5OtnN2ulJev+NQ7KDw==}
+  viem@2.55.19:
+    resolution: {integrity: sha512-4QPIX0eYPLsOBk53NKswVMkQoxuP7GlOBnB4wM6dkDokREO4QENNc3bmyPKK1PBTViXh0TPJCHLjIuU20Qi3fg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -1294,8 +1294,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1450,7 +1450,7 @@ snapshots:
       bitcoinjs-lib: 6.1.7
       ethers: 6.16.0
       global: 4.4.0
-      viem: 2.49.0(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.55.19(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -1458,13 +1458,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@gobob/bob-sdk@5.9.1(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
+  '@gobob/bob-sdk@5.14.1(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.2.0
       '@eslint/eslintrc': 3.3.5
       '@eslint/js': 10.0.1
       '@gobob/sats-wagmi': 0.3.23(@tanstack/react-query@5.91.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
-      '@magiceden-oss/runestone-lib': 1.0.2
       '@scure/base': 1.2.6
       '@scure/btc-signer': 1.8.1
       bip39: 3.1.0
@@ -1472,7 +1471,7 @@ snapshots:
       bitcoinjs-lib: 6.1.7
       global: 4.4.0
       globals: 17.4.0
-      viem: 2.49.0(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.55.19(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - '@tanstack/react-query'
       - bufferutil
@@ -1512,7 +1511,7 @@ snapshots:
   '@gobob/tokenlist@https://codeload.github.com/bob-collective/tokenlist/tar.gz/f307495b07ab7ff3d21d77e1917a8574e32d5468(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       '@scure/base': 1.2.6
-      viem: 2.49.0(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.55.19(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -2185,9 +2184,9 @@ snapshots:
 
   isarray@2.0.5: {}
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.21.0):
     dependencies:
-      ws: 8.18.3
+      ws: 8.21.0
 
   js-tokens@9.0.1: {}
 
@@ -2252,7 +2251,7 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  ox@0.14.20(typescript@5.9.3)(zod@4.3.6):
+  ox@0.14.34(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2487,16 +2486,16 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  viem@2.49.0(typescript@5.9.3)(zod@4.3.6):
+  viem@2.55.19(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.14.20(typescript@5.9.3)(zod@4.3.6)
-      ws: 8.18.3
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.34(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.21.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2603,6 +2602,6 @@ snapshots:
 
   ws@8.17.1: {}
 
-  ws@8.18.3: {}
+  ws@8.21.0: {}
 
   zod@4.3.6: {}

--- a/gateway-cli/src/chains/index.ts
+++ b/gateway-cli/src/chains/index.ts
@@ -158,22 +158,29 @@ export async function resolveRecipient(
 // ─── Registration payload ───────────────────────────────────────────────────
 
 /**
- * Build a registration payload for linking a transaction to an order.
- * Format depends on swap type: onramp (BTC→EVM), offramp (EVM→BTC), or tokenSwap (EVM→EVM).
+ * Build a registration payload for an onramp order.
+ *
+ * Only Bitcoin-originated orders are registered; bob-sdk 5.14.1 dropped registerTx for
+ * offramp/tokenSwap because the gateway sees EVM-source txs on-chain.
+ *
+ * @param tx - Raw signed Bitcoin transaction (hex) or its txid.
+ * @throws Error if the order does not originate on Bitcoin.
  */
 export function buildRegisterPayload(
   srcChain: string,
-  dstChain: string,
   orderId: string,
-  txId: string,
+  tx: string,
 ): RegisterTxV3 {
-  if (getChainFamily(srcChain) === 'bitcoin') {
-    return { onramp: { orderId, bitcoinTxHex: txId } };
+  if (getChainFamily(srcChain) !== 'bitcoin') {
+    throw new Error(
+      `Order ${orderId} originates on ${srcChain}, not Bitcoin — there is nothing to register.\n`
+      + `  The gateway detects EVM-source transactions on-chain; only Bitcoin onramp orders need registering.`,
+    );
   }
-  if (getChainFamily(dstChain) === 'bitcoin') {
-    return { offramp: { orderId, srcChain, srcTxHash: txId } };
-  }
-  return { tokenSwap: { orderId, srcChain, srcTxHash: txId } };
+  // 64 hex chars is a txid; anything longer is the serialized tx. Wrong field → 4xx.
+  return /^[0-9a-fA-F]{64}$/.test(tx)
+    ? { onramp: { orderId, bitcoinTxid: tx } }
+    : { onramp: { orderId, bitcoinTxHex: tx } };
 }
 
 // Re-export for direct access

--- a/gateway-cli/src/cli.ts
+++ b/gateway-cli/src/cli.ts
@@ -186,8 +186,8 @@ program
   }));
 
 program
-  .command("register <order-id> <txid>")
-  .description("Register a tx for an existing order (recovery)")
+  .command("register <order-id> <bitcoin-tx>")
+  .description("Register a Bitcoin tx (raw hex or txid) for an existing onramp order (recovery)")
   .option("--json", "Output as JSON", false)
   .action(withErrorHandling(async (orderId, txid, opts) => {
     const { handleRegister } = await import("./commands/register.js");

--- a/gateway-cli/src/commands/register.ts
+++ b/gateway-cli/src/commands/register.ts
@@ -2,11 +2,12 @@ import { getSdk, getApi } from "../config.js";
 import { buildRegisterPayload } from "../chains/index.js";
 
 /**
- * Handle the register command: manually register a transaction for an order.
- * Used for recovery when automatic registration fails.
- * 
- * @param opts - Order ID and transaction ID to register
- * @returns Registration result from Gateway API
+ * Register a Bitcoin transaction for an onramp order — recovery when the SDK's
+ * automatic registration fails. EVM-source orders are rejected before the request
+ * goes out: a no-op call would report success on an order nothing had reconciled.
+ *
+ * @param opts - Order ID and the raw signed Bitcoin transaction (hex) or its txid
+ * @throws Error if the order does not originate on Bitcoin
  */
 export async function handleRegister(opts: { orderId: string; txid: string }) {
   const sdk = getSdk();
@@ -14,7 +15,6 @@ export async function handleRegister(opts: { orderId: string; txid: string }) {
 
   const registerTx = buildRegisterPayload(
     order.srcInfo.chain,
-    order.dstInfo.chain,
     opts.orderId,
     opts.txid,
   );

--- a/gateway-cli/src/commands/swap.ts
+++ b/gateway-cli/src/commands/swap.ts
@@ -115,12 +115,14 @@ export async function handleSwap(opts: SwapOptions, log: Logger): Promise<SwapRe
 
   // ── Point of no return ─────────────────────────────────────────────────────
   // `executeQuote` is NOT idempotent. Internally it runs:
-  //   createOrder → (ERC20 reset/approve) → SIGN + BROADCAST the source tx → registerTx
-  // Only that prefix is safe to re-run. If it throws *after* the wallet has been asked
-  // to sign — a `registerTx` 5xx, a solver's "504 Gateway Timeout", a dropped socket,
-  // i.e. exactly the errors `isTransient` matches — then retrying the closure fetches a
-  // fresh quote, creates a SECOND order and broadcasts a SECOND transaction. The user's
-  // funds leave the wallet twice.
+  //   onramp:  createOrder → SIGN the PSBT → registerTx (registration IS the broadcast)
+  //   EVM src: createOrder → (ERC20 reset/approve) → SIGN + BROADCAST (no registerTx
+  //            since bob-sdk 5.14.1 — the gateway sees those txs on-chain)
+  // Only the prefix up to the first signature is safe to re-run. If it throws *after* the
+  // wallet has been asked to sign — an onramp registerTx 5xx, a solver's "504 Gateway
+  // Timeout", a dropped socket, i.e. exactly the errors `isTransient` matches — then
+  // retrying the closure fetches a fresh quote, creates a SECOND order and broadcasts a
+  // SECOND transaction. The user's funds leave the wallet twice.
   //
   // The SDK fires an ExecuteQuoteStep immediately BEFORE every wallet interaction
   // (ResetApproval / Approve / SendTransaction / SignBitcoinTransaction), so the first

--- a/gateway-cli/tests/commands/register.test.ts
+++ b/gateway-cli/tests/commands/register.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockRegisterTxV3 = vi.fn().mockResolvedValue({ status: "ok" });
+const mockGetOrder = vi.fn();
+
+vi.mock("../../src/config.js", () => ({
+  BTC_DECIMALS: 8,
+  getSdk: vi.fn(() => ({ getOrder: mockGetOrder })),
+  getApi: vi.fn(() => ({ registerTxV3: mockRegisterTxV3 })),
+}));
+
+const TXID = "a".repeat(64);
+const RAW_TX = "0200000001" + "b".repeat(200);
+
+const order = (srcChain: string, dstChain: string) => ({
+  srcInfo: { chain: srcChain },
+  dstInfo: { chain: dstChain },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRegisterTxV3.mockResolvedValue({ status: "ok" });
+});
+
+// `bitcoin_tx_hex` takes a full serialized tx, `bitcoin_txid` a txid — a txid in the
+// hex field is rejected server-side, so the two forms must land in different fields.
+describe("buildRegisterPayload", () => {
+  it("puts a 64-hex-char txid in bitcoinTxid", async () => {
+    const { buildRegisterPayload } = await import("../../src/chains/index.js");
+    expect(buildRegisterPayload("bitcoin", "order-1", TXID)).toEqual({
+      onramp: { orderId: "order-1", bitcoinTxid: TXID },
+    });
+  });
+
+  it("puts a serialized transaction in bitcoinTxHex", async () => {
+    const { buildRegisterPayload } = await import("../../src/chains/index.js");
+    expect(buildRegisterPayload("bitcoin", "order-1", RAW_TX)).toEqual({
+      onramp: { orderId: "order-1", bitcoinTxHex: RAW_TX },
+    });
+  });
+
+  // bob-sdk 5.14.1 dropped registerTx for both EVM-source paths.
+  it.each([
+    ["offramp", "ethereum", "bitcoin"],
+    ["tokenSwap", "ethereum", "base"],
+  ])("rejects a %s order — EVM-source txs are not registered", async (_variant, src) => {
+    const { buildRegisterPayload } = await import("../../src/chains/index.js");
+    expect(() => buildRegisterPayload(src, "order-1", TXID)).toThrow(/nothing to register/i);
+    expect(() => buildRegisterPayload(src, "order-1", TXID)).toThrow(new RegExp(src));
+  });
+});
+
+describe("handleRegister", () => {
+  it("registers a Bitcoin-source order", async () => {
+    mockGetOrder.mockResolvedValue(order("bitcoin", "base"));
+
+    const { handleRegister } = await import("../../src/commands/register.js");
+    const result = await handleRegister({ orderId: "order-1", txid: TXID });
+
+    expect(mockRegisterTxV3).toHaveBeenCalledWith({
+      registerTxV3: { onramp: { orderId: "order-1", bitcoinTxid: TXID } },
+    });
+    expect(result).toEqual({ status: "ok" });
+  });
+
+  // Must fail before the request: a no-op call would report success on a stuck order.
+  it.each([
+    ["offramp", "ethereum", "bitcoin"],
+    ["tokenSwap", "ethereum", "base"],
+  ])("refuses a %s order without calling the API", async (_variant, src, dst) => {
+    mockGetOrder.mockResolvedValue(order(src, dst));
+
+    const { handleRegister } = await import("../../src/commands/register.js");
+    await expect(handleRegister({ orderId: "order-1", txid: TXID })).rejects.toThrow(
+      /nothing to register/i,
+    );
+    expect(mockRegisterTxV3).not.toHaveBeenCalled();
+  });
+});

--- a/gateway-cli/tests/commands/swap.test.ts
+++ b/gateway-cli/tests/commands/swap.test.ts
@@ -108,8 +108,8 @@ vi.mock("../../src/chains/index.js", () => ({
   deriveAddress: vi.fn().mockResolvedValue("bc1qtest"),
   resolveSigner: vi.fn().mockResolvedValue({ address: "bc1qtest", signer: mockBtcSigner }),
   getTokenBalance: vi.fn().mockResolvedValue({ total: "5000000", allSpendable: "4900000" }),
-  buildRegisterPayload: vi.fn((_src: string, _dst: string, orderId: string, txId: string) => ({
-    onramp: { orderId, bitcoinTxHex: txId },
+  buildRegisterPayload: vi.fn((_src: string, orderId: string, txId: string) => ({
+    onramp: { orderId, bitcoinTxid: txId },
   })),
   resolvePrivateKey: vi.fn((chain: string, privateKey?: string) => privateKey),
   resolveRecipient: vi.fn().mockResolvedValue("0x4444444444444444444444444444444444444444"),
@@ -375,7 +375,8 @@ describe("handleSwap", () => {
 
   // ─── C1 / A4 — never retry a swap once the wallet has been asked to sign ────
   //
-  // `executeQuote` is not idempotent: createOrder → sign + BROADCAST → registerTx.
+  // `executeQuote` is not idempotent: createOrder → sign + BROADCAST (the onramp's
+  // registerTx, or the EVM send — bob-sdk 5.14.1 registers nothing after it).
   // Re-running it after the broadcast sends the user's funds a SECOND time. The SDK
   // fires its step callback immediately before it asks the wallet to sign, which is
   // the signal these tests rely on. Reachable via `--retry` only (gateway-bot CI does
@@ -444,7 +445,7 @@ describe("handleSwap", () => {
     mockExecuteQuote.mockImplementation(async ({ callback }: any) => {
       callback?.({ step: 1, type: "approve", totalSteps: 2 });
       callback?.({ step: 2, type: "send_transaction", totalSteps: 2 });
-      throw new Error("registerTx failed: 503 Service Unavailable");
+      throw new Error("waiting for transaction receipt failed: 503 Service Unavailable");
     });
 
     const { handleSwap } = await import("../../src/commands/swap.js");


### PR DESCRIPTION
## What

`@gobob/bob-sdk` 5.14.1 removed the `registerTx` call from the `offramp` **and** `tokenSwap` paths of `executeQuote` — the gateway detects EVM-source transactions on-chain. Only Bitcoin-originated (`onramp`) orders still need registering, and there handing over the signed transaction *is* the broadcast.

(5.14.0, from #1164, only gated tokenSwap behind `srcChain === 'bitcoin'`; 5.14.1 dropped both calls outright.)

This mirrors that in `gateway-cli`.

## Changes

- **`buildRegisterPayload(srcChain, orderId, tx)`** — dropped the `dstChain` parameter and the offramp/tokenSwap branches. A non-Bitcoin source chain now throws instead of building a payload the gateway no longer expects.
- **`register` command** — rejects EVM-source orders before the request goes out. A no-op call would report success on an order nothing had reconciled.
- **Bug fix**: a txid is now sent as `bitcoin_txid`, not `bitcoin_tx_hex`. The hex field is documented as "Hex-encoded full Bitcoin transaction" and rejected txids server-side, so `gateway-cli register <order-id> <txid>` could not have worked. 64 hex chars → `bitcoin_txid`; longer → `bitcoin_tx_hex`.
- **`viem` pinned 2.49.0 → 2.55.19** to match bob-sdk's own dependency. Without it the two copies produce 4 `TS2322` `Chain` conflicts in `src/chains/evm.ts` and `src/util/asset-resolver.ts` and the package does not compile.
- Point-of-no-return comment in `swap.ts` updated: the EVM-source paths no longer have a trailing `registerTx`, so the last thing that can fail after signing is the broadcast itself. Funds-safety behaviour is unchanged.
- README: `register` usage + rewrote the "Registration failure" bullet (it promised a recovery hint no code emits).
- Version 0.4.2 → 0.5.0.

## Tests

New `tests/commands/register.test.ts` (7 tests): txid vs. raw-hex field discrimination, and offramp/tokenSwap rejection with the API asserted *not* called.

```
tsc --noEmit  → 0 errors
vitest run    → 21 files, 165 tests passed
```